### PR TITLE
Some definitions & some slayer additions

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/humanoids/pirate_level_23.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/humanoids/pirate_level_23.plugin.kts
@@ -1,0 +1,76 @@
+package gg.rsmod.plugins.content.npcs.definitions.humanoids
+
+import gg.rsmod.plugins.content.drops.DropTableFactory
+import gg.rsmod.plugins.content.drops.global.Gems
+
+val ids = intArrayOf(Npcs.PIRATE, Npcs.PIRATE_183, Npcs.PIRATE_184)
+
+val table = DropTableFactory
+val pirate = table.build {
+    guaranteed {
+        obj(Items.BONES)
+    }
+
+    main {
+        total(1024)
+        obj(Items.IRON_DAGGER, slots = 48)
+        obj(Items.BRONZE_SCIMITAR, slots = 32)
+        obj(Items.IRON_PLATEBODY, slots = 8)
+
+        obj(Items.IRON_BOLTS, quantityRange = 2..12, slots = 80)
+        obj(Items.CHAOS_RUNE, quantity = 2, slots = 48)
+        obj(Items.NATURE_RUNE, quantity = 2, slots = 40)
+        obj(Items.BRONZE_ARROW, quantity = 9, slots = 24)
+        obj(Items.BRONZE_ARROW, quantity = 12, slots = 16)
+        obj(Items.AIR_RUNE, quantity = 10, slots = 16)
+        obj(Items.EARTH_RUNE, quantity = 9, slots = 16)
+        obj(Items.FIRE_RUNE, quantity = 5, slots = 16)
+        obj(Items.LAW_RUNE, quantity = 2, slots = 8)
+
+        obj(Items.COINS_995, quantity = 4, slots = 232)
+        obj(Items.COINS_995, quantity = 25, slots = 104)
+        obj(Items.COINS_995, quantity = 7, slots = 64)
+        obj(Items.COINS_995, quantity = 12, slots = 48)
+        obj(Items.COINS_995, quantity = 35, slots = 32)
+        obj(Items.COINS_995, quantity = 55, slots = 8)
+
+        obj(Items.EYE_PATCH, slots = 96)
+        nothing(64)
+        obj(Items.CHEFS_HAT, slots = 8)
+        obj(Items.IRON_BAR, slots = 8)
+
+        table(Gems.gemTable, slots = 8)
+    }
+}
+
+table.register(pirate, *ids)
+
+on_npc_death(*ids) {
+    table.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
+ids.forEach {
+    set_combat_def(it) {
+        configs {
+            attackSpeed = 5
+            respawnDelay = 25
+        }
+        stats {
+            hitpoints = 200
+            attack = 21
+            strength = 21
+            defence = 21
+        }
+        bonuses {
+            attackBonus = 8
+            strengthBonus = 10
+            defenceStab = 3
+            defenceSlash = 2
+        }
+        anims {
+            attack = 428
+            block = 424
+            death = 836
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/other/ice_giant_level_53.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/other/ice_giant_level_53.plugin.kts
@@ -1,0 +1,100 @@
+package gg.rsmod.plugins.content.npcs.definitions.other
+
+import gg.rsmod.game.model.combat.SlayerAssignment
+import gg.rsmod.plugins.content.drops.DropTableFactory
+import gg.rsmod.plugins.content.drops.global.Gems
+import gg.rsmod.plugins.content.drops.global.Seeds
+
+val ids = intArrayOf(Npcs.ICE_GIANT, Npcs.ICE_GIANT_3072, Npcs.ICE_GIANT_4685, Npcs.ICE_GIANT_4686, Npcs.ICE_GIANT_4687)
+
+val table = DropTableFactory
+val ice_giant = table.build {
+    guaranteed {
+        obj(Items.BIG_BONES)
+    }
+
+    main {
+        total(1024)
+        obj(Items.IRON_2H_SWORD, slots = 40)
+        obj(Items.BLACK_KITESHIELD, slots = 32)
+        obj(Items.STEEL_HATCHET, slots = 32)
+        obj(Items.STEEL_SWORD, slots = 32)
+        obj(Items.IRON_PLATELEGS, slots = 8)
+        obj(Items.MITHRIL_MACE, slots = 8)
+        obj(Items.MITHRIL_SQ_SHIELD, slots = 8)
+
+        obj(Items.ADAMANT_ARROW, quantity = 5, slots = 48)
+        obj(Items.NATURE_RUNE, quantity = 6, slots = 32)
+        obj(Items.MIND_RUNE, quantity = 24, slots = 24)
+        obj(Items.BODY_RUNE, quantity = 37, slots = 24)
+        obj(Items.LAW_RUNE, quantity = 3, slots = 16)
+        obj(Items.WATER_RUNE, quantity = 12, slots = 8)
+        obj(Items.COSMIC_RUNE, quantity = 4, slots = 8)
+        obj(Items.DEATH_RUNE, quantity = 3, slots = 8)
+        obj(Items.BLOOD_RUNE, quantity = 2, slots = 8)
+
+        table(Seeds.uncommonSeedtable, slots = 64)
+
+        obj(Items.COINS_995, quantity = 117, slots = 224)
+        obj(Items.COINS_995, quantity = 53, slots = 76)
+        obj(Items.COINS_995, quantity = 196, slots = 72)
+        obj(Items.COINS_995, quantity = 5, slots = 64)
+        obj(Items.COINS_995, quantity = 8, slots = 54)
+        obj(Items.COINS_995, quantity = 2, slots = 48)
+        obj(Items.COINS_995, quantity = 400, slots = 16)
+
+        obj(Items.JUG_OF_WINE, slots = 24)
+        obj(Items.MITHRIL_ORE, slots = 8)
+        obj(Items.BANANA, slots = 8)
+
+        table(Gems.gemTable, slots = 32)
+    }
+
+    table("Tertiary") {
+        total(100_000)
+        obj(Items.LONG_BONE, slots = 250)
+        obj(Items.CURVED_BONE, slots = 20)
+        obj(Items.CHAMPIONS_SCROLL_6800, slots = 20)
+        nothing(99710)
+    }
+}
+
+table.register(ice_giant, *ids)
+
+on_npc_death(*ids) {
+    table.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
+ids.forEach {
+    set_combat_def(it) {
+        configs {
+            attackSpeed = 5
+            respawnDelay = 30
+        }
+        stats {
+            hitpoints = 700
+            attack = 40
+            strength = 40
+            defence = 40
+        }
+        bonuses {
+            attackBonus = 29
+            strengthBonus = 31
+            defenceSlash = 3
+            defenceCrush = 2
+        }
+        anims {
+            block = 4651
+            attack = 4652
+            death = 4653
+        }
+        aggro {
+            radius = 5
+        }
+        slayerData {
+            slayerAssignment = SlayerAssignment.ICE_GIANT
+            levelRequirement = 1
+            xp = 70.0
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/other/ice_warrior_level_57.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/other/ice_warrior_level_57.plugin.kts
@@ -1,0 +1,86 @@
+package gg.rsmod.plugins.content.npcs.definitions.other
+
+import gg.rsmod.game.model.combat.SlayerAssignment
+import gg.rsmod.plugins.content.drops.DropTableFactory
+import gg.rsmod.plugins.content.drops.global.Gems
+import gg.rsmod.plugins.content.drops.global.Herbs
+import gg.rsmod.plugins.content.drops.global.Seeds
+
+val ids = intArrayOf(Npcs.ICE_WARRIOR, Npcs.ICE_WARRIOR_145, Npcs.ICE_WARRIOR_3073)
+
+val table = DropTableFactory
+val ice_warrior = table.build {
+    main {
+        total(1024)
+        obj(Items.IRON_BATTLEAXE, slots = 24)
+        obj(Items.MITHRIL_MACE, slots = 8)
+
+        obj(Items.NATURE_RUNE, quantity = 4, slots = 80)
+        obj(Items.CHAOS_RUNE, quantity = 3, slots = 64)
+        obj(Items.LAW_RUNE, quantity = 2, slots = 56)
+        obj(Items.COSMIC_RUNE, quantity = 2, slots = 40)
+        obj(Items.MITHRIL_ARROW, quantity = 3, slots = 40)
+        obj(Items.ADAMANT_ARROW, quantity = 2, slots = 16)
+        obj(Items.DEATH_RUNE, quantity = 2, slots = 24)
+        obj(Items.BLOOD_RUNE, quantity = 2, slots = 8)
+
+        table(Herbs.minorHerbTable, slots = 75)
+
+        table(Seeds.uncommonSeedtable, slots = 125)
+
+        obj(Items.COINS_995, quantity = 15, slots = 224)
+        obj(Items.COINS_995, quantity = 5, slots = 104)
+        obj(Items.COINS_995, quantity = 10, slots = 62)
+
+        nothing(50)
+
+        table(Gems.gemTable, slots = 24)
+    }
+
+    table("Tertiary") {
+        total(128)
+        obj(Items.CLUE_SCROLL_MEDIUM, slots = 1)
+        nothing(127)
+    }
+}
+
+table.register(ice_warrior, *ids)
+
+on_npc_death(*ids) {
+    table.getDrop(world, npc.damageMap.getMostDamage()!! as Player, npc.id, npc.tile)
+}
+
+ids.forEach {
+    set_combat_def(it) {
+        configs {
+            attackSpeed = 4
+            respawnDelay = 30
+        }
+        stats {
+            hitpoints = 590
+            attack = 47
+            strength = 47
+            defence = 47
+        }
+        bonuses {
+            defenceStab = 30
+            defenceSlash = 40
+            defenceCrush = 20
+            defenceMagic = 10
+            defenceRanged = 30
+        }
+        anims {
+            attack = 391
+            block = 389
+            death = 843
+        }
+        aggro {
+            radius = 5
+        }
+        slayerData {
+            slayerAssignment = SlayerAssignment.ICE_WARRIOR
+            levelRequirement = 1
+            xp = 59.0
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
@@ -18,6 +18,7 @@ data class Assignment(val assignment: SlayerAssignment, val amount: IntRange = 0
 enum class SlayerMaster(val id: Int, val identifier: String, val defaultAmount: IntRange) {
     TURAEL(Npcs.TURAEL, "Turael", 15..50),
     VANNAKA(Npcs.VANNAKA, "Vannaka", 60..120),
+    MAZCHNA(Npcs.MAZCHNA, identifier = "Mazchna", 15 .. 70),
 }
 
 // TODO: Note, I only added data for monsters that we currently have definitions for.
@@ -47,7 +48,11 @@ val slayerData = SlayerData(
             Assignment(assignment = SlayerAssignment.ZOMBIE),
         ),
         SlayerMaster.VANNAKA to listOf(
-
+            Assignment(assignment = SlayerAssignment.ICE_WARRIOR),
+            Assignment(assignment = SlayerAssignment.ICE_GIANT)
         ),
+        SlayerMaster.MAZCHNA to listOf(
+            Assignment(assignment = SlayerAssignment.ICE_WARRIOR)
+        )
     )
 )

--- a/game/src/main/kotlin/gg/rsmod/game/model/combat/SlayerAssignment.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/combat/SlayerAssignment.kt
@@ -25,5 +25,7 @@ enum class SlayerAssignment(val identifier: String) {
     HELLHOUNDS("Hellhounds"),
     ZOMBIE("Zombies"),
     BAT("Bats"),
-    COW("Cows");
+    COW("Cows"),
+    ICE_WARRIOR("Ice Warriors"),
+    ICE_GIANT("Ice Giants");
 }


### PR DESCRIPTION
## What has been done?
- Ice Giant Level 53 Definitions and Drop Table.
- Ice Warrior Level 57 Definitions and Drop Table.
- Ice Warrior & Giants slayer categories.
- Add support for Mazchna Slayer master.
- Add Ice giants and warriors to their respective masters as slayer assignments.

## Has your code been documented?
No, most of it is data related.