### PR TITLE
fix: run energy depletion and restoration was changed in 2009

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/MiscExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/MiscExt.kt
@@ -28,6 +28,9 @@ fun String.parseAmount(): Long = when {
 fun Int.interpolate(minChance: Int, maxChance: Int, minLvl: Int, maxLvl: Int): Int =
         minChance + (maxChance - minChance) * (this - minLvl) / (maxLvl - minLvl)
 
+fun Int.interpolate(minChance: Double, maxChance: Double, minLvl: Int, maxLvl: Int): Double =
+        minChance + (maxChance - minChance) * (this - minLvl) / (maxLvl - minLvl)
+
 fun Int.interpolate(minChance: Int, maxChance: Int, minLvl: Int, maxLvl: Int, cap: Int): Boolean =
         RANDOM.nextInt(cap) <= interpolate(minChance, maxChance, minLvl, maxLvl)
 


### PR DESCRIPTION
## What has been done?
An [update in 2009](https://runescape.wiki/w/Update:Run_energy_upgrade) changed the way energy depletion and restoration was calculated. Most notably, it ensured agility level played a role in both depletion and restoration.

There don't seem to be any relevant updates to those formula since then, so we can use the rs3-wiki for our data. However, the rs3 wiki is very inconsistent, claiming a restoration time of 1.15 minutes for 0-100% at 1 agility at [one place](https://runescape.wiki/w/Energy#Recovering_energy), and 0.45% per second (or 222 seconds) [at another](https://runescape.wiki/w/Rest).

The run energy page of [2011](https://runescape.wiki/w/Energy?oldid=9884152) agrees with the second source though, so I've taken that as the correct one. This gives, at level 1 agility:
- 0.45%/second when walking
- 2.8%/second when resting
- 3.8%/second at a musician

Furthermore, the 2011 wiki [states](https://runescape.wiki/w/Energy?oldid=9884152#Trivia) that it takes level 99 agility 15 seconds to fully restore at a musician.

The last two numbers are inconclusive: restoration rate when walking or resting at 99 agility. I've taken 0.6%/second and 4%/second for now, respectively, since they seem to fit the pattern best. Transforming these numbers to per-tick gives the numbers in the [recover functions](https://github.com/2011Scape/game/compare/main...Paleocene:tek5:run-energy?expand=1#diff-829c9cbb2e3b9c8531f7e3bb5d1b3eed10ac77c680aaccf5ec70d2400f633af2R58)