### PR TITLE
Add support for keyboard keys 1-10, and spacebar for Item Box Actions

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/QueueTaskExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/QueueTaskExt.kt
@@ -33,6 +33,8 @@ private val closeDialog: QueueTask.() -> Unit = {
         player.closeComponent(parent = 752, child = 12)
     if (player.interfaces.isOccupied(752, 13))
         player.closeComponent(parent = 752, child = 13)
+
+    player.interfaces.optionsOpen = false
 }
 
 /**
@@ -86,13 +88,26 @@ suspend fun QueueTask.options(vararg options: String, title: String = "Select an
         player.setComponentText(interfaceId = interfaceId, component = i + 2, text = optionsFiltered[i])
     }
     player.setComponentText(interfaceId = interfaceId, component = 1, text = title)
+    player.interfaces.optionsOpen = true
+
     terminateAction = closeDialog
     waitReturnValue()
     terminateAction!!(this)
+
+    // check if a key was pressed
+    // note that options max out at 5, so
+    // keys after 5 (such as 6)
+    // will just reset the option back to 1, 2.. etc
     val keyMsg = requestReturnValue as? KeyTypedMessage
     if(keyMsg != null) {
-        return (keyMsg.keycode - 15)
+        return if(keyMsg.keycode in 16..20) {
+            keyMsg.keycode - 15
+        } else {
+            keyMsg.keycode - 20
+        }
     }
+
+
     return (requestReturnValue as? ResumePauseButtonMessage)?.let { it.button - 1 } ?: -1
 }
 
@@ -363,6 +378,8 @@ suspend fun QueueTask.produceItemBox(
             player.setVarcString(id = (index + 132), text = (if (names.isNotEmpty()) names[index] else nameArray[index]) + (if (extraNames.isNotEmpty()) "<br>${extraNames[index]}" else ""))
         }
     }
+
+    player.interfaces.optionsOpen = true
 
     if(player.attr[LAST_KNOWN_ITEMBOX_ITEM] != itemArray[0]) {
         player.attr[LAST_KNOWN_SPACE_ACTION] = 14

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/QueueTaskExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/QueueTaskExt.kt
@@ -89,6 +89,10 @@ suspend fun QueueTask.options(vararg options: String, title: String = "Select an
     terminateAction = closeDialog
     waitReturnValue()
     terminateAction!!(this)
+    val keyMsg = requestReturnValue as? KeyTypedMessage
+    if(keyMsg != null) {
+        return (keyMsg.keycode - 15)
+    }
     return (requestReturnValue as? ResumePauseButtonMessage)?.let { it.button - 1 } ?: -1
 }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/QueueTaskExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/QueueTaskExt.kt
@@ -379,8 +379,6 @@ suspend fun QueueTask.produceItemBox(
         }
     }
 
-    player.interfaces.optionsOpen = true
-
     if(player.attr[LAST_KNOWN_ITEMBOX_ITEM] != itemArray[0]) {
         player.attr[LAST_KNOWN_SPACE_ACTION] = 14
     }

--- a/game/src/main/kotlin/gg/rsmod/game/message/handler/KeyTypedHandler.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/handler/KeyTypedHandler.kt
@@ -2,9 +2,11 @@ package gg.rsmod.game.message.handler
 
 import gg.rsmod.game.message.MessageHandler
 import gg.rsmod.game.message.impl.KeyTypedMessage
+import gg.rsmod.game.message.impl.ResumePauseButtonMessage
 import gg.rsmod.game.model.World
 import gg.rsmod.game.model.entity.Client
 import gg.rsmod.game.model.entity.Player
+import gg.rsmod.game.system.ServerSystem
 
 /**
  * @author Alycia <https://github.com/alycii>
@@ -15,12 +17,15 @@ class KeyTypedHandler : MessageHandler<KeyTypedMessage> {
         val keycode = message.keycode
         val player = client as Player
 
-        // escape key
-        if(keycode == 13) {
-            if(player.interfaces.getModal() != -1 && player.lock.canInterfaceInteract()) {
-                player.closeInterfaceModal()
+        println(keycode)
+        when(keycode) {
+            13 -> { // ESC
+                if(player.interfaces.getModal() != -1 && player.lock.canInterfaceInteract()) {
+                    player.closeInterfaceModal()
+                }
             }
         }
 
+        client.queues.submitReturnValue(message)
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/message/handler/KeyTypedHandler.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/handler/KeyTypedHandler.kt
@@ -17,7 +17,6 @@ class KeyTypedHandler : MessageHandler<KeyTypedMessage> {
         val keycode = message.keycode
         val player = client as Player
 
-        println(keycode)
         when(keycode) {
             13 -> { // ESC
                 if(player.interfaces.getModal() != -1 && player.lock.canInterfaceInteract()) {

--- a/game/src/main/kotlin/gg/rsmod/game/message/handler/KeyTypedHandler.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/handler/KeyTypedHandler.kt
@@ -29,7 +29,7 @@ class KeyTypedHandler : MessageHandler<KeyTypedMessage> {
                 }
             }
             16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 -> { // Keys 1..10
-                if(player.interfaces.optionsOpen) {
+                if(player.interfaces.optionsOpen || player.interfaces.isVisible(905)) {
                     client.queues.submitReturnValue(message)
                 }
             }

--- a/game/src/main/kotlin/gg/rsmod/game/message/handler/KeyTypedHandler.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/handler/KeyTypedHandler.kt
@@ -24,7 +24,8 @@ class KeyTypedHandler : MessageHandler<KeyTypedMessage> {
                 }
             }
         }
-
-        client.queues.submitReturnValue(message)
+        if(player.interfaces.isOccupied(752, 12) || player.interfaces.isOccupied(752, 13)) {
+            client.queues.submitReturnValue(message)
+        }
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/message/handler/KeyTypedHandler.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/handler/KeyTypedHandler.kt
@@ -23,9 +23,16 @@ class KeyTypedHandler : MessageHandler<KeyTypedMessage> {
                     player.closeInterfaceModal()
                 }
             }
-        }
-        if(player.interfaces.isOccupied(752, 12) || player.interfaces.isOccupied(752, 13)) {
-            client.queues.submitReturnValue(message)
+            83 -> { // SPACE
+                if(!player.interfaces.optionsOpen && (player.interfaces.isOccupied(752, 12) || player.interfaces.isOccupied(752, 13))) {
+                    client.queues.submitReturnValue(message)
+                }
+            }
+            16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26 -> { // Keys 1..10
+                if(player.interfaces.optionsOpen) {
+                    client.queues.submitReturnValue(message)
+                }
+            }
         }
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
@@ -285,3 +285,18 @@ val ESSENCE_MINE_INTERACTED_WITH = AttributeKey<Int>(persistenceKey = "last_loc_
  * saved in milliseonds
  */
 val CREATION_DATE = AttributeKey<Long>(persistenceKey = "creation_date")
