### PR TITLE
fix: max count for smithing items was calculated incorrectly

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/smithing/SmithingAction.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/smithing/SmithingAction.kt
@@ -14,7 +14,7 @@ class SmithingAction(val definitions: DefinitionSet) {
 
     suspend fun smith(task: QueueTask, product: BarProducts, amount: Int) {
         val player = task.player
-        val maxCount = min(amount, player.inventory.getItemCount(product.barType.item) * product.smithingType.barRequirement)
+        val maxCount = min(amount, player.inventory.getItemCount(product.barType.item) / product.smithingType.barRequirement)
 
         if(!canSmith(task, product, maxCount)) {
             player.animate(-1)
@@ -40,7 +40,7 @@ class SmithingAction(val definitions: DefinitionSet) {
             return false
         }
 
-        if(player.inventory.getItemCount(product.barType.item) < product.smithingType.barRequirement * amount) {
+        if(amount < 1) {
             task.messageBox("You don't have enough ${definitions.get(ItemDef::class.java, product.barType.item).name.lowercase()}s to make a ${product.smithingType.name.replace("TYPE_", "").replace("_", " ").lowercase()}.")
             return false
         }


### PR DESCRIPTION
## What has been done?
The max count when smithing items was calculated incorrectly - it should divide the bars in the inventory by the amount of bars per item, not muliply.

Also fixes the check in the canSmith function: if the amount is 0 or lower, we know there were not enough bars in the inventory.