### PR TITLE
Remove loop from npc-aggro

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/aggro/npc_aggro.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/aggro/npc_aggro.plugin.kts
@@ -44,8 +44,6 @@ on_timer(AGGRO_CHECK_TIMER) {
 
 fun checkRadius(npc: Npc): Boolean {
     val radius = npc.combatDef.aggressiveRadius
-
-    mainLoop@
     for (x in -radius..radius) {
         for (z in -radius..radius) {
             val tile = npc.tile.transform(x, z)
@@ -68,7 +66,6 @@ fun checkRadius(npc: Npc): Boolean {
                     return true
                 }
             }
-            break@mainLoop
         }
     }
     return false


### PR DESCRIPTION
## What has been done?

- Removes the mainLoop@ from npc aggression, I believe this is the main cause for why it doesn't work on the official server. Will continue to debug if not.
