### PR TITLE
Adds ash scatting using the same implementation as burying bones.

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/prayer/burying/BoneData.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/prayer/burying/BoneData.kt
@@ -6,7 +6,7 @@ enum class BoneData(val bone: Int, val experience: Double) {
 
     BONES(bone = Items.BONES, experience = 4.5),
     WOLF_BONES(bone = Items.WOLF_BONES, experience = 4.5),
-    BURNST_BONES(bone = Items.BURNT_BONES, experience = 4.5),
+    BURNT_BONES(bone = Items.BURNT_BONES, experience = 4.5),
     MONKEY_BONES(bone = Items.MONKEY_BONES, experience = 5.0),
     MONKEY_BONES_2(bone = Items.MONKEY_BONES_3180, experience = 5.0),
     MONKEY_BONES_3(bone = Items.MONKEY_BONES_3181, experience = 5.0),

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/prayer/scattering/AshData.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/prayer/scattering/AshData.kt
@@ -2,11 +2,11 @@ package gg.rsmod.plugins.content.skills.prayer.scattering
 
 import gg.rsmod.plugins.api.cfg.Items
 
-enum class AshData(val ash: Int, val experience: Double) {
+enum class AshData(val ash: Int, val gfx: Int, val experience: Double) {
 
-    IMPIOUS_ASHES(ash = Items.IMPIOUS_ASHES, experience = 4.0),
-    ACCURSED_ASHES(ash = Items.ACCURSED_ASHES, experience = 12.5),
-    INFERNAL_ASHES(ash = Items.INFERNAL_ASHES, experience = 62.5);
+    IMPIOUS_ASHES(ash = Items.IMPIOUS_ASHES, gfx = 56, experience = 4.0),
+    ACCURSED_ASHES(ash = Items.ACCURSED_ASHES, gfx = 47, experience = 12.5),
+    INFERNAL_ASHES(ash = Items.INFERNAL_ASHES, gfx = 40, experience = 62.5);
 
     companion object {
         val values = enumValues<AshData>()

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/prayer/scattering/AshData.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/prayer/scattering/AshData.kt
@@ -1,0 +1,15 @@
+package gg.rsmod.plugins.content.skills.prayer.scattering
+
+import gg.rsmod.plugins.api.cfg.Items
+
+enum class AshData(val ash: Int, val experience: Double) {
+
+    IMPIOUS_ASHES(ash = Items.IMPIOUS_ASHES, experience = 4.0),
+    ACCURSED_ASHES(ash = Items.ACCURSED_ASHES, experience = 12.5),
+    INFERNAL_ASHES(ash = Items.INFERNAL_ASHES, experience = 62.5);
+
+    companion object {
+        val values = enumValues<AshData>()
+        val ashDefinitions = values.associateBy { it.ash }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/prayer/scattering/ash_scattering.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/prayer/scattering/ash_scattering.plugin.kts
@@ -1,0 +1,21 @@
+package gg.rsmod.plugins.content.skills.prayer.scattering
+
+
+val ashData = AshData.values
+val definitions = AshData.ashDefinitions
+val ashes = ashData.map { it.ash }.toTypedArray()
+
+ashes.forEach { ash ->
+    on_item_option(ash, option = "scatter") {
+        player.lockingQueue(lockState = LockState.DELAY_ACTIONS) {
+
+            player.animate(445)
+            wait(2)
+
+            if (player.inventory.remove(item = ash, beginSlot = player.getInteractingItemSlot()).hasSucceeded()) {
+                player.filterableMessage("You scatter the ashes in the wind.")
+                player.addXp(Skills.PRAYER, definitions[ash]!!.experience)
+            }
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/prayer/scattering/ash_scattering.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/prayer/scattering/ash_scattering.plugin.kts
@@ -10,6 +10,7 @@ ashes.forEach { ash ->
         player.lockingQueue(lockState = LockState.DELAY_ACTIONS) {
 
             player.animate(445)
+            player.graphic(definitions[ash]!!.gfx)
             wait(2)
 
             if (player.inventory.remove(item = ash, beginSlot = player.getInteractingItemSlot()).hasSucceeded()) {


### PR DESCRIPTION
Corrects a spelling mistake in BoneData.kt

Scattering animation is missing particle effect.
See: https://www.youtube.com/watch?v=Yv7KXYc4Pu4

## What has been done?
Implements ash scattering as a prayer training method via the same implementation as bone burying.
Corrects a spelling mistake in BoneData.kt

## Has your code been documented?
No. I believe it is clear what is happening.