### PR TITLE
fix: continue fishing when inventory full with only one bait left

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/fishing/Fishing.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/fishing/Fishing.kt
@@ -61,7 +61,7 @@ object Fishing {
             return false
         }
 
-        if (player.inventory.isFull) {
+        if (player.inventory.isFull && (tool.baitId == null || player.inventory.getItemCount(tool.baitId) > 1)) {
             player.message("You don't have enough space in your inventory.")
             return false
         }


### PR DESCRIPTION
Continue fishing when inventory is full, but catching a fish would free up an inventory space