### PR TITLE
fix: add charms and clue scrolls to drop tables where needed

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_greataxe_lvl_10.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_greataxe_lvl_10.plugin.kts
@@ -34,7 +34,19 @@ val barbarian = table.build {
         obj(Items.BEER, slots = 8)
         obj(Items.COOKED_MEAT, slots = 8)
         obj(Items.RING_MOULD, slots = 8)
-
+    }
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 50)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 10)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 5)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 5)
+        nothing(slots = 930)
+    }
+    table("Tertiary") {
+        total(128)
+        obj(Items.CLUE_SCROLL_EASY, slots = 1)
+        nothing(127)
     }
 }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_greataxe_lvl_17.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_greataxe_lvl_17.plugin.kts
@@ -34,7 +34,19 @@ val barbarian = table.build {
         obj(Items.BEER, slots = 8)
         obj(Items.COOKED_MEAT, slots = 8)
         obj(Items.RING_MOULD, slots = 8)
-
+    }
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 50)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 10)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 5)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 5)
+        nothing(slots = 930)
+    }
+    table("Tertiary") {
+        total(128)
+        obj(Items.CLUE_SCROLL_EASY, slots = 1)
+        nothing(127)
     }
 }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_spear_lvl_10.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_spear_lvl_10.plugin.kts
@@ -34,7 +34,19 @@ val barbarian = table.build {
         obj(Items.BEER, slots = 8)
         obj(Items.COOKED_MEAT, slots = 8)
         obj(Items.RING_MOULD, slots = 8)
-
+    }
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 50)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 10)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 5)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 5)
+        nothing(slots = 930)
+    }
+    table("Tertiary") {
+        total(128)
+        obj(Items.CLUE_SCROLL_EASY, slots = 1)
+        nothing(127)
     }
 }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_spear_lvl_17.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_spear_lvl_17.plugin.kts
@@ -34,7 +34,19 @@ val barbarian = table.build {
         obj(Items.BEER, slots = 8)
         obj(Items.COOKED_MEAT, slots = 8)
         obj(Items.RING_MOULD, slots = 8)
-
+    }
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 50)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 10)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 5)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 5)
+        nothing(slots = 930)
+    }
+    table("Tertiary") {
+        total(128)
+        obj(Items.CLUE_SCROLL_EASY, slots = 1)
+        nothing(127)
     }
 }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_twohand_sword_lvl_10.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_twohand_sword_lvl_10.plugin.kts
@@ -34,7 +34,19 @@ val barbarian = table.build {
         obj(Items.BEER, slots = 8)
         obj(Items.COOKED_MEAT, slots = 8)
         obj(Items.RING_MOULD, slots = 8)
-
+    }
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 50)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 10)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 5)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 5)
+        nothing(slots = 930)
+    }
+    table("Tertiary") {
+        total(128)
+        obj(Items.CLUE_SCROLL_EASY, slots = 1)
+        nothing(127)
     }
 }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_twohand_sword_lvl_17.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/barbarian_twohand_sword_lvl_17.plugin.kts
@@ -34,7 +34,19 @@ val barbarian = table.build {
         obj(Items.BEER, slots = 8)
         obj(Items.COOKED_MEAT, slots = 8)
         obj(Items.RING_MOULD, slots = 8)
-
+    }
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 50)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 10)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 5)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 5)
+        nothing(slots = 930)
+    }
+    table("Tertiary") {
+        total(128)
+        obj(Items.CLUE_SCROLL_EASY, slots = 1)
+        nothing(127)
     }
 }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/cow_level_2.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/cow_level_2.plugin.kts
@@ -17,6 +17,14 @@ val cow = table.build {
         obj(Items.SLING, quantity = 1, slots = 64)
         nothing(slots = 960)
     }
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 9)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 40)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 3)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 1)
+        nothing(slots = 947)
+    }
 }
 
 table.register(cow, *ids)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/farmer_level_7.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/farmer_level_7.plugin.kts
@@ -31,6 +31,11 @@ val farmer = table.build {
         obj(Items.WATERING_CAN_8, slots = 1)
         nothing(28)
     }
+    table("Tertiary") {
+        total(128)
+        obj(Items.CLUE_SCROLL_EASY, slots = 1)
+        nothing(127)
+    }
 }
 
 table.register(farmer, *ids)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/giant_spider_level_2.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/giant_spider_level_2.plugin.kts
