### PR TITLE
WIP: Update netty

### DIFF
--- a/game/build.gradle
+++ b/game/build.gradle
@@ -10,6 +10,7 @@ mainClassName = 'gg.rsmod.game.Launcher'
 
 run {
     workingDir = rootProject.projectDir
+    systemProperty('io.netty.noUnsafe', 'true')
 }
 
 dependencies {

--- a/game/src/main/kotlin/gg/rsmod/game/protocol/GameHandler.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/protocol/GameHandler.kt
@@ -22,7 +22,7 @@ import mu.KLogging
 class GameHandler(private val world: World) : ChannelInboundHandlerAdapter() {
 
     override fun channelInactive(ctx: ChannelHandlerContext) {
-        val session = ctx.channel().attr(SYSTEM_KEY).andRemove
+        val session = ctx.channel().attr(SYSTEM_KEY).getAndSet(null)
         session?.terminate()
         ctx.channel().close()
     }

--- a/game/src/main/kotlin/gg/rsmod/game/service/login/LoginService.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/service/login/LoginService.kt
@@ -90,7 +90,7 @@ class LoginService : Service {
         if (client.channel.isActive) {
             pipeline.remove("handshake_encoder")
             pipeline.remove("login_decoder")
-            pipeline.remove("login_encoder")
+//            pipeline.remove("login_encoder")
 
             pipeline.addFirst("packet_encoder", GamePacketEncoder(encoderIsaac))
             pipeline.addAfter("packet_encoder", "message_encoder", GameMessageEncoder(gameSystem.service.messageEncoders, gameSystem.service.messageStructures))

--- a/gradle/properties.gradle
+++ b/gradle/properties.gradle
@@ -3,7 +3,7 @@ ext {
     junitVersion = '4.12'
     kotlinVersion = '1.8.0'
     kcoroutineVersion = '1.1.0'
-    nettyVersion = '4.0.34.Final'
+    nettyVersion = '4.0.56.Final'
     gsonVersion = '2.8.5'
     yamlVersion = '2.5.0'
     jacksonVersion = '2.5.0'


### PR DESCRIPTION
WIP on updating netty. 

Setting `io.netty.noUnsafe` to true ensures netty keeps using `UnpooledHeapByteBuf`, otherwise it will default to another implementation that doesn't provide access to the `array()` function.

I have commented out `pipeline.remove("login_encoder")` in the `LoginService`. Somehow, in newer versions of netty, a race condition occurs that causes the login encoder to be removed from the pipeline before that pipeline was called. A small Thread.sleep() before removing seems to be functionally the same.

This updates to the latest 4.0.x version. 4.1.x has other issues as well.