### PR TITLE
fix: less plugins

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/skillguides/skill_guides.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/skillguides/skill_guides.plugin.kts
@@ -2,6 +2,7 @@ package gg.rsmod.plugins.content.inter.skillguides
 
 import gg.rsmod.game.model.attr.SKILL_MENU
 import gg.rsmod.game.model.skill.SkillSet
+import gg.rsmod.plugins.content.skills.farming.data.Patch
 
 val SKILL_ID_VARBIT = 965
 val LEVELED_SKILL_VARBIT = 4729
@@ -31,6 +32,16 @@ SkillGuide.values.forEach { guide ->
         }
         when (player.getInteractingOpcode()) {
             61 -> openSkillMenu(player, guide)
+        }
+    }
+}
+
+val patchTransformIds = Patch.values().flatMap { world.definitions.get(ObjectDef::class.java, it.id).transforms?.toSet() ?: setOf() }.toSet()
+val patchTransforms = patchTransformIds.mapNotNull { world.definitions.getNullable(ObjectDef::class.java, it) }
+patchTransforms.forEach {
+    if (if_obj_has_option(it.id, "guide")) {
+        on_obj_option(it.id, "guide") {
+            Patch.byPatchId(player.getInteractingGameObj().id)?.let { openSkillMenu(player, SkillGuide.FARMING) }
         }
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/constants/CompostState.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/constants/CompostState.kt
@@ -14,5 +14,7 @@ enum class CompostState(val itemId: Int, val diseaseChanceFactor: Double, val pe
 
     companion object {
         fun fromPersistenceId(persistenceId: String) = values().first { it.persistenceId == persistenceId }
+        fun fromId(id: Int) = values().first { it.itemId == id }
+        val itemIds = values().map { it.itemId }.filterNot { it == -1 }
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/data/Seed.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/data/Seed.kt
@@ -250,5 +250,9 @@ enum class Seed(
                 it.seedName = world.definitions.get(ItemDef::class.java, it.seedId).name.lowercase()
             }
         }
+
+        val seedIds = values().map { it.seedId }
+
+        fun fromId(itemId: Int) = values().singleOrNull { it.seedId == itemId }
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/farmingInteractions.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/farmingInteractions.plugin.kts
@@ -1,22 +1,18 @@
 package gg.rsmod.plugins.content.skills.farming
 
 import gg.rsmod.game.model.priv.Privilege
-import gg.rsmod.plugins.content.skills.farming.constants.CompostState
 import gg.rsmod.plugins.content.skills.farming.data.Patch
-import gg.rsmod.plugins.content.skills.farming.data.Seed
 import gg.rsmod.plugins.content.skills.farming.data.SeedType
-import gg.rsmod.plugins.content.skills.farming.logic.handler.WaterHandler
 
 val transformIds = Patch.values().flatMap { world.definitions.get(ObjectDef::class.java, it.id).transforms?.toSet() ?: setOf() }.toSet()
 val transforms = transformIds.mapNotNull { world.definitions.getNullable(ObjectDef::class.java, it) }
 
 initializeRaking(transforms)
-initializePlanting(transforms)
-initializeComposting(transforms)
-initializeWatering(transforms)
-initializeCuring(transforms)
 initializeHarvesting(transforms)
 initializeClearing(transforms)
+initializeInspecting(transforms)
+
+initializeItemOnPatch(transforms)
 
 fun initializeRaking(transforms: List<ObjectDef>) {
     transforms.forEach {
@@ -25,58 +21,6 @@ fun initializeRaking(transforms: List<ObjectDef>) {
                 if (checkAvailability(player)) {
                     findPatch(player)?.let(player.farmingManager()::rake)
                 }
-            }
-
-            on_item_on_obj(it.id, item = Items.RAKE) {
-                if (checkAvailability(player)) {
-                    findPatch(player)?.let(player.farmingManager()::rake)
-                }
-            }
-        }
-    }
-}
-
-fun initializePlanting(transforms: List<ObjectDef>) {
-    transforms.forEach { transform ->
-        Seed.values().forEach { seed ->
-            on_item_on_obj(transform.id, item = seed.seedId) {
-                if (checkAvailability(player)) {
-                    findPatch(player)?.let { player.farmingManager().plant(it, seed) }
-                }
-            }
-        }
-    }
-}
-
-fun initializeComposting(transforms: List<ObjectDef>) {
-    transforms.forEach { transform ->
-        CompostState.values().filter { it.itemId > 0 }.forEach { compost ->
-            on_item_on_obj(transform.id, item = compost.itemId) {
-                if (checkAvailability(player)) {
-                    findPatch(player)?.let { player.farmingManager().addCompost(it, compost) }
-                }
-            }
-        }
-    }
-}
-
-fun initializeWatering(transforms: List<ObjectDef>) {
-    transforms.forEach { transform ->
-        WaterHandler.wateringCans.forEach { wateringCan ->
-            on_item_on_obj(transform.id, item = wateringCan) {
-                if (checkAvailability(player)) {
-                    findPatch(player)?.let { player.farmingManager().water(it, wateringCan) }
-                }
-            }
-        }
-    }
-}
-
-fun initializeCuring(transforms: List<ObjectDef>) {
-    transforms.forEach { transform ->
-        on_item_on_obj(transform.id, item = Items.PLANT_CURE) {
-            if (checkAvailability(player)) {
-                findPatch(player)?.let(player.farmingManager()::cure)
             }
         }
     }
@@ -103,6 +47,28 @@ fun initializeClearing(transforms: List<ObjectDef>) {
             on_obj_option(it.id, "clear") {
                 if (checkAvailability(player)) {
                     findPatch(player)?.let(player.farmingManager()::clear)
+                }
+            }
+        }
+    }
+}
+
+fun initializeItemOnPatch(transforms: List<ObjectDef>) {
+    transforms.forEach {
+        on_any_item_on_obj(it.id) {
+            if (checkAvailability(player)) {
+                findPatch(player)?.let { player.farmingManager().itemUsed(it, player.getInteractingItem().id) }
+            }
+        }
+    }
+}
+
+fun initializeInspecting(transforms: List<ObjectDef>) {
+    transforms.forEach {
+        if (if_obj_has_option(it.id, "inspect")) {
+            on_obj_option(it.id, "inspect") {
+                if (checkAvailability(player)) {
+                    findPatch(player)?.let(player.farmingManager()::inspect)
                 }
             }
         }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/FarmingManager.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/FarmingManager.kt
@@ -1,10 +1,13 @@
 package gg.rsmod.plugins.content.skills.farming.logic
 
 import gg.rsmod.game.model.entity.Player
+import gg.rsmod.plugins.api.cfg.Items
+import gg.rsmod.plugins.api.ext.message
 import gg.rsmod.plugins.content.skills.farming.constants.CompostState
 import gg.rsmod.plugins.content.skills.farming.data.Patch
 import gg.rsmod.plugins.content.skills.farming.data.Seed
 import gg.rsmod.plugins.content.skills.farming.data.SeedType
+import gg.rsmod.plugins.content.skills.farming.logic.handler.WaterHandler
 
 /**
  * Manager class for all farming-related logic, tied to a specific player
@@ -17,6 +20,19 @@ class FarmingManager(private val player: Player) {
     fun onFarmingTick(seedTypesToGrow: Set<SeedType>) {
         for (patch in patches.values) {
             patch.grow(seedTypesToGrow)
+        }
+    }
+
+    fun itemUsed(patch: Patch, item: Int) {
+        when (item) {
+            Items.RAKE -> rake(patch)
+            Items.SEED_DIBBER -> player.message("I should plant a seed, not the seed dibber.")
+            Items.PLANT_CURE -> cure(patch)
+            Items.SPADE -> clear(patch)
+            in CompostState.itemIds -> addCompost(patch, CompostState.fromId(item))
+            in WaterHandler.wateringCans -> water(patch, item)
+            in Seed.seedIds -> plant(patch, Seed.fromId(item)!!)
+            else -> player.message("Nothing interesting happens.")
         }
     }
 
@@ -50,6 +66,10 @@ class FarmingManager(private val player: Player) {
 
     fun clear(patch: Patch) {
         patches[patch]!!.clear()
+    }
+
+    fun inspect(patch: Patch) {
+        patches[patch]!!.inspect()
     }
 
     fun everythingFullyGrown(): Boolean {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/PatchManager.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/PatchManager.kt
@@ -22,6 +22,7 @@ class PatchManager(patch: Patch, player: Player): PatchVarbitUpdater(patch, play
     private val cureHandler = CureHandler(state, patch, player)
     private val harvestHandler = HarvestingHandler(state, patch, player)
     private val clearHandler = ClearHandler(state, player)
+    private val inspectHandler = InspectHandler(state, patch, player)
 
     val fullyGrown get() = state.isFullyGrown
 
@@ -59,6 +60,10 @@ class PatchManager(patch: Patch, player: Player): PatchVarbitUpdater(patch, play
 
     fun clear() {
         clearHandler.clear()
+    }
+
+    fun inspect() {
+        inspectHandler.inspect()
     }
 
     companion object : KLogging()

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/InspectHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/InspectHandler.kt
@@ -1,0 +1,40 @@
+package gg.rsmod.plugins.content.skills.farming.logic.handler
+
+import gg.rsmod.game.model.entity.Player
+import gg.rsmod.plugins.api.ext.*
+import gg.rsmod.plugins.content.skills.farming.constants.CompostState
+import gg.rsmod.plugins.content.skills.farming.data.Patch
+import gg.rsmod.plugins.content.skills.farming.logic.PatchState
+
+/**
+ * Logic related to inspecting a patch
+ */
+class InspectHandler(private val state: PatchState, private val patch: Patch, private val player: Player) {
+
+    fun inspect() {
+        val status = when {
+            state.isWeedy -> "The patch needs weeding."
+            state.isEmpty -> "The patch is empty and weeded."
+            state.isDiseased -> "The patch is diseased and needs attending to before it dies."
+            state.isDead -> "The patch has become infected by disease and has died."
+            state.isPlantFullyGrown -> "The patch is fully grown."
+            else -> "The patch has something growing in it."
+            // TODO: "The patch has the remains of a tree stump in it."
+        }
+        val soil = when (state.compostState) {
+            CompostState.None -> "The soil has not been treated."
+            CompostState.Compost -> "The soil has been treated with compost."
+            CompostState.SuperCompost -> "The soil has been treated with super compost."
+        }
+        player.queue {
+            player.message("This is ${patch.patchName.prefixAn()}.")
+            player.message(soil)
+            player.message(status)
+            if (state.isProtected) {
+                player.message("A nearby gardener is looking after this patch for you.")
+            }
+            // TODO: "A nearby scarecrow is giving protection for this patch."
+            // TODO: "A nearby flower is giving protection for this patch."
+        }
+    }
+}

--- a/game/src/main/kotlin/gg/rsmod/game/plugin/KotlinPlugin.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/plugin/KotlinPlugin.kt
@@ -301,6 +301,16 @@ abstract class KotlinPlugin(private val r: PluginRepository, val world: World, v
     }
 
     /**
+     * Invoke [logic] when an [item] is used on a [gg.rsmod.game.model.entity.GameObject]
+     *
+     * @param obj the game object id
+     * @param item the item id
+     */
+    fun on_any_item_on_obj(obj: Int, lineOfSightDistance: Int = -1, logic: (Plugin).() -> Unit) {
+        r.bindAnyItemOnObject(obj, lineOfSightDistance, logic)
+    }
+
+    /**
      * Invoke [plugin] when [item1] is used on [item2] or vise-versa.
      */
     fun on_item_on_item(item1: Int, item2: Int, plugin: Plugin.() -> Unit) = r.bindItemOnItem(item1, item2, plugin)


### PR DESCRIPTION
## What has been done?
- Introduces another plugin intializer: `on_any_item_on_obj`. This plugin triggers whever any item is used on the object. It is till possible to initialize using a specific item on that object: those plugins take precedence over the "general" plugin.
- Initializes all farming patches with the `on_any_item_on_obj` initializer
- Implements the `Inspect` option on farming patches
- In theory implements the `Guide` option on farming patches. This might require some deeper changes to really function though - it seems the server doesn't receive the request

## Has your code been documented?
Where needed