### PR TITLE
feat: Weeds farming

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/cfg/Objs.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/cfg/Objs.kt
@@ -4767,6 +4767,7 @@ object Objs {
     const val DEAD_HERBS = 8147
     const val DEAD_HERBS_8148 = 8148
     const val DEAD_HERBS_8149 = 8149
+    const val HERB_PATCH_8151 = 8151
     const val ASGARNIAN_HOPS_8154 = 8154
     const val ASGARNIAN_HOPS_8155 = 8155
     const val ASGARNIAN_HOPS_8156 = 8156

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/core/PlayerManager.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/core/PlayerManager.kt
@@ -36,7 +36,7 @@ object PlayerManager {
             val includeCurrentFarmTick = FarmTicker.gameTicksUntilNextFarmTick(player.world) < ticksLeftOnNextTimer
 
             // Replay all player farming ticks that occurred while logged out
-            for (seedList in FarmTicker.pastSeedTypes(player.world, lastWorldFarmTick, includeCurrentFarmTick)) {
+            for (seedList in FarmTicker.pastSeedTypes(player.world, lastWorldFarmTick + 1, includeCurrentFarmTick)) {
                 grow(player, seedList)
                 if (GrowthManager.everythingFullyGrown(player)) {
                     // If everything is fully grown, there's no need to replay any more player farming ticks

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/core/WorldFarmingManager.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/core/WorldFarmingManager.kt
@@ -2,6 +2,7 @@ package gg.rsmod.plugins.content.skills.farming.core
 
 import gg.rsmod.game.model.World
 import gg.rsmod.plugins.content.skills.farming.constants.Constants
+import gg.rsmod.plugins.content.skills.farming.data.Patch
 
 object WorldFarmingManager {
 
@@ -11,6 +12,7 @@ object WorldFarmingManager {
     fun onWorldInit(world: World) {
         FarmTicker.initialize(world)
         world.timers[Constants.worldFarmingTimer] = Constants.worldFarmingTickLength - FarmTicker.gameTicksSinceLastFarmTick(world)
+        Patch.initialize(world)
     }
 
     /**

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/data/Patch.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/data/Patch.kt
@@ -1,0 +1,23 @@
+package gg.rsmod.plugins.content.skills.farming.data
+
+import gg.rsmod.game.fs.def.ObjectDef
+import gg.rsmod.game.model.World
+import gg.rsmod.plugins.api.cfg.Objs
+
+enum class Patch(val id: Int, val patchName: String, vararg val seedTypes: SeedType) {
+    CatherbyHerb(Objs.HERB_PATCH_8151, "herb patch", SeedType.Herb);
+
+    var varbit: Int = -1
+        private set
+
+    companion object {
+        /**
+         * Initializes the definitions and varbits for all patches. This ensures this only needs to be done on startup
+         */
+        fun initialize(world: World) {
+            values().forEach {
+                it.varbit = world.definitions.get(ObjectDef::class.java, it.id).varbit
+            }
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/farmingInteractions.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/farmingInteractions.plugin.kts
@@ -1,0 +1,29 @@
+package gg.rsmod.plugins.content.skills.farming
+
+import gg.rsmod.plugins.content.skills.farming.data.Patch
+import gg.rsmod.plugins.content.skills.farming.logic.patchHandler.WeedsHandler
+
+Patch.values().forEach { patch ->
+    val transformIds = world.definitions.get(ObjectDef::class.java, patch.id).transforms?.toSet() ?: return@forEach
+    val transforms = transformIds.mapNotNull { world.definitions.getNullable(ObjectDef::class.java, it) }
+
+    initializeRaking(patch, transforms)
+}
+
+fun initializeRaking(patch: Patch, transforms: List<ObjectDef>) {
+    transforms.forEach {
+        if (if_obj_has_option(it.id, "rake")) {
+            on_obj_option(it.id, "rake") {
+                player.queue {
+                    WeedsHandler(patch, player).rake(this)
+                }
+            }
+
+            on_item_on_obj(it.id, item = Items.RAKE) {
+                player.queue {
+                    WeedsHandler(patch, player).rake(this)
+                }
+            }
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/farmingInteractions.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/farmingInteractions.plugin.kts
@@ -1,5 +1,6 @@
 package gg.rsmod.plugins.content.skills.farming
 
+import gg.rsmod.game.model.priv.Privilege
 import gg.rsmod.plugins.content.skills.farming.data.Patch
 import gg.rsmod.plugins.content.skills.farming.logic.patchHandler.WeedsHandler
 
@@ -14,16 +15,29 @@ fun initializeRaking(patch: Patch, transforms: List<ObjectDef>) {
     transforms.forEach {
         if (if_obj_has_option(it.id, "rake")) {
             on_obj_option(it.id, "rake") {
-                player.queue {
-                    WeedsHandler(patch, player).rake(this)
+                if (checkAvailability(player)) {
+                    player.queue {
+                        WeedsHandler(patch, player).rake(this)
+                    }
                 }
             }
 
             on_item_on_obj(it.id, item = Items.RAKE) {
-                player.queue {
-                    WeedsHandler(patch, player).rake(this)
+                if (checkAvailability(player)) {
+                    player.queue {
+                        WeedsHandler(patch, player).rake(this)
+                    }
                 }
             }
         }
+    }
+}
+
+fun checkAvailability(player: Player): Boolean {
+    return if (world.privileges.isEligible(player.privilege, Privilege.ADMIN_POWER)) {
+        true
+    } else {
+        player.message("Coming soon...")
+        false
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/GrowthManager.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/GrowthManager.kt
@@ -1,18 +1,26 @@
 package gg.rsmod.plugins.content.skills.farming.logic
 
 import gg.rsmod.game.model.entity.Player
+import gg.rsmod.plugins.content.skills.farming.data.Patch
 import gg.rsmod.plugins.content.skills.farming.data.SeedType
+import gg.rsmod.plugins.content.skills.farming.logic.patchHandler.WeedsHandler
 
 object GrowthManager {
     fun growWeeds(player: Player) {
-
+        for (patch in Patch.values()) {
+            WeedsHandler(patch, player).growWeeds()
+        }
     }
 
     fun growSeeds(player: Player, seedTypesToGrow: List<SeedType>) {
+        // TODO
+    }
 
+    fun growProduce(player: Player, seedTypesToGrow: List<SeedType>) {
+        // TODO
     }
 
     fun everythingFullyGrown(player: Player): Boolean {
-        return false
+        return Patch.values().all { WeedsHandler(it, player).patchIsFullyGrown }
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/patchHandler/PatchVarbitUpdater.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/patchHandler/PatchVarbitUpdater.kt
@@ -1,0 +1,27 @@
+package gg.rsmod.plugins.content.skills.farming.logic.patchHandler
+
+import gg.rsmod.game.model.entity.Player
+import gg.rsmod.plugins.api.ext.getVarbit
+import gg.rsmod.plugins.api.ext.setVarbit
+import gg.rsmod.plugins.content.skills.farming.data.Patch
+
+abstract class PatchVarbitUpdater(protected val patch: Patch, protected val player: Player) {
+
+    protected fun setVarbit(newValue: Int) {
+        player.setVarbit(patch.varbit, newValue)
+    }
+
+    protected fun updateVarbit(delta: Int) {
+        player.setVarbit(patch.varbit, player.getVarbit(patch.varbit) + delta)
+    }
+
+    protected fun increaseVarbitByOne() {
+        updateVarbit(1)
+    }
+
+    protected fun decreaseVarbitByOne() {
+        updateVarbit(-1)
+    }
+
+    protected val varbitValue get() = player.getVarbit(patch.varbit)
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/patchHandler/WeedsHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/patchHandler/WeedsHandler.kt
@@ -1,0 +1,78 @@
+package gg.rsmod.plugins.content.skills.farming.logic.patchHandler
+
+import gg.rsmod.game.model.entity.Player
+import gg.rsmod.game.model.queue.QueueTask
+import gg.rsmod.plugins.api.Skills
+import gg.rsmod.plugins.api.cfg.Items
+import gg.rsmod.plugins.api.ext.interpolate
+import gg.rsmod.plugins.api.ext.message
+import gg.rsmod.plugins.content.skills.farming.data.Patch
+
+class WeedsHandler(patch: Patch, player: Player): PatchVarbitUpdater(patch, player) {
+
+    private val canGrowWeeds: Boolean get() = varbitValue in growableVarbits
+
+    private val patchHasWeeds get() = varbitValue in weedVarbits
+
+    val patchIsFullyGrown get() = varbitValue == fullyGrownWeedsVarbit
+
+    fun growWeeds() {
+        if (canGrowWeeds) {
+            decreaseVarbitByOne()
+        }
+    }
+
+    suspend fun rake(task: QueueTask) {
+        while (canRake) {
+            player.animate(rakingAnimation)
+            task.wait(rakingWaitTime)
+
+            // Another check whether raking is possible - something might have changed in the past few ticks
+            if (canRake) {
+                if (rollRakingSuccess()) {
+                    increaseVarbitByOne()
+                    player.inventory.add(Items.WEEDS)
+                    player.addXp(Skills.FARMING, rakingXp)
+                    if (!patchHasWeeds) {
+                        break
+                    }
+                }
+            }
+        }
+        player.animate(-1)
+    }
+
+    private val canRake: Boolean get() {
+        if (!patchHasWeeds) {
+            player.message("The ${patch.patchName} doesn't need weeding right now.")
+            return false
+        }
+
+        if (player.inventory.isFull) {
+            player.message("You don't have enough inventory space.")
+            return false
+        }
+
+        if (!player.inventory.contains(Items.RAKE)) {
+            player.message("You need a rake to do that.")
+            return false
+        }
+
+        return true
+    }
+
+    private fun rollRakingSuccess(): Boolean {
+        val farmingLevel = player.getSkills().getCurrentLevel(Skills.FARMING)
+        return farmingLevel.interpolate(minChance = 64, maxChance = 512, minLvl = 1, maxLvl = 99, cap = 256)
+    }
+
+    companion object {
+        private const val rakingAnimation = 2273
+        private const val rakingWaitTime = 4
+        private const val rakingXp = 4.0
+        private const val fullyGrownWeedsVarbit = 0
+
+        private val growableVarbits = 1..3
+        private val weedVarbits = 0..2
+    }
+}


### PR DESCRIPTION
## What has been done?
Adds raking functionality to the Catherby herb patch. Weeds will regrow one stage each world farming tick.

Small bugfix to the player login logic for farming.

For now, attempting to rake as a normal player is not possible.

## Has your code been documented?
Yes