### PR TITLE
fix: ensure farming ticks don't occur during player queue

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/ChopHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/ChopHandler.kt
@@ -12,6 +12,8 @@ import gg.rsmod.plugins.content.skills.woodcutting.AxeType
  */
 class ChopHandler(private val state: PatchState, private val player: Player) {
 
+    private val farmingTimerDelayer = FarmingTimerDelayer(player)
+
     fun chopDown() {
         val axe = AxeType.values.reversed().firstOrNull {
             player.getSkills()
@@ -27,9 +29,14 @@ class ChopHandler(private val state: PatchState, private val player: Player) {
         if (state.canBeChopped && state.seed!!.seedType == SeedType.FruitTree) {
             player.queue {
                 player.animate(axe.animation)
-                wait(6)
+                farmingTimerDelayer.delayIfNeeded(chopWaitTime)
+                wait(chopWaitTime)
                 state.chopDown()
             }
         }
+    }
+
+    companion object {
+        private const val chopWaitTime = 6
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/ClearHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/ClearHandler.kt
@@ -13,6 +13,8 @@ import gg.rsmod.plugins.content.skills.farming.logic.PatchState
  */
 class ClearHandler(private val state: PatchState, private val player: Player) {
 
+    private val farmingTimerDelayer = FarmingTimerDelayer(player)
+
     private fun canClear() = (state.isDead || (state.isProducing && state.livesLeft == 0 && state.seed!!.harvest.choppedDownVarbit == null) || state.isChoppedDown) && player.inventory.contains(Items.SPADE)
 
     fun clear() {
@@ -20,7 +22,8 @@ class ClearHandler(private val state: PatchState, private val player: Player) {
             player.lockingQueue {
                 player.animate(animation)
                 player.playSound(sound)
-                wait(3)
+                farmingTimerDelayer.delayIfNeeded(clearWaitTime)
+                wait(clearWaitTime)
                 state.clear()
                 player.filterableMessage("You have successfully cleared this patch for new crops.")
             }
@@ -30,5 +33,6 @@ class ClearHandler(private val state: PatchState, private val player: Player) {
     companion object {
         private const val animation = 830
         private const val sound = 1470
+        private const val clearWaitTime = 3
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/CompostHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/CompostHandler.kt
@@ -14,6 +14,9 @@ import gg.rsmod.plugins.content.skills.farming.logic.PatchState
  * Logic related to composting an empty patch
  */
 class CompostHandler(private val state: PatchState, private val patch: Patch, private val player: Player) {
+
+    private val farmingTimerDelayer = FarmingTimerDelayer(player)
+
     fun addCompost(compost: CompostState) {
         when {
             compost == CompostState.None -> Unit
@@ -25,7 +28,8 @@ class CompostHandler(private val state: PatchState, private val patch: Patch, pr
                 player.lockingQueue {
                     player.animate(animation)
                     player.playSound(sound)
-                    wait(3)
+                    farmingTimerDelayer.delayIfNeeded(compostWaitTime)
+                    wait(compostWaitTime)
                     val slot = player.inventory.getItemIndex(compost.itemId, false)
                     if (player.inventory.remove(compost.itemId, beginSlot = slot).hasSucceeded()) {
                         player.inventory.add(compost.replacement, beginSlot = slot)
@@ -41,5 +45,6 @@ class CompostHandler(private val state: PatchState, private val patch: Patch, pr
     companion object {
         private const val animation = 2283
         private const val sound = 2427
+        private const val compostWaitTime = 3
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/CureHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/CureHandler.kt
@@ -12,12 +12,16 @@ import gg.rsmod.plugins.content.skills.farming.logic.PatchState
  * Logic related to curing a patch that is diseased
  */
 class CureHandler(private val state: PatchState, private val player: Player) {
+
+    private val farmingTimerDelayer = FarmingTimerDelayer(player)
+
     fun cure(cureType: CureType) {
         if (canCure(cureType)) {
             player.lockingQueue {
                 player.animate(cureType.animation)
                 player.playSound(cureType.sound)
-                wait(3)
+                farmingTimerDelayer.delayIfNeeded(cureWaitTime)
+                wait(cureWaitTime)
                 if (canCure(cureType)) {
                     state.cure()
                     val slot = player.inventory.getItemIndex(Items.PLANT_CURE, false)
@@ -51,5 +55,9 @@ class CureHandler(private val state: PatchState, private val player: Player) {
         }
 
         return true
+    }
+
+    companion object {
+        private const val cureWaitTime = 3
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/FarmingTimerDelayer.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/FarmingTimerDelayer.kt
@@ -1,0 +1,13 @@
+package gg.rsmod.plugins.content.skills.farming.logic.handler
+
+import gg.rsmod.game.model.entity.Player
+import gg.rsmod.plugins.content.skills.farming.constants.Constants
+
+class FarmingTimerDelayer(private val player: Player) {
+    fun delayIfNeeded(waitTime: Int) {
+        val leftOnTimer = player.timers[Constants.playerFarmingTimer]
+        if (leftOnTimer <= waitTime) {
+            player.timers[Constants.playerFarmingTimer] = waitTime + 1
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/HarvestingHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/HarvestingHandler.kt
@@ -18,6 +18,9 @@ import kotlin.math.ceil
  * Logic related to harvesting a patch that is fully grown
  */
 class HarvestingHandler(private val state: PatchState, private val patch: Patch, private val player: Player) {
+
+    private val farmingTimerDelayer = FarmingTimerDelayer(player)
+
     fun harvest() {
         if (!canHarvest()) {
             return
@@ -27,7 +30,8 @@ class HarvestingHandler(private val state: PatchState, private val patch: Patch,
             player.filterableMessage("You begin to harvest the ${state.seed!!.seedName.replace("sapling", "tree")}.")
             while (state.livesLeft > 0 && canHarvest()) {
                 player.animate(state.seed!!.seedType.harvest.harvestAnimation)
-                wait(2)
+                farmingTimerDelayer.delayIfNeeded(harvestWaitTime)
+                wait(harvestWaitTime)
                 if (canHarvest()) {
                     player.addXp(Skills.FARMING, state.seed!!.harvest.harvestXp)
                     if (state.seed!! == Seed.Limpwurt) {
@@ -83,5 +87,7 @@ class HarvestingHandler(private val state: PatchState, private val patch: Patch,
         return !player.world.chance(slots, 256)
     }
 
-    companion object : KLogging()
+    companion object : KLogging() {
+        private const val harvestWaitTime = 2
+    }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/HealthCheckHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/HealthCheckHandler.kt
@@ -11,14 +11,22 @@ import gg.rsmod.plugins.content.skills.farming.logic.PatchState
  * Logic related to curing a patch that is diseased
  */
 class HealthCheckHandler(private val state: PatchState, private val patch: Patch, private val player: Player) {
+
+    private val farmingTimerDelayer = FarmingTimerDelayer(player)
+
     fun checkHealth() {
         if (state.healthCanBeChecked) {
             player.lockingQueue {
-                wait(2)
+                farmingTimerDelayer.delayIfNeeded(healthCheckWaitTime)
+                wait(healthCheckWaitTime)
                 player.addXp(Skills.FARMING, state.seed!!.harvest.healthCheckXp!!)
                 player.filterableMessage("You examine the ${patch.patchName.removeSuffix(" patch")} for signs of disease and find that it's in perfect health.")
                 state.checkHealth()
             }
         }
+    }
+
+    companion object {
+        private const val healthCheckWaitTime = 2
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/PlantingHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/PlantingHandler.kt
@@ -11,6 +11,9 @@ import gg.rsmod.plugins.content.skills.farming.logic.PatchState
  * Logic related to planting a seed in an empty patch
  */
 class PlantingHandler(private val state: PatchState, private val patch: Patch, private val player: Player) {
+
+    private val farmingTimerDelayer = FarmingTimerDelayer(player)
+
     fun plant(seed: Seed) {
         player.lockingQueue {
             if (!canPlant(seed)) {
@@ -21,6 +24,7 @@ class PlantingHandler(private val state: PatchState, private val patch: Patch, p
                 seed.seedType.plant.plantingTool.replacementId?.let(player.inventory::add)
                 player.animate(seed.seedType.plant.plantingTool.animation)
                 player.playSound(seed.seedType.plant.plantingTool.plantingSound)
+                farmingTimerDelayer.delayIfNeeded(plantingWaitTime)
                 wait(plantingWaitTime)
                 player.addXp(Skills.FARMING, seed.plant.plantXp)
                 player.filterableMessage(seed.seedType.plant.plantingTool.plantedMessage(seed, patch))

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/RakeHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/RakeHandler.kt
@@ -15,6 +15,8 @@ import gg.rsmod.plugins.content.skills.farming.logic.PatchState
  */
 class RakeHandler(private val state: PatchState, private val patch: Patch, private val player: Player) {
 
+    private val farmingTimerDelayer = FarmingTimerDelayer(player)
+
     private fun canGrowWeeds() = state.seed == null && !state.isWeedsFullyGrown
 
     fun growWeeds() {
@@ -28,6 +30,7 @@ class RakeHandler(private val state: PatchState, private val patch: Patch, priva
             while (canRake) {
                 player.animate(rakingAnimation)
                 player.playSound(rakingSound)
+                farmingTimerDelayer.delayIfNeeded(rakingWaitTime)
                 wait(rakingWaitTime)
 
                 // Another check whether raking is possible - something might have changed in the past few ticks

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/WaterHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/WaterHandler.kt
@@ -11,12 +11,16 @@ import gg.rsmod.plugins.content.skills.farming.logic.PatchState
  * Logic related to watering a patch that is still growing
  */
 class WaterHandler(private val state: PatchState, private val patch: Patch, private val player: Player) {
+
+    private val farmingTimerDelayer = FarmingTimerDelayer(player)
+
     fun water(wateringCan: Int) {
         if (canWater(wateringCan)) {
             player.lockingQueue {
                 player.animate(animation)
                 player.playSound(sound)
-                wait(4)
+                farmingTimerDelayer.delayIfNeeded(waterWaitTime)
+                wait(waterWaitTime)
                 if (canWater(wateringCan)) {
                     state.water()
                     val slot = player.inventory.getItemIndex(wateringCan, false)
@@ -68,6 +72,7 @@ class WaterHandler(private val state: PatchState, private val patch: Patch, priv
     companion object {
         private const val animation = 2293
         private const val sound = 2446
+        private const val waterWaitTime = 4
 
         private const val emptyWateringCan = Items.WATERING_CAN
         val wateringCans = listOf(


### PR DESCRIPTION
## What has been done?
Slightly delay the player farming timer if it would reach zero during a player farming action

## Has your code been documented?
No, only small adjustments