### PR TITLE
feat: add check for multi-combat

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/combat.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/combat.plugin.kts
@@ -32,6 +32,17 @@ suspend fun cycle(it: QueueTask): Boolean {
     val pawn = it.pawn
     val target = pawn.attr[COMBAT_TARGET_FOCUS_ATTR]?.get() ?: return false
 
+    // handle multi-way combat
+
+    if(!pawn.tile.isMulti(world)) {
+        if (target.isAttacking() && target.getCombatTarget() != pawn) {
+            if (pawn is Player) {
+                pawn.message("Someone is already fighting this.")
+            }
+            return false
+        }
+    }
+
     if (!pawn.lock.canAttack()) {
         Combat.reset(pawn)
         return false


### PR DESCRIPTION
## What has been done?

Added a simple check to see if the Pawn is within a multi-combat tile, and if not, then prevent from attacking a target that is already engaged in combat and it's target is not the Pawn attacking.