+
+/**
+ * The last known action that the player
+ * requested from the item box with space bar
+ */
+val LAST_KNOWN_SPACE_ACTION = AttributeKey<Int>(persistenceKey = "last_space_action")
+
+/**
+ * The last known initial item that the player
+ * used to request an item box
+ *
+ * Note: this is used to "reset" the space bar
+ * attribute should a "new" item box be produced
+ */
+val LAST_KNOWN_ITEMBOX_ITEM = AttributeKey<Int>(persistenceKey = "last_item_box")

--- a/game/src/main/kotlin/gg/rsmod/game/model/interf/InterfaceSet.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/interf/InterfaceSet.kt
@@ -12,6 +12,12 @@ import mu.KLogging
 class InterfaceSet(private val listener: InterfaceListener) {
 
     /**
+     * If the player has options dialogue
+     * opened
+     */
+    var optionsOpen: Boolean = false
+
+    /**
      * A map of currently visible interfaces.
      *
      * Key: bit-shifted value of the parent and child id.


### PR DESCRIPTION
## What has been done?

When producing an item box (fletching logs, spinning wool, smelting bars, etc..) you can now press keys on your keyboard to initialize the action.

For example, you want to fletch some regular logs, you use your knife on the logs and then press 1 to signal you want to fletch arrow shafts (as it's the first option in the item box)

Spacebar support has also been added, on which if you use key 2 for example, it'll remember that you pressed 2 and will act as though you pressed 2. This resets on a new item box being produced, and defaults to 1.

An example of a reset would be spacebar for fletching longbow (u) and then going to the spinning wheel, on opening the spinning wheel options, space bar will now act as key 1 and attempt to spin wool. This is also reset for fletching now, and spacebar will act as key 1 should you attempt to fletch again,