### PR TITLE
Npc aggression, multi-way combat

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/Combat.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/Combat.kt
@@ -143,6 +143,17 @@ object Combat {
             return false
         }
 
+        // handle multi-way combat
+
+        if(!pawn.tile.isMulti(pawn.world)) {
+            if (target.isAttacking() && target.getCombatTarget() != pawn) {
+                if (pawn is Player) {
+                    pawn.message("Someone is already fighting this.")
+                }
+                return false
+            }
+        }
+
         val maxDistance = when {
             pawn is Player && pawn.hasLargeViewport() -> Player.LARGE_VIEW_DISTANCE
             else -> Player.NORMAL_VIEW_DISTANCE

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/combat.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/combat.plugin.kts
@@ -32,6 +32,17 @@ suspend fun cycle(it: QueueTask): Boolean {
     val pawn = it.pawn
     val target = pawn.attr[COMBAT_TARGET_FOCUS_ATTR]?.get() ?: return false
 
+    // handle multi-way combat
+
+    if(!pawn.tile.isMulti(world)) {
+        if (target.isAttacking() && target.getCombatTarget() != pawn) {
+            if (pawn is Player) {
+                pawn.message("Someone is already fighting this.")
+            }
+            return false
+        }
+    }
+
     if (!pawn.lock.canAttack()) {
         Combat.reset(pawn)
         return false

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/combat.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/combat.plugin.kts
@@ -32,17 +32,6 @@ suspend fun cycle(it: QueueTask): Boolean {
     val pawn = it.pawn
     val target = pawn.attr[COMBAT_TARGET_FOCUS_ATTR]?.get() ?: return false
 
-    // handle multi-way combat
-
-    if(!pawn.tile.isMulti(world)) {
-        if (target.isAttacking() && target.getCombatTarget() != pawn) {
-            if (pawn is Player) {
-                pawn.message("Someone is already fighting this.")
-            }
-            return false
-        }
-    }
-
     if (!pawn.lock.canAttack()) {
         Combat.reset(pawn)
         return false

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/aggro/npc_aggro.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/aggro/npc_aggro.plugin.kts
@@ -1,6 +1,7 @@
 package gg.rsmod.plugins.content.mechanics.aggro
 
 import gg.rsmod.game.model.attr.COMBAT_TARGET_FOCUS_ATTR
+import gg.rsmod.game.model.attr.FACING_PAWN_ATTR
 import gg.rsmod.plugins.content.combat.getCombatTarget
 import gg.rsmod.plugins.content.combat.isAttacking
 import gg.rsmod.plugins.content.combat.isBeingAttacked
@@ -30,13 +31,19 @@ on_global_npc_spawn {
 }
 
 on_timer(AGGRO_CHECK_TIMER) {
-    if ((!npc.isAttacking() || npc.tile.isMulti(world)) && npc.lock.canAttack() && npc.isActive()) {
-        checkRadius(npc)
+    if (world.random(10) == 1) {
+        if ((!npc.isAttacking() || npc.tile.isMulti(world)) && npc.lock.canAttack() && npc.isActive()) {
+            if (!checkRadius(npc)) {
+                npc.resetInteractions()
+                npc.resetFacePawn()
+                npc.interruptQueues()
+            }
+        }
     }
     npc.timers[AGGRO_CHECK_TIMER] = npc.combatDef.aggroTargetDelay
 }
 
-fun checkRadius(npc: Npc) {
+fun checkRadius(npc: Npc) : Boolean {
     val radius = npc.combatDef.aggressiveRadius
 
     mainLoop@
@@ -59,11 +66,13 @@ fun checkRadius(npc: Npc) {
             if (npc.getCombatTarget() != target) {
                 if(!target.isAttacking() && !target.isBeingAttacked()) {
                     npc.attack(target)
+                    return true
                 }
             }
             break@mainLoop
         }
     }
+    return false
 }
 
 fun canAttack(npc: Npc, target: Player): Boolean {


### PR DESCRIPTION
## What has been done?

- Added multi-way combat checks
- Re-installed NPC aggression plugin

- NPC aggression has had a couple changes, including checking if the radius was met and an attack was initiated, if not then interrupt all queues, interactions, and facing. Also added was a random check so that aggression wasn't "immediate" but gradual. 
