### PR TITLE
feat: more combat defs

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/NpcParams.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/NpcParams.kt
@@ -60,6 +60,8 @@ class NpcCombatBuilder {
 
     private var venomChance = -1.0
 
+    private var xpMultiplier = -1.0
+
     private var poisonImmunity = false
 
     private var venomImmunity = false
@@ -85,6 +87,9 @@ class NpcCombatBuilder {
         venomChance = Math.max(0.0, venomChance)
         slayerReq = Math.max(1, slayerReq)
         slayerXp = Math.max(0.0, slayerXp)
+        if (xpMultiplier < 0.0) {
+            xpMultiplier = 1.0
+        }
 
         if (aggroTimer == -1) {
             aggroTimer = DEFAULT_AGGRO_TIMER
@@ -95,7 +100,7 @@ class NpcCombatBuilder {
             defaultBlockAnim, deathAnimList, respawnDelay, aggroRadius,
             aggroTargetDelay, aggroTimer, poisonChance, venomChance,
             poisonImmunity, venomImmunity, slayerReq, slayerXp,
-            bonuses.toList(), speciesSet, spell
+            bonuses.toList(), speciesSet, spell, xpMultiplier
         )
     }
 
@@ -223,6 +228,12 @@ class NpcCombatBuilder {
     fun setVenomChance(chance: Double): NpcCombatBuilder {
         check(venomChance == -1.0) { "Venom chance already set." }
         venomChance = chance
+        return this
+    }
+
+    fun setXpMultiplier(multiplier: Double): NpcCombatBuilder {
+        check(xpMultiplier == -1.0) { "Xp multiplier already set." }
+        xpMultiplier = multiplier
         return this
     }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/dsl/NpcCombatDsl.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/dsl/NpcCombatDsl.kt
@@ -35,6 +35,7 @@ object NpcCombatDsl {
             combatBuilder.setRespawnDelay(builder.respawnDelay)
             combatBuilder.setPoisonChance(builder.poisonChance)
             combatBuilder.setVenomChance(builder.venomChance)
+            combatBuilder.setXpMultiplier(builder.xpMultiplier)
         }
 
         fun aggro(init: AggressivenessBuilder.() -> Unit) {
@@ -120,6 +121,11 @@ object NpcCombatDsl {
         var venomChance = -1.0
 
         var spell = -1
+
+        /**
+         * Some mobs reward less xp per hit than normal
+         */
+        var xpMultiplier = -1.0
     }
 
     @CombatDslMarker

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/Combat.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/Combat.kt
@@ -102,7 +102,7 @@ object Combat {
 
         val averageLvl = Math.floor((attackLvl + strengthLvl + defenceLvl + hitpoints) / 4.0)
         val averageDefBonus = Math.floor((npc.getBonus(BonusSlot.DEFENCE_STAB) + npc.getBonus(BonusSlot.DEFENCE_SLASH) + npc.getBonus(BonusSlot.DEFENCE_CRUSH)) / 3.0)
-        return 1.0 + Math.floor(averageLvl * (averageDefBonus + npc.getStrengthBonus() + npc.getAttackBonus()) / 5120.0) / 40.0
+        return (1.0 + Math.floor(averageLvl * (averageDefBonus + npc.getStrengthBonus() + npc.getAttackBonus()) / 5120.0) / 40.0) * npc.combatDef.xpMultiplier
     }
 
     fun raycast(pawn: Pawn, target: Pawn, distance: Int, projectile: Boolean): Boolean {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/black_bear_level_19.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/black_bear_level_19.plugin.kts
@@ -1,0 +1,50 @@
+package gg.rsmod.plugins.content.npcs.definitions
+
+import gg.rsmod.plugins.content.drops.DropTableFactory
+
+val ids = intArrayOf(Npcs.BLACK_BEAR)
+
+val table = DropTableFactory
+val blackBear = table.build {
+
+    guaranteed {
+        obj(Items.BONES)
+        obj(Items.BEAR_FUR)
+        obj(Items.RAW_BEAR_MEAT)
+    }
+
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 180)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 8)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 11)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 5)
+        nothing(slots = 796)
+    }
+}
+
+table.register(blackBear, *ids)
+
+on_npc_death(*ids) {
+    table.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
+ids.forEach {
+    set_combat_def(it) {
+        configs {
+            attackSpeed = 4
+            respawnDelay = 50
+        }
+        stats {
+            hitpoints = 250
+            attack = 15
+            strength = 16
+            defence = 13
+        }
+        anims {
+            attack = 4925
+            death = 4929
+            block = 4927
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/ghost_level_19.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/ghost_level_19.plugin.kts
@@ -1,0 +1,30 @@
+package gg.rsmod.plugins.content.npcs.definitions
+
+val ids = intArrayOf(Npcs.GHOST_104)
+
+ids.forEach {
+    set_combat_def(it) {
+        configs {
+            attackSpeed = 4
+            respawnDelay = 40
+        }
+        stats {
+            hitpoints = 250
+            attack = 13
+            strength = 13
+            defence = 18
+        }
+        bonuses {
+            defenceStab = 5
+            defenceSlash = 5
+            defenceCrush = 5
+            defenceMagic = 5
+            defenceRanged = 5
+        }
+        anims {
+            attack = 5535
+            death = 5534
+            block = 5533
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/ghost_level_19.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/ghost_level_19.plugin.kts
@@ -1,6 +1,6 @@
 package gg.rsmod.plugins.content.npcs.definitions
 
-val ids = intArrayOf(Npcs.GHOST_104)
+val ids = intArrayOf(Npcs.GHOST_104, Npcs.GHOST_5349, Npcs.GHOST_5350, Npcs.GHOST_5351, Npcs.GHOST_5352)
 
 ids.forEach {
     set_combat_def(it) {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/moss_giant_level_42.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/moss_giant_level_42.plugin.kts
@@ -1,0 +1,84 @@
+package gg.rsmod.plugins.content.npcs.definitions
+
+import gg.rsmod.plugins.content.drops.DropTableFactory
+import gg.rsmod.plugins.content.drops.global.Gems
+import gg.rsmod.plugins.content.drops.global.Herbs
+import gg.rsmod.plugins.content.drops.global.Seeds
+
+val ids = intArrayOf(Npcs.MOSS_GIANT)
+
+val table = DropTableFactory
+val mossGiant = table.build {
+    guaranteed {
+        obj(Items.BIG_BONES)
+    }
+    main {
+        total(128)
+
+        obj(Items.BLACK_SQ_SHIELD, slots = 5)
+        obj(Items.MAGIC_STAFF, slots = 2)
+        obj(Items.STEEL_MED_HELM, slots = 2)
+        obj(Items.MITHRIL_SWORD, slots = 2)
+        obj(Items.MITHRIL_SPEAR, slots = 2)
+        obj(Items.STEEL_KITESHIELD, slots = 1)
+        obj(Items.LAW_RUNE, quantity = 3, slots = 4)
+        obj(Items.AIR_RUNE, quantity = 18, slots = 3)
+        obj(Items.EARTH_RUNE, quantity = 27, slots = 3)
+        obj(Items.CHAOS_RUNE, quantity = 7, slots = 3)
+        obj(Items.NATURE_RUNE, quantity = 6, slots = 3)
+        obj(Items.COSMIC_RUNE, quantity = 3, slots = 2)
+        obj(Items.IRON_ARROW, quantity = 15, slots = 2)
+        obj(Items.STEEL_ARROW, quantity = 30, slots = 1)
+        obj(Items.DEATH_RUNE, quantity = 3, slots = 1)
+        obj(Items.BLOOD_RUNE, quantity = 1, slots = 1)
+        obj(Items.COINS_995, quantity = 37, slots = 19)
+        obj(Items.COINS_995, quantity = 2, slots = 8)
+        obj(Items.COINS_995, quantity = 119, slots = 10)
+        obj(Items.COINS_995, quantity = 300, slots = 2)
+        obj(Items.STEEL_BAR, slots = 6)
+        obj(Items.COAL, slots = 1)
+        obj(Items.SPINACH_ROLL, slots = 1)
+
+        table(Herbs.minorHerbTable, slots = 5)
+        table(Seeds.uncommonSeedtable, slots = 35)
+        table(Gems.gemTable, slots = 4)
+    }
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 360)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 30)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 30)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 7)
+        nothing(slots = 573)
+    }
+}
+
+table.register(mossGiant, *ids)
+
+on_npc_death(*ids) {
+    table.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
+ids.forEach {
+    set_combat_def(it) {
+        configs {
+            attackSpeed = 6
+            respawnDelay = 30
+        }
+        stats {
+            hitpoints = 600
+            attack = 30
+            strength = 30
+            defence = 30
+        }
+        bonuses {
+            attackStab = 33
+            attackCrush = 31
+        }
+        anims {
+            attack = 4652
+            death = 4653
+            block = 4651
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/outlaw_level_35.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/outlaw_level_35.plugin.kts
@@ -1,0 +1,71 @@
+package gg.rsmod.plugins.content.npcs.definitions
+
+import gg.rsmod.plugins.api.cfg.Items
+import gg.rsmod.plugins.api.cfg.Npcs
+import gg.rsmod.plugins.content.drops.DropTableFactory
+import gg.rsmod.plugins.content.drops.global.Herbs
+
+val ids = intArrayOf(Npcs.OUTLAW, Npcs.OUTLAW_5843, Npcs.OUTLAW_5844, Npcs.OUTLAW_5845, Npcs.OUTLAW_5846, Npcs.OUTLAW_5847, Npcs.OUTLAW_5848, Npcs.OUTLAW_5849, Npcs.OUTLAW_5850, Npcs.OUTLAW_5851)
+
+val table = DropTableFactory
+val outlaw = table.build {
+    guaranteed {
+        obj(Items.BONES)
+    }
+    main {
+        total(128)
+
+        obj(Items.BRONZE_MED_HELM, slots = 2)
+        obj(Items.MIND_RUNE, quantity = 9, slots = 2)
+        obj(Items.WATER_RUNE, quantity = 6, slots = 2)
+        obj(Items.EARTH_RUNE, quantity = 5, slots = 2)
+        obj(Items.COINS_995, quantity = 5, slots = 12)
+        obj(Items.COINS_995, quantity = 15, slots = 4)
+        obj(Items.COINS_995, quantity = 25, slots = 1)
+        obj(Items.ROPE, slots = 46)
+        obj(Items.FISHING_BAIT, slots = 15)
+        obj(Items.CABBAGE, slots = 6)
+        obj(Items.COPPER_ORE, slots = 2)
+        obj(Items.KNIFE, slots = 1)
+
+        table(Herbs.minorHerbTable, slots = 32)
+    }
+    table("Charms") {
+        total(1000)
+        obj(Items.GOLD_CHARM, quantity = 1, slots = 360)
+        obj(Items.GREEN_CHARM, quantity = 1, slots = 30)
+        obj(Items.CRIMSON_CHARM, quantity = 1, slots = 30)
+        obj(Items.BLUE_CHARM, quantity = 1, slots = 7)
+        nothing(slots = 573)
+    }
+}
+
+table.register(outlaw, *ids)
+
+on_npc_death(*ids) {
+    table.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
+ids.forEach {
+    set_combat_def(it) {
+        configs {
+            attackSpeed = 4
+            respawnDelay = 2
+            xpMultiplier = 0.025
+        }
+        stats {
+            hitpoints = 200
+            attack = 35
+            strength = 30
+            defence = 25
+        }
+        bonuses {
+            attackCrush = -21
+        }
+        anims {
+            attack = 390
+            block = 424
+            death = 836
+        }
+    }
+}

--- a/game/src/main/kotlin/gg/rsmod/game/model/combat/NpcCombatDef.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/combat/NpcCombatDef.kt
@@ -11,7 +11,7 @@ data class NpcCombatDef(
     val aggressiveRadius: Int, val aggroTargetDelay: Int, val aggressiveTimer: Int,
     val poisonChance: Double, val venomChance: Double, val poisonImmunity: Boolean,
     val venomImmunity: Boolean, val slayerReq: Int, val slayerXp: Double,
-    val bonuses: List<Int>, val species: Set<Any>, val spell: Int
+    val bonuses: List<Int>, val species: Set<Any>, val spell: Int, val xpMultiplier: Double
 ) {
 
     companion object {
@@ -33,7 +33,8 @@ data class NpcCombatDef(
             aggressiveTimer = 0, poisonChance = 0.0,
             venomChance = 0.0, poisonImmunity = false, venomImmunity = false,
             slayerReq = 1, slayerXp = 0.0, bonuses = emptyList(), species = emptySet(),
-            spell = -1
+            spell = -1,
+            xpMultiplier = 1.0
         )
     }
 }


### PR DESCRIPTION
## What has been done?
- Adds moss giant combat definition
- Adds ghost combat definition
- Adds black bear combat definition
- Adds outlaw combat definition
   - Adds an npc combat setting "xpMultiplier". Any combat xp gained from attacking this npc is multiplied by that factor. Needed because outlaws only provide 2.5% as much xp as other monsters. Will be needed for the vampire in vampire slayer as well, for example 