### PR TITLE
Add discord widget to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ This repository hosts the game server files which contain all of our relevant pl
 [license-badge]: https://img.shields.io/badge/license-ISC-informational
 
 [discord]: https://discord.gg/jDbBAKjhxh
-[discord-badge]: https://img.shields.io/discord/1066359868908384286?color=%237289da&logo=discord
+[discord-badge]: https://img.shields.io/discord/1055304546521469019?color=%237289da&logo=discord

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-<p align="center">
-  <img src="https://cdn.discordapp.com/attachments/1067274729205010463/1082144752985702451/2011scapelogo.png" />
-  <br>
-  <br>
-  <br>
-  <img src="https://cdn.discordapp.com/attachments/1067274729205010463/1082144013475397702/image.png" />
-  <br>
-</p>
+<img src="https://cdn.discordapp.com/attachments/1067274729205010463/1082144752985702451/2011scapelogo.png" />
 
+<img src="https://cdn.discordapp.com/attachments/1067274729205010463/1082144013475397702/image.png" />
+
+[![license][license-badge]][isc] [![discord-badge]][discord]
+
+  
 # Game Server
 
 This repository hosts the game server files which contain all of our relevant plugins, core, and data. The game server is derived from RSMod v1 and has been since converted to work with the RuneTek-5 engine, and targets revision 667.
+
 # Community
 
 - Discord: [2011Scape Discord](https://discord.gg/jDbBAKjhxh)
@@ -27,3 +26,10 @@ This repository hosts the game server files which contain all of our relevant pl
 - [OpenRS2 Archive](https://archive.openrs2.org/)
 - [Lost City, 2004 Emulator](https://discord.gg/hN3tHUmZEN)
 - [2009Scape, 2009 Emulator](https://2009scape.org)
+
+[isc]: https://opensource.org/licenses/LGPL-3.0
+[license]: https://github.com/2011Scape/game/blob/main/LICENSE
+[license-badge]: https://img.shields.io/badge/license-ISC-informational
+
+[discord]: https://discord.gg/jDbBAKjhxh
+[discord-badge]: https://img.shields.io/discord/1066359868908384286?color=%237289da&logo=discord


### PR DESCRIPTION
Discord information will now display on the README, as well as licensing information.