### PR TITLE
feat: added drill demon random event

### DIFF
--- a/data/cfg/gates/gates.json
+++ b/data/cfg/gates/gates.json
@@ -11,6 +11,16 @@
 },
   {
     "opened": {
+      "hinge": 7051,
+      "extension": 7052
+    },
+    "closed": {
+      "hinge": 7049,
+      "extension": 7050
+    }
+},
+  {
+    "opened": {
       "hinge": 45211,
       "extension": 45213
     },

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/cfg/Objs.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/cfg/Objs.kt
@@ -6030,6 +6030,10 @@ object Objs {
     const val FLAGPOLE_10057 = 10057
     const val OBSTACLE_NET_10062 = 10062
     const val OBSTACLE_PIPE_10063 = 10063
+    const val SITUP_SIGN = 10072
+    const val PUSHUP_SIGN = 10073
+    const val STARJUMP_SIGN = 10074
+    const val RUNNINGMAN_SIGN = 10075
     const val EXERCISE_MAT = 10076
     const val EXERCISE_MAT_10077 = 10077
     const val EXERCISE_MAT_10078 = 10078

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_12107.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_12107.plugin.kts
@@ -7,7 +7,7 @@ spawn_npc(npc = Npcs.ABYSSAL_LEECH, x = 3022, z = 4815, walkRadius = 5, directio
 spawn_npc(npc = Npcs.ABYSSAL_LEECH, x = 3019, z = 4819, walkRadius = 5, direction = Direction.NORTH)
 spawn_npc(npc = Npcs.ABYSSAL_LEECH, x = 3016, z = 4819, walkRadius = 5, direction = Direction.NORTH)
 spawn_npc(npc = Npcs.ABYSSAL_LEECH, x = 3017, z = 4827, walkRadius = 5, direction = Direction.NORTH)
-spawn_npc(npc = Npcs.ABYSSAL_LEECH, x = 3017, z = 3829, walkRadius = 5, direction = Direction.NORTH)
+spawn_npc(npc = Npcs.ABYSSAL_LEECH, x = 3017, z = 4829, walkRadius = 5, direction = Direction.NORTH)
 spawn_npc(npc = Npcs.ABYSSAL_LEECH, x = 3014, z = 4829, walkRadius = 5, direction = Direction.NORTH)
 spawn_npc(npc = Npcs.ABYSSAL_LEECH, x = 3017, z = 4838, walkRadius = 5, direction = Direction.NORTH)
 spawn_npc(npc = Npcs.ABYSSAL_LEECH, x = 3014, z = 4838, walkRadius = 5, direction = Direction.NORTH)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_12619.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_12619.plugin.kts
@@ -1,0 +1,8 @@
+package gg.rsmod.plugins.content.areas.spawns
+
+spawn_obj(obj = Objs.SITUP_SIGN, x = 3160, z = 4821, height = 0, type = 10, rot = 0)
+spawn_obj(obj = Objs.PUSHUP_SIGN, x = 3162, z = 4821, height = 0, type = 10, rot = 0)
+spawn_obj(obj = Objs.STARJUMP_SIGN, x = 3164, z = 4821, height = 0, type = 10, rot = 0)
+spawn_obj(obj = Objs.RUNNINGMAN_SIGN, x = 3166, z = 4821, height = 0, type = 10, rot = 0)
+
+spawn_npc(npc = Npcs.SERGEANT_DAMIEN, x = 3163, z = 4822, direction = Direction.SOUTH)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/wilderness/dark_mage.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/wilderness/dark_mage.plugin.kts
@@ -1,7 +1,5 @@
 package gg.rsmod.plugins.content.areas.wilderness
 
-import gg.rsmod.plugins.content.skills.runecrafting.*
-
 val darkMage = Npcs.DARK_MAGE_2262
 
 on_npc_option(darkMage, option = "talk-to") {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -25,6 +25,12 @@ on_command("farm_tick", Privilege.ADMIN_POWER) {
     player.farmingManager().onFarmingTick(FarmTicker.SeedTypesForTick(SeedType.values().toSet(), SeedType.values().toSet()))
 }
 
+on_command("toggle_drill_demon", Privilege.ADMIN_POWER) {
+    player.attr[DRILL_DEMON_ACTIVE] = !(player.attr[DRILL_DEMON_ACTIVE] ?: false)
+    player.message("The Drill Demon random event has been toggled.")
+}
+
+
 on_command("pnpc", Privilege.ADMIN_POWER) {
     val args = player.getCommandArgs()
     tryWithUsage(player, args, "Invalid format! Example of proper command <col=42C66C>::pnpc 1</col>") { values ->

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/Combat.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/Combat.kt
@@ -155,14 +155,14 @@ object Combat {
         }
 
         // handle multi-way combat
-
-        if(!pawn.tile.isMulti(pawn.world)) {
-            if (target.isAttacking() && target.getCombatTarget() != pawn) {
-                if (pawn is Player) {
-                    pawn.message("Someone is already fighting this.")
-                }
-                return false
+        if (target.isAttacking() && target.getCombatTarget() != pawn) {
+            if (!target.isBeingAttacked()) {
+                return true
             }
+            if (pawn is Player) {
+                pawn.message("Someone is already fighting this.")
+            }
+            return false
         }
 
         val maxDistance = when {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/random_box.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/random_box.plugin.kts
@@ -1,0 +1,70 @@
+package gg.rsmod.plugins.content.items
+
+import gg.rsmod.plugins.content.drops.DropTableFactory
+import gg.rsmod.plugins.content.drops.DropTableType
+import gg.rsmod.plugins.content.drops.global.Rare
+import gg.rsmod.util.Misc
+
+/**
+ * @author Alycia <https://github.com/alycii>
+ */
+
+on_item_option(item = Items.RANDOM_EVENT_GIFT, option = "open") {
+    if(player.inventory.remove(player.getInteractingItem(), beginSlot = player.getInteractingItemSlot()).hasSucceeded()) {
+        val drop = DropTableFactory.createDropInventory(player, Items.RANDOM_EVENT_GIFT, DropTableType.STALL) ?: return@on_item_option
+        val item = drop[0]
+        val def = world.definitions.get(ItemDef::class.java, item.id)
+        val extraString = when(def.cost * item.amount) {
+            in 0..100 -> "Better luck next time!"
+            in 101..500 -> "Well, it could have been worse."
+            else -> "Excellent!"
+        }
+        player.message("Inside the box you find ${Misc.formatWithIndefiniteArticle(def.name.lowercase(), item.amount)}! $extraString")
+    }
+}
+
+val randomBox = DropTableFactory.build {
+    main {
+        total(13)
+        obj(Items.CABBAGE, slots = 1)
+        obj(Items.DIAMOND, slots = 1)
+        obj(Items.BUCKET, slots = 1)
+        obj(Items.COINS_995, quantity = 500, slots = 1)
+        obj(Items.FLIER, slots = 1)
+        obj(Items.OLD_BOOT, slots = 1)
+        obj(Items.BODY_RUNE, slots = 1)
+        obj(Items.ONION, slots = 1)
+        obj(Items.MITHRIL_SCIMITAR, slots = 1)
+        obj(Items.CASKET, slots = 1)
+        obj(Items.STEEL_PLATEBODY, slots = 1)
+        obj(Items.NATURE_RUNE, quantity = 20, slots = 1)
+        table(Rare.rareTable, slots = 1)
+    }
+    table("Camo") {
+        total(3)
+        nothing(0)
+
+        // Check if the player has all camo items
+        val hasAllCamoItems = player.hasItem(Items.CAMO_TOP) && player.hasItem(Items.CAMO_BOTTOMS) && player.hasItem(Items.CAMO_HELMET)
+
+        if (!player.hasItem(Items.CAMO_TOP) && !hasAllCamoItems) {
+            obj(Items.CAMO_TOP, slots = 1)
+        } else {
+            obj(Items.COINS, quantity = 500, slots = 1)
+        }
+
+        if (!player.hasItem(Items.CAMO_BOTTOMS) && !hasAllCamoItems) {
+            obj(Items.CAMO_BOTTOMS, slots = 1)
+        } else {
+            obj(Items.COINS, quantity = 500, slots = 1)
+        }
+
+        if (!player.hasItem(Items.CAMO_HELMET) && !hasAllCamoItems) {
+            obj(Items.CAMO_HELMET, slots = 1)
+        } else {
+            obj(Items.COINS, quantity = 500, slots = 1)
+        }
+    }
+}
+
+DropTableFactory.register(randomBox, Items.RANDOM_EVENT_GIFT, type = DropTableType.STALL)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/magic/PawnExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/magic/PawnExt.kt
@@ -12,6 +12,7 @@ import gg.rsmod.plugins.api.ext.message
 fun Player.canTeleport(type: TeleportType): Boolean {
     val currWildLvl = tile.getWildernessLevel()
     val wildLvlRestriction = type.wildLvlRestriction
+    val randomEvent = tile.regionId
 
     if (!lock.canTeleport()) {
         return false
@@ -20,6 +21,11 @@ fun Player.canTeleport(type: TeleportType): Boolean {
     if (currWildLvl > wildLvlRestriction) {
         message("A mysterious force blocks your teleport spell!")
         message("You can't use this teleport after level $wildLvlRestriction wilderness.")
+        return false
+    }
+
+    if (randomEvent == 12619) {
+        message("You can't use this teleport here.")
         return false
     }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/gates/gates.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/gates/gates.plugin.kts
@@ -120,7 +120,7 @@ fun close_gate(p: Player, obj: GameObject, gates: GateSet) {
     val extensionObj = if (extension) obj else otherGate
 
     if (is_stuck(world, obj) || is_stuck(world, otherGate)) {
-        p.message("The door seems to be stuck.")
+        p.message("The gate seems to be stuck.")
         p.playSound(STUCK_DOOR_SFX)
         return
     }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/abyss.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/abyss.plugin.kts
@@ -422,7 +422,7 @@ on_obj_option(obj = Objs.SOUL_RIFT, option = "exit-through", lineOfSightDistance
     if (obj.isSpawned(world)) {
         player.faceTile(obj.tile)
         when (obj.tile.x) {
-            3050 -> player.moveTo(2841, 4829)
+            3050 -> player.message("A strange power blocks your entrance.")
         }
     }
 }
@@ -442,7 +442,7 @@ on_obj_option(obj = Objs.DEATH_RIFT, option = "exit-through", lineOfSightDistanc
     if (obj.isSpawned(world)) {
         player.faceTile(obj.tile)
         when (obj.tile.x) {
-            3051 -> player.moveTo(2208, 4830)
+            3050 -> player.moveTo(2208, 4830)
         }
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/drill_demon.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/drill_demon.plugin.kts
@@ -1,0 +1,256 @@
+package gg.rsmod.plugins.content.randoms
+
+import gg.rsmod.game.model.attr.*
+import gg.rsmod.plugins.content.combat.strategy.MagicCombatStrategy
+import kotlin.random.Random
+
+/**
+ * @author Harley <https://github.com/HarleyGilpin>
+ */
+
+val sergeantDamien = Npcs.SERGEANT_DAMIEN
+
+on_npc_option(sergeantDamien, option = "talk-to") {
+    player.queue {
+        if (player.tile.regionId == 12619) {
+            atTheDrillDemonTrainingArea(this)
+        } else {
+            if (player.attr[DRILL_DEMON_ACTIVE] == false || !player.attr.has(DRILL_DEMON_ACTIVE)) {
+                NotAllowedZone(this)
+            } else {
+                sergeantDamienDialogue(this)
+            }
+        }
+    }
+}
+
+suspend fun sergeantDamienDialogue(it: QueueTask) {
+    it.chatNpc("Private ${it.player.username}, atten-SHUN!",
+                        "You've been recommended for my corps.",
+                        "Do you think you can be the best?")
+    val option1 = it.options("Sir, yes sir!", "No thanks, I'm not interested.")
+    when (option1) {
+        1 -> sirYesSir(it)
+        2 -> notInterested(it)
+    }
+}
+
+suspend fun sirYesSir(it: QueueTask) {
+    var lastKnownPosition: Tile = it.player.tile
+    var teleportToDrillDemon = Tile(3163, 4821)
+    it.chatPlayer("Sir, yes sir!")
+    it.player.attr[LAST_KNOWN_POSITION] = lastKnownPosition
+    it.player.moveTo(teleportToDrillDemon)
+    it.wait(1)
+    it.player.graphic(86)
+    val npc = it.player.getInteractingNpc()
+    npc.queue {
+        world.remove(npc)
+        npc.graphic(86)
+    }
+}
+
+suspend fun notInterested(it: QueueTask) {
+    it.chatPlayer("No thanks, I'm not interested.")
+}
+
+suspend fun atTheDrillDemonTrainingArea(it: QueueTask) {
+    it.chatNpc("Move yourself, Private! Follow my orders and you",
+                        "may, just may, leave here in a fit state for my corps!")
+    it.player.attr[CORRECT_EXERCISE] = Random.nextInt(1, 5)
+    val exercise: Int? = it.player.attr[CORRECT_EXERCISE]
+    if (exercise != null) {
+        afterPerformingCorrectExerciseOrStartingEvent(it, exercise)
+    }
+}
+
+suspend fun useExerciseMatBeforeInstruction(it: QueueTask) {
+    it.chatNpc("I haven't given you the order yet, worm!", npc = sergeantDamien)
+    // Continue with the dialogue below.
+}
+
+suspend fun afterPerformingCorrectExerciseOrStartingEvent(it: QueueTask, exerciseType: Int) {
+    val dialogue = when (exerciseType) {
+        1 -> ("I want to see you on that mat doing star jumps, private!")
+        2 -> ("Drop and give me push ups on that mat, private!")
+        3 -> ("Get yourself over there and jog on that mat, private!")
+        4 -> ("Get on that mat and give me sit ups, private!")
+        else -> throw IllegalArgumentException("Invalid exercise: $exerciseType")
+    }
+    it.chatNpc(dialogue, npc = sergeantDamien)
+    val option1 = it.options("Okay.", "I want to leave.")
+    if (it.player.attr[EXERCISE_SCORE]!! > 4) {
+        it.chatNpc("Well I'll be, you actually did it, Private.",
+            "Now take this and get out of my sight.", npc = sergeantDamien)
+        it.player.inventory.add(Item(Items.RANDOM_EVENT_GIFT))
+        it.player.addLoyalty(world.random(1..30))
+        it.player.attr[DRILL_DEMON_ACTIVE] = false
+        it.player.attr[EXERCISE_SCORE] = 0
+        val lastKnownPosition: Tile? = it.player.attr[LAST_KNOWN_POSITION]
+        if (lastKnownPosition != null) {
+            it.player.moveTo(lastKnownPosition)
+        } else {
+            // Handle the case where the saved position is null, e.g., notify the player.
+            it.player.message("No saved position found.")
+        }
+    }
+    when (option1) {
+        1 -> it.chatPlayer("Okay.")
+        2 -> {
+            it.chatPlayer("I want to leave.")
+            it.chatNpc("Pathetic. Get out of here then.", npc = sergeantDamien)
+            val lastKnownPosition: Tile? = it.player.attr[LAST_KNOWN_POSITION]
+            if (lastKnownPosition != null) {
+                it.player.moveTo(lastKnownPosition)
+            } else {
+                // Handle the case where the saved position is null, e.g., notify the player.
+                it.player.message("No saved position found.")
+            }
+        }
+    }
+}
+
+suspend fun afterPerformingIncorrectExercise(it: QueueTask, exerciseType: Int) {
+    val dialogue = when (exerciseType) {
+        1 -> Pair("Wrong exercise, worm!",
+                  "Drop and give me push ups on that mat, private!")
+        2 -> Pair("Wrong exercise, worm!,",
+                  "I want to see you on that mat doing star jumps, private!")
+        3 -> Pair("Wrong exercise, worm!",
+                  "Get on that mat and give me sit ups, private!")
+        4 -> Pair("Wrong exercise, worm!",
+                  "Get yourself over there and jog on that mat, private!")
+        else -> throw IllegalArgumentException("Invalid exercise: $exerciseType")
+    }
+
+    it.chatNpc(dialogue.first, dialogue.second, npc = sergeantDamien)
+    val option1 = it.options("Okay.", "I want to leave.")
+    val lastKnownPosition = it.player.attr[LAST_KNOWN_POSITION]
+    when (option1) {
+        1 -> it.chatPlayer("Okay.")
+        2 -> {
+            it.chatPlayer("I want to leave.")
+            it.chatNpc("Pathetic. Get out of here then.", npc = sergeantDamien)
+            if (lastKnownPosition != null) {
+                it.player.moveTo(lastKnownPosition)
+            }
+        }
+    }
+}
+
+suspend fun NotAllowedZone(it: QueueTask) {
+    it.chatNpc("As you were, soldier.", npc = sergeantDamien)
+}
+
+fun getCorrectMatId(exerciseType: Int): Int {
+    return when (exerciseType) {
+        1 -> 10078 //Star jumps
+        2 -> 10077 //Push ups
+        3 -> 10079 //Running Man
+        4 -> 10076 //Situps
+        else -> throw IllegalArgumentException("Invalid exercise: $exerciseType")
+    }
+}
+
+fun interactWithMat(p: Player, obj: GameObject, correctMatId: Int, exerciseType: Int) {
+    val faceSouth = Tile(x = obj.tile.x, z = obj.tile.z - 1)
+    p.lockingQueue {
+        var ticks = 0
+        var isCorrectExercise = false
+        while (true) {
+            when (ticks) {
+                1 -> p.moveTo(obj.tile.x, 4820)
+                2 -> p.faceTile(faceSouth)
+                3 -> {
+                    when (exerciseType) {
+                        1 -> p.animate(2761) // Star jumps
+                        2 -> p.animate(2762) // Push ups
+                        3 -> p.animate(2763) // Sit ups
+                        4 -> p.animate(2764) // Running man
+                    }
+                }
+                4 -> {
+                    isCorrectExercise = p.getInteractingGameObj()?.id == correctMatId
+                    if (isCorrectExercise) {
+                        chatNpc("You perform the exercise correctly.", npc = sergeantDamien)
+                    } else {
+                        chatNpc("You perform the wrong exercise.", npc = sergeantDamien)
+                    }
+                }
+                5 -> {
+                    if (isCorrectExercise) {
+                        player.queue {
+                            player.attr[EXERCISE_SCORE] = (player.attr[EXERCISE_SCORE] ?: 0) + 1
+                            player.attr[CORRECT_EXERCISE] = Random.nextInt(1, 5)
+                            val exercise: Int? = player.attr[CORRECT_EXERCISE]
+                            if (exercise != null) {
+                                afterPerformingCorrectExerciseOrStartingEvent(this, exercise)
+                            }
+                        }
+                    } else {
+                        player.queue {
+                            player.attr[EXERCISE_SCORE] = 0
+                            val exercise: Int? = player.attr[CORRECT_EXERCISE]
+                            if (exercise != null) {
+                                afterPerformingIncorrectExercise(this, exercise)
+                            }
+                        }
+                    }
+                    p.unlock()
+                    break
+                }
+            }
+            ticks++
+            wait(1)
+        }
+    }
+}
+
+on_obj_option(obj = Objs.EXERCISE_MAT_10079, option = "use", lineOfSightDistance = 1) {
+    val obj = player.getInteractingGameObj()
+    if (obj.isSpawned(world)) {
+        player.queue {
+            val correctExercise: Int? = player.attr[CORRECT_EXERCISE]
+            if (correctExercise != null) {
+                interactWithMat(player, obj, correctMatId = getCorrectMatId(correctExercise), exerciseType = 4) // Running man
+            }
+        }
+    }
+}
+
+on_obj_option(obj = Objs.EXERCISE_MAT_10078, option = "use", lineOfSightDistance = 1) {
+    val obj = player.getInteractingGameObj()
+    if (obj.isSpawned(world)) {
+        player.queue {
+            val correctExercise: Int? = player.attr[CORRECT_EXERCISE]
+            if (correctExercise != null) {
+                interactWithMat(player, obj, correctMatId = getCorrectMatId(correctExercise), exerciseType = 1) // Star Jumps
+            }
+        }
+    }
+}
+
+on_obj_option(obj = Objs.EXERCISE_MAT_10077, option = "use", lineOfSightDistance = 1) {
+    val obj = player.getInteractingGameObj()
+    if (obj.isSpawned(world)) {
+        player.queue {
+            val correctExercise: Int? = player.attr[CORRECT_EXERCISE]
+            if (correctExercise != null) {
+                interactWithMat(player, obj, correctMatId = getCorrectMatId(correctExercise), exerciseType = 2) // Push ups
+            }
+        }
+    }
+}
+
+
+on_obj_option(obj = Objs.EXERCISE_MAT, option = "use", lineOfSightDistance = 1) {
+    val obj = player.getInteractingGameObj()
+    if (obj.isSpawned(world)) {
+        player.queue {
+            val correctExercise: Int? = player.attr[CORRECT_EXERCISE]
+            if (correctExercise != null) {
+                interactWithMat(player, obj, correctMatId = getCorrectMatId(correctExercise), exerciseType = 3) // Sit ups
+            }
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/drill_demon.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/drill_demon.plugin.kts
@@ -84,7 +84,7 @@ suspend fun afterPerformingCorrectExerciseOrStartingEvent(it: QueueTask, exercis
         it.player.addLoyalty(world.random(1..30))
         it.player.attr[DRILL_DEMON_ACTIVE] = false
         it.player.attr[EXERCISE_SCORE] = 0
-        it.player.attr[BOTTING_SCORE] = (it.player.attr[BOTTING_SCORE] ?: 0) - 1
+        it.player.attr[BOTTING_SCORE] = maxOf(0, (it.player.attr[BOTTING_SCORE] ?: 0) - 1)
         val lastKnownPosition: Tile? = it.player.attr[LAST_KNOWN_POSITION]
         val backupPosition = Tile(x = 3222, z = 3219, 0)
         if (lastKnownPosition != null) {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/drill_demon.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/drill_demon.plugin.kts
@@ -1,45 +1,45 @@
 package gg.rsmod.plugins.content.randoms
 
 import gg.rsmod.game.model.attr.*
-import gg.rsmod.plugins.content.combat.strategy.MagicCombatStrategy
 import kotlin.random.Random
 
 /**
  * @author Harley <https://github.com/HarleyGilpin>
+ *
+ *This plugin is for the Drill Demon random event, in which players are tested on their agility.
+ *
  */
 
 val sergeantDamien = Npcs.SERGEANT_DAMIEN
 
+// Handle the 'talk-to' option for Sergeant Damien
 on_npc_option(sergeantDamien, option = "talk-to") {
     player.queue {
+        // If the player is in the training area, start the Drill Demon event
         if (player.tile.regionId == 12619) {
             atTheDrillDemonTrainingArea(this)
         } else {
+            // If the player is not in the training area, check if they have already started the event
             if (player.attr[DRILL_DEMON_ACTIVE] == false || !player.attr.has(DRILL_DEMON_ACTIVE)) {
                 NotAllowedZone(this)
             } else {
+                // If the player has started the event, continue with the dialogue
                 sergeantDamienDialogue(this)
             }
         }
     }
 }
 
+// Handle the Drill Demon dialogue with Sergeant Damien
 suspend fun sergeantDamienDialogue(it: QueueTask) {
+    var lastKnownPosition: Tile = it.player.tile
+    var teleportToDrillDemon = Tile(3163, 4821)
     it.chatNpc("Private ${it.player.username}, atten-SHUN!",
                         "You've been recommended for my corps.",
                         "Do you think you can be the best?")
-    val option1 = it.options("Sir, yes sir!", "No thanks, I'm not interested.")
-    when (option1) {
-        1 -> sirYesSir(it)
-        2 -> notInterested(it)
-    }
-}
-
-suspend fun sirYesSir(it: QueueTask) {
-    var lastKnownPosition: Tile = it.player.tile
-    var teleportToDrillDemon = Tile(3163, 4821)
     it.chatPlayer("Sir, yes sir!")
     it.player.attr[LAST_KNOWN_POSITION] = lastKnownPosition
+    it.wait(1)
     it.player.moveTo(teleportToDrillDemon)
     it.wait(1)
     it.player.graphic(86)
@@ -48,10 +48,6 @@ suspend fun sirYesSir(it: QueueTask) {
         world.remove(npc)
         npc.graphic(86)
     }
-}
-
-suspend fun notInterested(it: QueueTask) {
-    it.chatPlayer("No thanks, I'm not interested.")
 }
 
 suspend fun atTheDrillDemonTrainingArea(it: QueueTask) {
@@ -88,22 +84,15 @@ suspend fun afterPerformingCorrectExerciseOrStartingEvent(it: QueueTask, exercis
         it.player.addLoyalty(world.random(1..30))
         it.player.attr[DRILL_DEMON_ACTIVE] = false
         it.player.attr[EXERCISE_SCORE] = 0
-        val lastKnownPositionMap: Map<String, Any>? = it.player.attr[LAST_KNOWN_POSITION] as? Map<String, Any>
+        val lastKnownPosition: Tile? = it.player.attr[LAST_KNOWN_POSITION]
         val backupPosition = Tile(x = 3222, z = 3219, 0)
-        if (lastKnownPositionMap != null) {
-            val x = lastKnownPositionMap?.get("x") as? Int
-            val y = lastKnownPositionMap?.get("y") as? Int
-            val height = lastKnownPositionMap?.get("height") as? Int
-
-            if (x != null && y != null && height != null) {
-                val lastKnownPosition = Tile(x, y, height)
+        if (lastKnownPosition != null) {
                 it.player.moveTo(lastKnownPosition)
             } else {
                 // Handle the case where the saved position is null, e.g., notify the player.
                 it.player.message("We couldn't locate your last known position. We'll teleport you to Lumbridge.")
                 it.player.moveTo(backupPosition)
             }
-        }
     }
 }
 
@@ -118,8 +107,7 @@ suspend fun afterPerformingIncorrectExercise(it: QueueTask) {
     it.chatNpc(dialogue.first, dialogue.second, npc = sergeantDamien)
 }
 
-
-
+//Handles the wrong player talking to the NPC.
 suspend fun NotAllowedZone(it: QueueTask) {
     it.chatNpc("As you were, soldier.", npc = sergeantDamien)
 }
@@ -134,15 +122,31 @@ fun getCorrectMatId(exerciseType: Int): Int {
     }
 }
 
+/**
+Handles the interaction between a player and an exercise mat object, executing the specified exercise type.
+Evaluates the player's performance and updates the exercise score accordingly.
+@param p The player interacting with the exercise mat.
+@param obj The exercise mat game object.
+@param correctMatId The ID of the correct exercise mat the player should be interacting with.
+@param exerciseType The type of exercise to be performed (1: Star jumps, 2: Push ups, 3: Sit ups, 4: Running man).
+ */
 fun interactWithMat(p: Player, obj: GameObject, correctMatId: Int, exerciseType: Int) {
     val faceSouth = Tile(x = obj.tile.x, z = obj.tile.z - 1)
+// Lock the player's actions during this interaction sequence
     p.lockingQueue {
         var ticks = 0
         var isCorrectExercise = false
+
+        // Loop through actions to be executed in sequence
         while (true) {
             when (ticks) {
+                // Move player to the exercise mat's position
                 1 -> p.moveTo(obj.tile.x, 4820)
+
+                // Face the player to the south
                 2 -> p.faceTile(faceSouth)
+
+                // Execute the animation corresponding to the exercise type
                 3 -> {
                     when (exerciseType) {
                         1 -> p.animate(2761) // Star jumps
@@ -151,6 +155,8 @@ fun interactWithMat(p: Player, obj: GameObject, correctMatId: Int, exerciseType:
                         4 -> p.animate(2764) // Running man
                     }
                 }
+
+                // Check if the player is performing the correct exercise
                 4 -> {
                     isCorrectExercise = p.getInteractingGameObj()?.id == correctMatId
                     if (isCorrectExercise) {
@@ -159,6 +165,8 @@ fun interactWithMat(p: Player, obj: GameObject, correctMatId: Int, exerciseType:
                         chatNpc("You perform the wrong exercise.", npc = sergeantDamien)
                     }
                 }
+
+                // Update player's score based on whether the exercise was performed correctly
                 5 -> {
                     if (isCorrectExercise) {
                         player.queue {
@@ -178,21 +186,30 @@ fun interactWithMat(p: Player, obj: GameObject, correctMatId: Int, exerciseType:
                             }
                         }
                     }
+                    // Unlock player's actions and exit the loop
                     p.unlock()
                     break
                 }
             }
+            // Increment the tick counter
             ticks++
+            // Wait for 1 tick before proceeding to the next action
             wait(1)
         }
     }
 }
 
+// Set up an event handler for the "use" option on the exercise mat object
 on_obj_option(obj = Objs.EXERCISE_MAT_10079, option = "use", lineOfSightDistance = 1) {
     val obj = player.getInteractingGameObj()
+    // Check if the exercise mat object is spawned in the game world
     if (obj.isSpawned(world)) {
+        // Queue the player's actions for the interaction
         player.queue {
+            // Get the correct exercise the player should perform
             val correctExercise: Int? = player.attr[CORRECT_EXERCISE]
+
+            // If there is a correct exercise, initiate the interaction with the exercise mat
             if (correctExercise != null) {
                 interactWithMat(player, obj, correctMatId = getCorrectMatId(correctExercise), exerciseType = 4) // Running man
             }
@@ -200,11 +217,16 @@ on_obj_option(obj = Objs.EXERCISE_MAT_10079, option = "use", lineOfSightDistance
     }
 }
 
+// Set up an event handler for the "use" option on the exercise mat object
 on_obj_option(obj = Objs.EXERCISE_MAT_10078, option = "use", lineOfSightDistance = 1) {
     val obj = player.getInteractingGameObj()
+    // Check if the exercise mat object is spawned in the game world
     if (obj.isSpawned(world)) {
+        // Queue the player's actions for the interaction
         player.queue {
+            // Get the correct exercise the player should perform
             val correctExercise: Int? = player.attr[CORRECT_EXERCISE]
+            // If there is a correct exercise, initiate the interaction with the exercise mat
             if (correctExercise != null) {
                 interactWithMat(player, obj, correctMatId = getCorrectMatId(correctExercise), exerciseType = 1) // Star Jumps
             }
@@ -212,10 +234,14 @@ on_obj_option(obj = Objs.EXERCISE_MAT_10078, option = "use", lineOfSightDistance
     }
 }
 
+// Set up an event handler for the "use" option on the exercise mat object
 on_obj_option(obj = Objs.EXERCISE_MAT_10077, option = "use", lineOfSightDistance = 1) {
     val obj = player.getInteractingGameObj()
+    // Check if the exercise mat object is spawned in the game world
     if (obj.isSpawned(world)) {
+        // Queue the player's actions for the interaction
         player.queue {
+            // Get the correct exercise the player should perform
             val correctExercise: Int? = player.attr[CORRECT_EXERCISE]
             if (correctExercise != null) {
                 interactWithMat(player, obj, correctMatId = getCorrectMatId(correctExercise), exerciseType = 2) // Push ups
@@ -224,11 +250,14 @@ on_obj_option(obj = Objs.EXERCISE_MAT_10077, option = "use", lineOfSightDistance
     }
 }
 
-
+// Set up an event handler for the "use" option on the exercise mat object
 on_obj_option(obj = Objs.EXERCISE_MAT, option = "use", lineOfSightDistance = 1) {
     val obj = player.getInteractingGameObj()
+    // Check if the exercise mat object is spawned in the game world
     if (obj.isSpawned(world)) {
+        // Queue the player's actions for the interaction
         player.queue {
+            // Get the correct exercise the player should perform
             val correctExercise: Int? = player.attr[CORRECT_EXERCISE]
             if (correctExercise != null) {
                 interactWithMat(player, obj, correctMatId = getCorrectMatId(correctExercise), exerciseType = 3) // Sit ups

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/drill_demon.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/drill_demon.plugin.kts
@@ -84,6 +84,7 @@ suspend fun afterPerformingCorrectExerciseOrStartingEvent(it: QueueTask, exercis
         it.player.addLoyalty(world.random(1..30))
         it.player.attr[DRILL_DEMON_ACTIVE] = false
         it.player.attr[EXERCISE_SCORE] = 0
+        it.player.attr[BOTTING_SCORE] = (it.player.attr[BOTTING_SCORE] ?: 0) - 1
         val lastKnownPosition: Tile? = it.player.attr[LAST_KNOWN_POSITION]
         val backupPosition = Tile(x = 3222, z = 3219, 0)
         if (lastKnownPosition != null) {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/random_event_handler.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/random_event_handler.plugin.kts
@@ -1,0 +1,99 @@
+import gg.rsmod.game.model.Direction
+import gg.rsmod.game.model.attr.DRILL_DEMON_ACTIVE
+import gg.rsmod.game.model.attr.NO_CLIP_ATTR
+import gg.rsmod.game.model.timer.TimerKey
+import kotlin.math.sqrt
+
+val DRILL_DEMON_TIMER = TimerKey(persistenceKey = "drill_demon", tickOffline = false, resetOnDeath = false, tickForward = false, removeOnZero = true)
+val SERGEANT_DAMEIN = Npcs.SERGEANT_DAMIEN
+val FORCE_CHAT_TIMER = TimerKey()
+val DELAY = 10..20
+val FOLLOW_TARGET_TIMER = TimerKey()
+val FOLLOW_TARGET_DELAY = 1..3
+
+
+val spawnRange = (1500..5400) //25 minutes to 90 minutes converted to seconds.
+
+on_login {
+    if (!player.timers.has(DRILL_DEMON_TIMER)) {
+        player.timers[DRILL_DEMON_TIMER] = world.random(spawnRange)
+    }
+}
+
+on_global_npc_spawn {
+    if (npc.id == SERGEANT_DAMEIN) {
+        npc.timers[FORCE_CHAT_TIMER] = world.random(DELAY)
+    }
+}
+
+on_timer(FORCE_CHAT_TIMER) {
+    if (world.random(1) == 0) {
+        npc.forceChat("Stop day-dreaming, Private!")
+        npc.timers[FORCE_CHAT_TIMER] = world.random(DELAY)
+    }
+}
+
+on_timer(DRILL_DEMON_TIMER) {
+    if (player.isLocked() || player.isDead() || player.attr[DRILL_DEMON_ACTIVE] == true || player.interfaces.currentModal != -1) {
+        player.timers[DRILL_DEMON_TIMER] = 10
+        return@on_timer
+    }
+    val npc_sergeant_damien = Npc(player, SERGEANT_DAMEIN, player.tile.step(direction = Direction.NORTH), world)
+    world.spawn(npc_sergeant_damien)
+    player.attr[DRILL_DEMON_ACTIVE] = true
+    npc_sergeant_damien.graphic(86)
+    npc_sergeant_damien.followRadius = 5 // Set the follow radius for Sergeant Damien
+    npc_sergeant_damien.facePawn(player)
+    followTargetPlayer(npc_sergeant_damien, player)
+    npc_sergeant_damien.timers[FOLLOW_TARGET_TIMER] = world.random(FOLLOW_TARGET_DELAY)
+    player.timers[DRILL_DEMON_TIMER] = world.random(spawnRange)
+}
+
+on_timer(FOLLOW_TARGET_TIMER) {
+    if (npc.id == SERGEANT_DAMEIN) {
+        val targetPlayer = getNearestPlayer(npc)
+        if (targetPlayer != null && targetPlayer.attr.has(DRILL_DEMON_ACTIVE)) {
+            followTargetPlayer(npc, targetPlayer)
+        }
+        npc.timers[FOLLOW_TARGET_TIMER] = world.random(FOLLOW_TARGET_DELAY)
+    }
+}
+
+fun followTargetPlayer(npc: Npc, targetPlayer: Player) {
+    val noClip = npc.attr[NO_CLIP_ATTR] ?: false
+    if (world.collision.chunks.get(targetPlayer.tile, createIfNeeded = false) != null) {
+        npc.walkMask = npc.def.walkMask
+        npc.facePawn(targetPlayer)
+        npc.walkTo(targetPlayer.tile, detectCollision = !noClip)
+    }
+}
+
+fun getNearestPlayer(npc: Npc): Player? {
+    val radius = npc.followRadius
+    var nearestPlayer: Player? = null
+    var minDistance = Int.MAX_VALUE
+
+    for (x in -radius..radius) {
+        for (z in -radius..radius) {
+            val tile = npc.tile.transform(x, z)
+            val chunk = world.chunks.get(tile, createIfNeeded = false) ?: continue
+
+            val players = chunk.getEntities<Player>(tile, EntityType.PLAYER, EntityType.CLIENT)
+            if (players.isEmpty()) {
+                continue
+            }
+
+            players.forEach { player ->
+                val distanceX = npc.tile.x - player.tile.x
+                val distanceZ = npc.tile.z - player.tile.z
+                val distance = sqrt((distanceX * distanceX + distanceZ * distanceZ).toDouble()).toInt()
+
+                if (distance < minDistance) {
+                    nearestPlayer = player
+                    minDistance = distance
+                }
+            }
+        }
+    }
+    return nearestPlayer
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/random_event_handler.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/random_event_handler.plugin.kts
@@ -4,19 +4,34 @@ import gg.rsmod.game.model.attr.NO_CLIP_ATTR
 import gg.rsmod.game.model.timer.TimerKey
 import kotlin.math.sqrt
 
+/**
+ * @author Harley <https://github.com/HarleyGilpin>
+ */
+
+// Define the timer key for the Drill Demon event
 val DRILL_DEMON_TIMER = TimerKey(persistenceKey = "drill_demon", tickOffline = false, resetOnDeath = false, tickForward = false, removeOnZero = true)
+
+// Define a reference to the Sergeant Damien NPC
 val SERGEANT_DAMEIN = Npcs.SERGEANT_DAMIEN
+
+// Define the timer key for force chat actions
 val FORCE_CHAT_TIMER = TimerKey()
+
+// Define a range for the delay (in ticks) before displaying yellow overhead NPC text
 val DELAY = 10..20
+
+// Define the timer key for following the target player
 val FOLLOW_TARGET_TIMER = TimerKey()
+
+// Define a range for the delay (in ticks) before Sergeant Damien starts following the target player
 val FOLLOW_TARGET_DELAY = 1..3
 
 
-val spawnRange = (1500..5400) //25 minutes to 90 minutes converted to seconds.
+val spawnTimer = (2252..8108) //25 minutes to 90 minutes converted to game ticks.
 
 on_login {
     if (!player.timers.has(DRILL_DEMON_TIMER)) {
-        player.timers[DRILL_DEMON_TIMER] = world.random(spawnRange)
+        player.timers[DRILL_DEMON_TIMER] = world.random(spawnTimer)
     }
 }
 
@@ -33,20 +48,38 @@ on_timer(FORCE_CHAT_TIMER) {
     }
 }
 
+// Set up a timer event for the Drill Demon event
 on_timer(DRILL_DEMON_TIMER) {
     if (player.isLocked() || player.isDead() || player.attr[DRILL_DEMON_ACTIVE] == true || player.interfaces.currentModal != -1) {
         player.timers[DRILL_DEMON_TIMER] = 10
         return@on_timer
     }
+    // Create and spawn the NPC Sergeant Damien one step north of the player
     val npc_sergeant_damien = Npc(player, SERGEANT_DAMEIN, player.tile.step(direction = Direction.NORTH), world)
+
+    //Spawn the drill sergeant
     world.spawn(npc_sergeant_damien)
+
+    // Mark the event as active for the player
     player.attr[DRILL_DEMON_ACTIVE] = true
+
+    // Apply a graphic effect to Sergeant Damien
     npc_sergeant_damien.graphic(86)
-    npc_sergeant_damien.followRadius = 5 // Set the follow radius for Sergeant Damien
+
+    // Set the follow radius for Sergeant Damien
+    npc_sergeant_damien.followRadius = 5
+
+    // Make Sergeant Damien face the player
     npc_sergeant_damien.facePawn(player)
+
+    // Make Sergeant Damien follow the target player
     followTargetPlayer(npc_sergeant_damien, player)
+
+    // Set a random delay before Sergeant Damien starts following the player
     npc_sergeant_damien.timers[FOLLOW_TARGET_TIMER] = world.random(FOLLOW_TARGET_DELAY)
-    player.timers[DRILL_DEMON_TIMER] = world.random(spawnRange)
+
+    // Set a random delay for the next event occurrence
+    player.timers[DRILL_DEMON_TIMER] = world.random(spawnTimer)
 }
 
 on_timer(FOLLOW_TARGET_TIMER) {
@@ -69,25 +102,37 @@ fun followTargetPlayer(npc: Npc, targetPlayer: Player) {
 }
 
 fun getNearestPlayer(npc: Npc): Player? {
+    // Get the follow radius for the NPC
     val radius = npc.followRadius
+// Initialize variables for tracking the nearest player and minimum distance
     var nearestPlayer: Player? = null
     var minDistance = Int.MAX_VALUE
 
+// Iterate through all tiles within the follow radius
     for (x in -radius..radius) {
         for (z in -radius..radius) {
+            // Calculate the tile position based on the current offsets (x, z) from the NPC's tile
             val tile = npc.tile.transform(x, z)
+
+            // Get the chunk corresponding to the current tile
             val chunk = world.chunks.get(tile, createIfNeeded = false) ?: continue
 
+            // Get all players in the current chunk and filter them by their position on the tile
             val players = chunk.getEntities<Player>(tile, EntityType.PLAYER, EntityType.CLIENT)
+
+            // If no players are present on the current tile, move on to the next tile
             if (players.isEmpty()) {
                 continue
             }
 
+            // Iterate through all players on the tile and calculate their distance to the NPC
             players.forEach { player ->
                 val distanceX = npc.tile.x - player.tile.x
                 val distanceZ = npc.tile.z - player.tile.z
+                // Calculate the Euclidean distance between the NPC and the player
                 val distance = sqrt((distanceX * distanceX + distanceZ * distanceZ).toDouble()).toInt()
 
+                // Update the nearest player and minimum distance if the current player is closer
                 if (distance < minDistance) {
                     nearestPlayer = player
                     minDistance = distance
@@ -95,5 +140,6 @@ fun getNearestPlayer(npc: Npc): Player? {
             }
         }
     }
+// Return the nearest player, or null if no players are found within the follow radius
     return nearestPlayer
 }

--- a/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
@@ -1,5 +1,6 @@
 package gg.rsmod.game.model.attr
 
+import gg.rsmod.game.model.Tile
 import gg.rsmod.game.model.container.ItemTransaction
 import gg.rsmod.game.model.entity.*
 import gg.rsmod.game.model.item.Item
@@ -344,6 +345,14 @@ val DISABLE_LEVER_WARNING = AttributeKey<Boolean>(persistenceKey = "disable_leve
  * Attribute for web fatigue
  */
 val WEB_FATIGUE = AttributeKey<Int>(persistenceKey = "web_fatigue")
+
+/**
+ * Attribute for Drill Demon random event
+ */
+val CORRECT_EXERCISE = AttributeKey<Int>(persistenceKey = "correct_exercise")
+val LAST_KNOWN_POSITION = AttributeKey<Tile>("last_known_position")
+val EXERCISE_SCORE = AttributeKey<Int>(persistenceKey = "exercise_score")
+val DRILL_DEMON_ACTIVE = AttributeKey<Boolean>(persistenceKey = "drill_demon_active")
 
 /**
  * Placeholder for attributes of type Long when saving and loading player data

--- a/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
@@ -355,6 +355,11 @@ val EXERCISE_SCORE = AttributeKey<Int>(persistenceKey = "exercise_score")
 val DRILL_DEMON_ACTIVE = AttributeKey<Boolean>(persistenceKey = "drill_demon_active")
 
 /**
+ * Anti-cheat
+ */
+val BOTTING_SCORE = AttributeKey<Int>(persistenceKey = "botting_score")
+
+/**
  * Placeholder for attributes of type Long when saving and loading player data
  */
 val LONG_ATTRIBUTES = AttributeKey<Map<String, Long>>(persistenceKey = "long_attributes")

--- a/game/src/main/kotlin/gg/rsmod/game/model/entity/Npc.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/entity/Npc.kt
@@ -56,6 +56,11 @@ class Npc private constructor(val id: Int, world: World, val spawnTile: Tile) : 
     var walkRadius = 0
 
     /**
+     * The radius from [spawnTile], in tiles, which the npc can randomly walk.
+     */
+    var followRadius = 0
+
+    /**
      * The current hitpoints the npc has.
      */
     private var hitpoints = 10

--- a/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
@@ -605,6 +605,21 @@ open class Player(world: World) : Pawn(world) {
         world.instanceAllocator.logout(this)
         world.plugins.executeLogout(this)
         world.unregister(this)
+        //Anti-cheat
+        if (this.attr[DRILL_DEMON_ACTIVE] == true) {
+            this.attr[DRILL_DEMON_ACTIVE] = false
+            this.attr[BOTTING_SCORE] = (this.attr[BOTTING_SCORE] ?: 0) + 1
+            if (this.tile.regionId == 12619) {
+                val lastKnownPosition: Tile? = this.attr[LAST_KNOWN_POSITION]
+                val backupPosition = Tile(x = 3222, z = 3219, 0)
+                if (lastKnownPosition != null) {
+                    this.moveTo(lastKnownPosition)
+                } else {
+                    // Handle the case where the saved position is null, e.g., notify the player.
+                    this.moveTo(backupPosition)
+                }
+            }
+        }
     }
 
     fun calculateWeight() {


### PR DESCRIPTION
## What has been done?
### Description

This pull request adds an anti-cheat mechanism for the Drill Demon random event in the game. The mechanism works by tracking successful completions of the event and penalizing players who log out or fail to complete the event before logout. The penalization is implemented by increasing a flag called BOTTING_SCORE attached to the player's account.

Successful completions of the event will decrease the BOTTING_SCORE towards zero. However, negative integers are not possible, so repeat offenders will still have a score greater than zero, making it easier to identify and take action against them.

The Drill Demon event is randomly triggered between 25 and 90 minutes, during which the demon follows the player around the map until they talk to him.
### Changes Made

  - [fix: added death altar to abyss runecrafting rift.](https://github.com/2011Scape/game/commit/8a10673ac011e3d949d293afa644ee500bc00170)
  - [chore: added gate for falador farming patch to gates.json](https://github.com/2011Scape/game/commit/c816eac38f9db295e5a8c62eebee1aa17557e15d)
  - [feat: added drill demon random event.](https://github.com/2011Scape/game/commit/5aab892bf2c1c52b336ae79a6e1ae45b3ca541bc)
  - [feat: added drill demon minigame spawns.](https://github.com/2011Scape/game/commit/939f25535bcebfabeb8a9c81c6f1e32d2257a7f1)
  - [bug: fixed issue that caused npcs to be unattackable if a player logged out.](https://github.com/2011Scape/game/pull/367/commits/38ab39936e0e656d2e426ac3252282b083b34c5f)

### Reason for Changes

The anti-cheat mechanism is necessary to prevent players from exploiting the game with bots for unfair gains. By tracking successful completions and penalizing players who log out or fail to complete the event, we can deter cheating and promote fair play. The changes also make it easier to identify and take action against repeat offenders.

## Has your code been documented?
Yes.