### PR TITLE
fix: some farming fixes

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/data/Seed.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/data/Seed.kt
@@ -369,6 +369,7 @@ enum class Seed(
     fun isWatered(varbit: Int) = varbit in wateredVarbits
     fun isAtHealthCheck(varbit: Int) = varbit == harvest.healthCheckVarbit
     fun isProducing(varbit: Int) = varbit in produceBearingVarbits
+    fun produceAvailable(varbit: Int) = if (isProducing(varbit)) plant.baseLives - (produceBearingVarbits.last - varbit) else 0
     fun growthStage(varbit: Int): Int {
         return when {
             isAtHealthCheck(varbit) || isProducing(varbit) -> growth.growthStages

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/PatchState.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/PatchState.kt
@@ -24,7 +24,7 @@ class PatchState(private val patch: Patch, private val player: Player) {
     val compostState get() = CompostState.fromVarbit(compostVarbit.value)
     val isProtectedThroughPayment get() = protectedVarbit.value == 1
     val isWatered get() = seed?.isWatered(mainVarbit.value) ?: false
-    val livesLeft get() = livesVarbit.value
+    val livesLeft get() = if (isProducing) produceAvailable else livesVarbit.value
     val isWeedy get() = weeds > 0
     val isWeedsFullyGrown get() = weeds == maxWeeds
     val isEmpty get() = mainVarbit.value == emptyPatchVarbit
@@ -39,6 +39,7 @@ class PatchState(private val patch: Patch, private val player: Player) {
     val isProtected get() = isProtectedThroughPayment // TODO: flowers protecting allotments
     val healthCanBeChecked get() = seed?.let { it.harvest.healthCheckXp != null && it.isAtHealthCheck(mainVarbit.value) } ?: false
     val isProducing get() = seed?.isProducing(mainVarbit.value) ?: false
+    val produceAvailable get() = seed?.produceAvailable(mainVarbit.value) ?: 0
     val canBeChopped get() = isPlantFullyGrown && seed!!.harvest.choppedDownVarbit != null && livesLeft == 0
     val isChoppedDown get() = seed != null && seed!!.harvest.choppedDownVarbit == mainVarbit.value
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/CureHandler.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/logic/handler/CureHandler.kt
@@ -25,10 +25,11 @@ class CureHandler(private val state: PatchState, private val player: Player) {
                 if (canCure(cureType)) {
                     state.cure()
                     val slot = player.inventory.getItemIndex(Items.PLANT_CURE, false)
-                    if (player.inventory.remove(Items.PLANT_CURE, beginSlot = slot).hasSucceeded()) {
+                    if (cureType == CureType.Potion && player.inventory.remove(Items.PLANT_CURE, beginSlot = slot).hasSucceeded()) {
                         player.inventory.add(Items.VIAL, beginSlot = slot)
                     }
                 }
+                player.animate(-1)
             }
         }
     }

--- a/game/src/main/kotlin/gg/rsmod/game/plugin/PluginRepository.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/plugin/PluginRepository.kt
@@ -1205,8 +1205,7 @@ class PluginRepository(val world: World) {
     }
 
     fun executeItemOnObject(p: Player, obj: Int, item: Int): Boolean {
-        val plugins = itemOnObjectPlugins[item]
-        val logic = plugins[obj] ?: anyItemOnObjectPlugins[obj] ?: return false
+        val logic = itemOnObjectPlugins[item]?.get(obj) ?: anyItemOnObjectPlugins[obj] ?: return false
         p.executePlugin(logic)
         return true
     }

--- a/game/src/main/kotlin/gg/rsmod/game/plugin/PluginRepository.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/plugin/PluginRepository.kt
@@ -1205,8 +1205,8 @@ class PluginRepository(val world: World) {
     }
 
     fun executeItemOnObject(p: Player, obj: Int, item: Int): Boolean {
-        val plugins = itemOnObjectPlugins[item] ?: anyItemOnObjectPlugins
-        val logic = plugins[obj] ?: return false
+        val plugins = itemOnObjectPlugins[item]
+        val logic = plugins[obj] ?: anyItemOnObjectPlugins[obj] ?: return false
         p.executePlugin(logic)
         return true
     }


### PR DESCRIPTION
## What has been done?
- Don't use lives varbit for producing crops. Lives are contained in the main varbit for these crops and using the lives varbit as well can lead to bugs
- Don't use plant cures to fix a tree - this needs secateurs
- Fix to find the correct plugin when any item is used on an object, where that item can also be used on other objects. This fixes not being able to compost sweetcorn, for example

## Has your code been documented?
No