### PR TITLE
fix: Add chocolate cake to foods and fix cake heal amount

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Food.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Food.kt
@@ -39,9 +39,12 @@ enum class Food(
      * Pastries.
      */
     BREAD(item = Items.BREAD, heal = 50),
-    CAKE(item = Items.CAKE, replacement = Items._23_CAKE, heal = 30),
-    CAKE_23(item = Items._23_CAKE, replacement = Items.SLICE_OF_CAKE, heal = 30),
-    SLICE_OF_CAKE(item = Items.SLICE_OF_CAKE, heal = 30),
+    CAKE(item = Items.CAKE, replacement = Items._23_CAKE, heal = 40),
+    CAKE_23(item = Items._23_CAKE, replacement = Items.SLICE_OF_CAKE, heal = 40),
+    SLICE_OF_CAKE(item = Items.SLICE_OF_CAKE, heal = 40),
+    CHOCOLATE_CAKE(item = Items.CHOCOLATE_CAKE, heal = 50),
+    CHOCOLATE_CAKE_23(item = Items._23_CHOCOLATE_CAKE, heal = 50),
+    SLICE_OF_CHOCOLATE_CAKE(item = Items.CHOCOLATE_SLICE, heal = 50),
 
     /**
      * Vegetables


### PR DESCRIPTION
## What has been done?
Cakes heal 40 per bite, instead of 30. Also adds chocolate cakes because those can be gained from the bakery stall as well