### PR TITLE
Improve performance of drop tables

### DIFF
--- a/game/plugins/build.gradle
+++ b/game/plugins/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation project(':net')
     implementation project(':util')
     implementation "it.unimi.dsi:fastutil:$fastUtilVersion"
+    testImplementation 'io.mockk:mockk:1.13.4'
 }
 
 dokka {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/drops/DropTable.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/drops/DropTable.kt
@@ -5,7 +5,7 @@ package gg.rsmod.plugins.content.drops
  * @param name      The name of this table.
  * @param entries   The drop entries.
  */
-data class DropTable(val name: String?, val entries: Array<DropEntry>) {
+data class DropTable(val name: String?, val entries: Array<TableBuilder.Entry>) {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/drops/DropTableFactory.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/drops/DropTableFactory.kt
@@ -75,7 +75,7 @@ object DropTableFactory {
             val guaranteed = tables.firstOrNull { it.name == GUARANTEED_TABLE_NAME }
             val remaining = tables.filterNot { it.name == GUARANTEED_TABLE_NAME }
             if (guaranteed != null) {
-                items.addAll(guaranteed.entries.filterIsInstance<DropEntry.ItemDrop>().map { it.item })
+                items.addAll(guaranteed.entries.map { it.drop }.filterIsInstance<DropEntry.ItemDrop>().map { it.item })
             }
 
             val remainingTables = remaining.map { DropEntry.TableDrop(it) }
@@ -118,7 +118,7 @@ object DropTableFactory {
         if (table.name == GUARANTEED_TABLE_NAME) {
             // For every drop in the guaranteed table, count the items that are not stackable, and the items
             // that are stackable but not yet in the inventory
-            return table.entries.filterIsInstance<DropEntry.ItemDrop>()
+            return table.entries.map { it.drop }.filterIsInstance<DropEntry.ItemDrop>()
                 .map { it.item.id }
                 .count(player.inventory::requiresFreeSlotToAdd)
         }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/drops/DropTableFactory.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/drops/DropTableFactory.kt
@@ -6,6 +6,7 @@ import gg.rsmod.game.model.entity.GroundItem
 import gg.rsmod.game.model.entity.Pawn
 import gg.rsmod.game.model.entity.Player
 import gg.rsmod.game.model.item.Item
+import mu.KLogging
 import java.security.SecureRandom
 import java.util.*
 import kotlin.collections.set
@@ -299,11 +300,13 @@ class TableBuilder(val player: Player, val prng: SecureRandom, val name: String?
      */
     internal fun build(): DropTable {
         if (occupiedSlots != totalSlots && name != GUARANTEED_TABLE_NAME) {
-            println("Drop table has $totalSlots total slots, but $occupiedSlots were used.")
+            logger.error("Drop table has $totalSlots total slots, but $occupiedSlots were used.")
         }
 
         return DropTable(name, entries.toTypedArray())
     }
 
     data class Entry(val index: Int, val drop: DropEntry)
+
+    companion object : KLogging()
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/drops/DropTableFactory.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/drops/DropTableFactory.kt
@@ -30,7 +30,7 @@ object DropTableFactory {
     /**
      * The PRNG for selecting an entry.
      */
-    private val prng = SecureRandom()
+    var prng = SecureRandom()
 
     /**
      * Registers a drop table.

--- a/game/plugins/src/test/kotlin/gg/rsmod/plugins/content/drops/DropTableFactoryTest.kt
+++ b/game/plugins/src/test/kotlin/gg/rsmod/plugins/content/drops/DropTableFactoryTest.kt
@@ -22,7 +22,7 @@ class DropTableFactoryTest {
 
     @Test
     fun test() {
-        val indices = listOf(50, 239, 359, 360, 449, 450, 451, 1000)
+        val indices = listOf(0, 50, 239, 359, 360, 449, 450, 451, 1000, 1023)
         every { randomMock.nextInt(1024) } returnsMany indices
 
         val table = factory.build {
@@ -44,11 +44,13 @@ class DropTableFactoryTest {
 
         assertEquals(Items.TIN_ORE, drops[0]!!.single().id)
         assertEquals(Items.TIN_ORE, drops[1]!!.single().id)
-        assertEquals(Items.COPPER_ORE, drops[2]!!.single().id)
-        assertEquals(Items.IRON_ORE, drops[3]!!.single().id)
-        assertEquals(Items.COAL, drops[4]!!.single().id)
-        assertEquals(Items.GOLD_ORE, drops[5]!!.single().id)
-        assertEquals(0, drops[6]!!.size)
+        assertEquals(Items.TIN_ORE, drops[2]!!.single().id)
+        assertEquals(Items.COPPER_ORE, drops[3]!!.single().id)
+        assertEquals(Items.IRON_ORE, drops[4]!!.single().id)
+        assertEquals(Items.COAL, drops[5]!!.single().id)
+        assertEquals(Items.GOLD_ORE, drops[6]!!.single().id)
         assertEquals(0, drops[7]!!.size)
+        assertEquals(0, drops[8]!!.size)
+        assertEquals(0, drops[9]!!.size)
     }
 }

--- a/game/plugins/src/test/kotlin/gg/rsmod/plugins/content/drops/DropTableFactoryTest.kt
+++ b/game/plugins/src/test/kotlin/gg/rsmod/plugins/content/drops/DropTableFactoryTest.kt
@@ -1,0 +1,54 @@
+package gg.rsmod.plugins.content.drops
+
+import gg.rsmod.game.model.entity.Player
+import gg.rsmod.plugins.api.cfg.Items
+import io.mockk.every
+import io.mockk.mockk
+import java.security.SecureRandom
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DropTableFactoryTest {
+
+    private val factory = DropTableFactory
+    private val randomMock: SecureRandom = mockk()
+    private val player: Player = mockk()
+
+    private val npcId = 10
+
+    init {
+        factory.prng = randomMock
+    }
+
+    @Test
+    fun test() {
+        val indices = listOf(50, 239, 359, 360, 449, 450, 451, 1000)
+        every { randomMock.nextInt(1024) } returnsMany indices
+
+        val table = factory.build {
+            main {
+                total(1024)
+
+                obj(Items.TIN_ORE, slots = 240)
+                obj(Items.COPPER_ORE, slots = 120)
+                obj(Items.IRON_ORE, slots = 60)
+                obj(Items.COAL, slots = 30)
+                obj(Items.GOLD_ORE, slots = 1)
+                nothing(573)
+            }
+        }
+
+        factory.register(table, npcId)
+
+        val drops = indices.map { factory.getDrop(player, npcId) }
+
+        assertEquals(Items.TIN_ORE, drops[0]!!.single().id)
+        assertEquals(Items.TIN_ORE, drops[1]!!.single().id)
+        assertEquals(Items.COPPER_ORE, drops[2]!!.single().id)
+        assertEquals(Items.IRON_ORE, drops[3]!!.single().id)
+        assertEquals(Items.COAL, drops[4]!!.single().id)
+        assertEquals(Items.GOLD_ORE, drops[5]!!.single().id)
+        assertEquals(0, drops[6]!!.size)
+        assertEquals(0, drops[7]!!.size)
+    }
+}


### PR DESCRIPTION
## What has been done?
Reduces the looping required for drop tables, especially larger tables. In the old situation, an array of `slots * 2` size was reserved, and a loop was performed of a total of `slots` times. In this proposed PR, the created list has a size of `amount of items and tables`, and a loop is performed of at most `(amount of items and tables) * 2`. This should improve performance for almost all tables.

The `SecureRandom` in the drop table factory is public for now to be able to easily test functionality. That can easily be made private again though.