### PR TITLE
fix: Apply fix to give proper attack animation for weapons considered as Long Swords

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/CombatConfigs.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/CombatConfigs.kt
@@ -118,7 +118,7 @@ object CombatConfigs {
                 pawn.hasWeaponType(WeaponType.SCYTHE) -> 8056
                 pawn.hasWeaponType(WeaponType.BOW) -> 426
                 pawn.hasWeaponType(WeaponType.CROSSBOW) -> 4230
-                pawn.hasWeaponType(WeaponType.LONG_SWORD) -> if (style == 2) 390 else 386
+                pawn.hasWeaponType(WeaponType.LONG_SWORD) -> if (style == 2) 386 else 390
                 pawn.hasWeaponType(WeaponType.TWO_HANDED) -> if (style == 0) 406 else 407
                 pawn.hasWeaponType(WeaponType.PICKAXE) -> if (style == 2) 400 else 401
                 pawn.hasWeaponType(WeaponType.DAGGER) -> if (style == 2) 390 else 386


### PR DESCRIPTION
## What has been done?
Weapons considered as long swords were previously using the lunge animation for regular attacks whilst it is supposed to use the slash animation. This addresses that issue.

## Has your code been documented?
No, just a simple id change