### PR TITLE
fix: data loss on long and double attributes

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/model/attr/AttributeMap.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/attr/AttributeMap.kt
@@ -49,5 +49,23 @@ class AttributeMap {
         }
     }
 
-    fun toPersistentMap(): Map<String, Any> = attributes.filterKeys { it.persistenceKey != null }.mapKeys { it.key.persistenceKey!! }
+    /**
+     * Gathers all persistent attributes so that they can be saved in the player profile.
+     * The dynamic nature of attributes makes it hard if not impossible to distinguish between Ints, Doubles and Longs
+     * when loading a player profile, without explicitly stating the type. Therefore, all Longs and Doubles are
+     * stored in a separate attribute.
+     */
+    fun toPersistentMap(): Map<String, Any> {
+        val persistentAttributes = attributes.filterKeys { it.persistenceKey != null }
+        val longs = persistentAttributes.filter { it.value is Long }
+        val doubles = persistentAttributes.filter { it.value is Double }
+        val others = persistentAttributes.filter { it.value !is Long && it.value !is Double }.toMutableMap()
+        if (longs.any()) {
+            others[LONG_ATTRIBUTES] = longs.mapKeys { it.key.persistenceKey!! }
+        }
+        if (doubles.any()) {
+            others[DOUBLE_ATTRIBUTES] = doubles.mapKeys { it.key.persistenceKey!! }
+        }
+        return others.mapKeys { it.key.persistenceKey!! }
+    }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
@@ -300,3 +300,13 @@ val LAST_KNOWN_SPACE_ACTION = AttributeKey<Int>(persistenceKey = "last_space_act
  * attribute should a "new" item box be produced
  */
 val LAST_KNOWN_ITEMBOX_ITEM = AttributeKey<Int>(persistenceKey = "last_item_box")
+
+/**
+ * Placeholder for attributes of type Long when saving and loading player data
+ */
+val LONG_ATTRIBUTES = AttributeKey<Map<String, Long>>(persistenceKey = "long_attributes")
+
+/**
+ * Placeholder for attributes of type Double when saving and loading player data
+ */
+val DOUBLE_ATTRIBUTES = AttributeKey<Map<String, Double>>(persistenceKey = "double_attributes")


### PR DESCRIPTION
## What has been done?
The current code converts all double player attributes to ints on loading. This is fine, until we start using doubles or longs as attributes, such as the creation date. This PR fixes that, by making a distinction between ints, doubles and longs on saving and loading a player profile. Since type erasure is a thing in the JVM, there isn't really a clean way to do this.

This is a preparatory PR for the farming skill, where some long values need to be stored as well.

## Has your code been documented?
Yes