### PR TITLE
Fix: Unintuitive behaviour when loading XTEA keys.

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/service/xtea/XteaKeyService.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/service/xtea/XteaKeyService.kt
@@ -14,6 +14,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.nameWithoutExtension
 
 /**
  * A [Service] that loads and exposes XTEA keys required for map decryption.
@@ -116,7 +117,8 @@ class XteaKeyService : Service {
     }
 
     private fun loadDirectory(path: Path) {
-        Files.list(path).forEach { list ->
+        val nonHiddenFiles = Files.list(path).filter { it.nameWithoutExtension.isNotEmpty() }
+        nonHiddenFiles.forEach { list ->
             val region = FilenameUtils.removeExtension(list.fileName.toString()).toInt()
             val keys = IntArray(4)
             Files.newBufferedReader(list).useLines { lines ->

--- a/game/src/main/kotlin/gg/rsmod/game/service/xtea/XteaKeyService.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/service/xtea/XteaKeyService.kt
@@ -13,6 +13,7 @@ import java.io.FileNotFoundException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.listDirectoryEntries
 
 /**
  * A [Service] that loads and exposes XTEA keys required for map decryption.
@@ -31,10 +32,13 @@ class XteaKeyService : Service {
         if (!Files.exists(path)) {
             throw FileNotFoundException("Path does not exist. $path")
         }
-        val singleFile = path.resolve("xteas.json")
-        if (Files.exists(singleFile)) {
+        val keyFiles = path.listDirectoryEntries("*.json")
+        if (keyFiles.size == 1) {
+            val singleFile = keyFiles.first()
+            logger.info { "Loading XTEA keys from single file: $singleFile" }
             loadSingleFile(singleFile)
         } else {
+            logger.info { "Multiple XTEA key files detected - loading as directory" }
             loadDirectory(path)
         }
 


### PR DESCRIPTION
## What has been done?

The `XteaKeyService` has been changed to check for a single JSON file regardless of it's name, and attempt to load that as the "single file" key mode. The `loadDirectory` method has been modified to ignore hidden files, such as the gitignore file. The motivation behind this change is that the link to the XTEA keys on the README has a different filename from what the server was previously expecting, and outputted no error message when it wasn't found, which is an unintuitive design.

## Proposed Changes

  - `XteaKeyService` now searches for a single JSON file and loads it as a single file, rather than looking for `xteas.json` specifically.
  - `XteaKeyService` now ignores all files that have an empty filename when the extension is removed (that is, files beginning with a period).