@@ -1,6 +1,52 @@
 package gg.rsmod.plugins.content.npcs.definitions
 
+import gg.rsmod.plugins.content.drops.DropTableFactory
+
 val ids = intArrayOf(Npcs.GIANT_SPIDER, Npcs.GIANT_SPIDER_60, Npcs.GIANT_SPIDER_12352)
+
+val table = DropTableFactory
+val spider = table.build {
+    main {
+        total(48)
+        obj(Items.AIR_RUNE, quantityRange = 4..6, slots = 7)
+        obj(Items.EARTH_RUNE, quantity = 4, slots = 7)
+        obj(Items.FIRE_RUNE, quantity = 6, slots = 7)
+        obj(Items.BODY_RUNE, quantity = 7, slots = 3)
+        nothing(24)
+    }
+
+    table("Secondary") {
+        total(128)
+        obj(Items.BRONZE_MED_HELM, slots = 48)
+        obj(Items.BRONZE_BOLTS, slots = 12)
+        obj(Items.BRONZE_ARROW, slots = 12)
+        obj(Items.LONGBOW, slots = 4)
+        obj(Items.BRONZE_KITESHIELD, slots = 1)
+        nothing(51)
+    }
+
+    table("Tertiary") {
+        total(128)
+        obj(Items.STAFF_OF_AIR, slots = 1)
+        obj(Items.SLING, slots = 1)
+        nothing(126)
+    }
+
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 90)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 11)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 30)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 9)
+        nothing(slots = 860)
+    }
+}
+
+table.register(spider, *ids)
+
+on_npc_death(*ids) {
+    table.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
 
 ids.forEach {
     set_combat_def(it) {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/guard_level_21.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/guard_level_21.plugin.kts
@@ -48,6 +48,15 @@ val guard = table.build {
         nothing(slots = 127)
         obj(Items.CLUE_SCROLL_MEDIUM, slots = 1)
     }
+
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 70)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 9)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 5)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 2)
+        nothing(slots = 914)
+    }
 }
 
 table.register(guard, *ids)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/haakon_the_champion_lvl_29.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/haakon_the_champion_lvl_29.plugin.kts
@@ -35,7 +35,11 @@ val barbarian = table.build {
         obj(Items.BEER, slots = 8)
         obj(Items.COOKED_MEAT, slots = 8)
         obj(Items.RING_MOULD, slots = 8)
-
+    }
+    table("Tertiary") {
+        total(128)
+        obj(Items.CLUE_SCROLL_EASY, slots = 1)
+        nothing(127)
     }
 }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/lesser_demon_lvl_82.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/lesser_demon_lvl_82.plugin.kts
@@ -38,7 +38,15 @@ val lesserDemon = table.build {
 
         obj(Items.JUG_OF_WINE, slots = 24)
         obj(Items.GOLD_ORE, slots = 16)
+    }
 
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 20)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 8)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 30)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 7)
+        nothing(slots = 935)
     }
 }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/scorpion_level_14.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/scorpion_level_14.plugin.kts
@@ -1,5 +1,25 @@
 package gg.rsmod.plugins.content.npcs.definitions
 
+import gg.rsmod.plugins.content.drops.DropTableFactory
+
+val table = DropTableFactory
+val scorpion = table.build {
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 30)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 70)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 10)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 5)
+        nothing(slots = 885)
+    }
+}
+
+table.register(scorpion, Npcs.SCORPION)
+
+on_npc_death(Npcs.SCORPION) {
+    table.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
 set_combat_def(npc = Npcs.SCORPION) {
     configs {
         attackSpeed = 4

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/unicorn_level_15.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/unicorn_level_15.plugin.kts
@@ -10,6 +10,15 @@ val unicorn = table.build {
         obj(Items.BONES)
         obj(Items.UNICORN_HORN)
     }
+
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 130)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 60)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 40)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 5)
+        nothing(slots = 765)
+    }
 }
 
 table.register(unicorn, *ids)


### PR DESCRIPTION
## What has been done?
- Adds charm drop tables to existing npc definitions
- Adds clue scrolls to existing npc definitions
- Adds one missing drop table