### PR TITLE
Wilderness

### DIFF
--- a/data/packets.yml
+++ b/data/packets.yml
@@ -1075,6 +1075,16 @@ in-packets:
         trans: ADD
         sign: UNSIGNED
 
+  - message: gg.rsmod.game.message.impl.OpPlayer2Message
+    type: FIXED
+    opcode: 53
+    length: 3
+    structure:
+      - name: unknown
+        type: BYTE
+      - name: index
+        type: SHORT
+
   - message: gg.rsmod.game.message.impl.OpPlayer3Message
     type: FIXED
     opcode: 77

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/InterfaceDestination.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/InterfaceDestination.kt
@@ -48,6 +48,8 @@ enum class InterfaceDestination(
 
     TAB_AREA(interfaceId = -1, fixedChildId = 199, resizeChildId = 87),
 
+    PVP_OVERLAY(interfaceId = -1, fixedChildId = 19, resizeChildId = 10, clickThrough = true),
+
 
 
     ;

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
@@ -591,8 +591,6 @@ fun Player.hasSkullIcon(icon: SkullIcon): Boolean = skullIcon == icon.id
 
 fun Player.isClientResizable(): Boolean = interfaces.displayMode == DisplayMode.RESIZABLE_NORMAL || interfaces.displayMode == DisplayMode.FULLSCREEN
 
-fun Player.inWilderness(): Boolean = false
-
 fun Player.sendWorldMapTile() {
     runClientScript(1749, tile.as30BitInteger)
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/TileExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/TileExt.kt
@@ -2,6 +2,7 @@ package gg.rsmod.plugins.api.ext
 
 import gg.rsmod.game.model.Tile
 import gg.rsmod.game.model.World
+import java.lang.Integer.min
 
 fun Tile.isMulti(world: World): Boolean {
     val region = regionId
@@ -9,9 +10,23 @@ fun Tile.isMulti(world: World): Boolean {
     return world.getMultiCombatChunks().contains(chunk) || world.getMultiCombatRegions().contains(region)
 }
 
+val wildernessRegionIds = arrayOf(
+    11831, 11832, 11833, 11834, 11835, 11836, 11837,
+    12087, 12088, 12089, 12090, 12091, 12092, 12093,
+    12343, 12344, 12345, 12346, 12347, 12348, 12349,
+    12599, 12600, 12601, 12602, 12603, 12604, 12605,
+    12855, 12856, 12857, 12858, 12859, 12860, 12861,
+    13111, 13112, 13113, 13114, 13115, 13116, 13117,
+    13367, 13368, 13369, 13370, 13371, 13372, 13373
+)
+
 fun Tile.getWildernessLevel(): Int {
+    if(!wildernessRegionIds.contains(regionId) || z <= 3524) {
+        return 0
+    }
+
     /** Note from Ally: taken directly from cs2 script 54 */
-    val undergroundLevel = (z - 9920) / 8 + 1;
-    val level = (z - 3520) / 8 + 1;
+    val undergroundLevel = ((z - 9920) / 8 + 1)
+    val level = ((z - 3520) / 8 + 1)
     return if(z > 6400) undergroundLevel else level
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/TileExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/TileExt.kt
@@ -10,10 +10,8 @@ fun Tile.isMulti(world: World): Boolean {
 }
 
 fun Tile.getWildernessLevel(): Int {
-    if (x !in 2941..3392 || z !in 3524..3968) {
-        return 0
-    }
-
-    val z = if (this.z > 6400) this.z - 6400 else this.z
-    return (((z - 3525) shr 3) + 1)
+    /** Note from Ally: taken directly from cs2 script 54 */
+    val undergroundLevel = (z - 9920) / 8 + 1;
+    val level = (z - 3520) / 8 + 1;
+    return if(z > 6400) undergroundLevel else level
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/wilderness/wilderness.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/wilderness/wilderness.plugin.kts
@@ -1,0 +1,24 @@
+package gg.rsmod.plugins.content.areas.wilderness
+
+val wildernessCheckTimer = TimerKey()
+
+val INTERFACE_ID = 381
+
+on_login {
+    player.timers[wildernessCheckTimer] = 5
+}
+
+on_timer(wildernessCheckTimer) {
+    checkWildernessLevel(player)
+    player.timers[wildernessCheckTimer] = 1
+}
+
+fun checkWildernessLevel(player: Player) {
+    if (player.tile.getWildernessLevel() > 0) {
+        player.openInterface(dest = InterfaceDestination.PVP_OVERLAY, interfaceId = INTERFACE_ID)
+        player.sendOption("Attack", 2)
+    } else {
+        player.closeInterface(dest = InterfaceDestination.PVP_OVERLAY)
+        player.removeOption(2)
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/wilderness/wilderness.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/wilderness/wilderness.plugin.kts
@@ -5,7 +5,7 @@ val wildernessCheckTimer = TimerKey()
 val INTERFACE_ID = 381
 
 on_login {
-    player.timers[wildernessCheckTimer] = 5
+    player.timers[wildernessCheckTimer] = 1
 }
 
 on_timer(wildernessCheckTimer) {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/Combat.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/Combat.kt
@@ -210,13 +210,12 @@ object Combat {
                 }
 
                 if (!inPvpArea(target)) {
-                    pawn.message("You can't attack ${target.username} there.")
                     return false
                 }
 
                 val combatLvlRange = getValidCombatLvlRange(pawn)
                 if (target.combatLevel !in combatLvlRange) {
-                    pawn.message("You can't attack ${target.username} - your level different is too great.")
+                    pawn.message("The level difference between you and your opponent is too great.")
                     return false
                 }
             }
@@ -224,7 +223,7 @@ object Combat {
         return true
     }
 
-    private fun inPvpArea(player: Player): Boolean = player.inWilderness()
+    private fun inPvpArea(player: Player): Boolean = player.tile.getWildernessLevel() > 0
 
     private fun getValidCombatLvlRange(player: Player): IntRange {
         val wildLvl = player.tile.getWildernessLevel()

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/jewellery/amulet_of_glory.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/jewellery/amulet_of_glory.plugin.kts
@@ -121,9 +121,9 @@ fun replacement(original: Int): Int {
  */
 fun message(original: Int): String {
     return when (original) {
-        Items.AMULET_OF_GLORY_4 or Items.AMULET_OF_GLORY_T4 -> "Your amulet of glory has three charges left."
-        Items.AMULET_OF_GLORY_3 or Items.AMULET_OF_GLORY_T3 -> "Your amulet of glory has two charges left."
-        Items.AMULET_OF_GLORY_2 or Items.AMULET_OF_GLORY_T2 -> "Your amulet of glory has one charge left."
+        Items.AMULET_OF_GLORY_4, Items.AMULET_OF_GLORY_T4 -> "Your amulet of glory has three charges left."
+        Items.AMULET_OF_GLORY_3, Items.AMULET_OF_GLORY_T3 -> "Your amulet of glory has two charges left."
+        Items.AMULET_OF_GLORY_2, Items.AMULET_OF_GLORY_T2 -> "Your amulet of glory has one charge left."
         else -> "You use your amulet of glory's last charge."
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/watersource/fill_water.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/watersource/fill_water.plugin.kts
@@ -105,12 +105,14 @@ ids.forEach { obj ->
  * Handles the 'empty' option on water containers.
  */
 WaterContainerData.values.forEach { data ->
-    on_item_option(data.resultItem, "empty") {
-        val slot = player.getInteractingSlot()
-        if (player.inventory.remove(data.resultItem, assureFullRemoval = true, beginSlot = slot).hasSucceeded()) {
-            val name = player.world.definitions.get(ItemDef::class.java, data.resultItem).name.lowercase()
-            player.inventory.add(data.startItem, assureFullInsertion = true, beginSlot = slot)
-            player.filterableMessage("You empty the $name.")
+    if(world.definitions.get(ItemDef::class.java, data.resultItem).inventoryMenu.contains("empty")) {
+        on_item_option(data.resultItem, "empty") {
+            val slot = player.getInteractingSlot()
+            if (player.inventory.remove(data.resultItem, assureFullRemoval = true, beginSlot = slot).hasSucceeded()) {
+                val name = player.world.definitions.get(ItemDef::class.java, data.resultItem).name.lowercase()
+                player.inventory.add(data.startItem, assureFullInsertion = true, beginSlot = slot)
+                player.filterableMessage("You empty the $name.")
+            }
         }
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/message/MessageDecoderSet.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/MessageDecoderSet.kt
@@ -58,6 +58,7 @@ class MessageDecoderSet {
         put(OpLocUMessage::class.java, OpLocUDecoder(), OpLocUHandler(), structures)
         put(OpNpcTMessage::class.java, OpNpcTDecoder(), OpNpcTHandler(), structures)
 
+        put(OpPlayer2Message::class.java, OpPlayer2Decoder(), OpPlayer2Handler(), structures)
         put(OpPlayer3Message::class.java, OpPlayer3Decoder(), OpPlayer3Handler(), structures)
         put(OpPlayer4Message::class.java, OpPlayer4Decoder(), OpPlayer4Handler(), structures)
         put(OpPlayerTMessage::class.java, OpPlayerTDecoder(), OpPlayerTHandler(), structures)

--- a/game/src/main/kotlin/gg/rsmod/game/message/handler/OpPlayer2Handler.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/handler/OpPlayer2Handler.kt
@@ -38,6 +38,6 @@ class OpPlayer2Handler : MessageHandler<OpPlayer2Message> {
 
         client.attr[INTERACTING_PLAYER_ATTR] = WeakReference(other)
         client.attr[INTERACTING_OPT_ATTR] = option
-        client.executePlugin(PawnPathAction.walkPlugin)
+        client.attack(other)
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/model/interf/InterfaceSet.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/interf/InterfaceSet.kt
@@ -123,7 +123,6 @@ class InterfaceSet(private val listener: InterfaceListener) {
             listener.onInterfaceClose(found)
             return found
         }
-        logger.warn("No interface visible in pane ({}, {}).", hash shr 16, hash and 0xFFFF)
         return -1
     }
 


### PR DESCRIPTION
## What has been done?
- Added OpPlayer2 packet ("Attack")
- Added Wilderness plugin, which checks current wilderness level and updates Attack option/overlay
- Changed the message when trying to attack someone who is higher/lower level than your current wilderness level
- Fixed an issue with `Empty` option not available on Watering Can(8)
- Used the formula taken directly from CS2 Script (54) for the Wilderness level check
- Added region checks for wilderness
- Fixed amulet of glory degradation message

## Has your code been documented?
- No