### PR TITLE
fix: use proper varbit for prayer points

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
@@ -14,6 +14,7 @@ import gg.rsmod.game.model.container.ContainerStackType
 import gg.rsmod.game.model.container.ItemContainer
 import gg.rsmod.game.model.entity.DynamicObject
 import gg.rsmod.game.model.entity.Player
+import gg.rsmod.game.model.entity.Player.Companion.PRAYER_VARBIT
 import gg.rsmod.game.model.interf.DisplayMode
 import gg.rsmod.game.model.item.Item
 import gg.rsmod.game.model.shop.PurchasePolicy
@@ -992,4 +993,19 @@ fun Player.refreshBonuses() {
             bonusName = StringBuilder(bonusName).append("%").toString()
         setComponentText(667, 31 + i, bonusName)//31 to 48 is bonuses
     }
+}
+
+fun Player.setPrayerPoints(points: Int) {
+    prayerPoints = points.toDouble()
+    setVarbit(PRAYER_VARBIT, prayerPoints.toInt())
+}
+
+fun Player.removePrayerPoints(points: Double) {
+    prayerPoints = (prayerPoints - points).coerceAtLeast(0.0)
+    setVarbit(PRAYER_VARBIT, prayerPoints.toInt())
+}
+
+fun Player.addPrayerPoints(points: Double) {
+    prayerPoints = (prayerPoints + points)
+    setVarbit(PRAYER_VARBIT, prayerPoints.toInt())
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/wilderness/mage_of_zamorak.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/wilderness/mage_of_zamorak.plugin.kts
@@ -77,7 +77,7 @@ fun teleportToAbyss(player: Player, dialogue: String = "Veniens! Sallakar! Rinne
         p.playSound(127)
         wait(MagicCombatStrategy.getHitDelay(npc.tile, p.tile) + 1)
         p.moveTo(targetTile)
-        p.getSkills().setCurrentLevel(Skills.PRAYER, 0)
+        p.setPrayerPoints(0)
     }
 }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/prayeraltar/prayer_altar.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/prayeraltar/prayer_altar.plugin.kts
@@ -29,9 +29,6 @@ ALTARS_PRAY.forEach { altar ->
     }
 }
 
-/**
- * TODO Handle prayer points and recharging
- */
 fun rechargePrayerPoints(player: Player) {
-    val maximumPoints = player.getSkills().getMaxLevel(Skills.PRAYER) * 10
+    player.setPrayerPoints(player.getSkills().getMaxLevel(Skills.PRAYER) * 10)
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/runetek5.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/runetek5.plugin.kts
@@ -4,8 +4,10 @@ import gg.rsmod.game.model.attr.DISPLAY_MODE_CHANGE_ATTR
 import gg.rsmod.game.model.attr.INTERACTING_ITEM_SLOT
 import gg.rsmod.game.model.attr.OTHER_ITEM_SLOT_ATTR
 import gg.rsmod.game.model.collision.ObjectType
+import gg.rsmod.game.model.entity.Player.Companion.PRAYER_VARBIT
 import gg.rsmod.game.model.interf.DisplayMode
 import gg.rsmod.game.model.timer.DAILY_TIMER
+import gg.rsmod.game.model.timer.PRAYER_INITIALIZATION_TIMER
 import gg.rsmod.game.model.timer.SAVE_TIMER
 import gg.rsmod.game.model.timer.TIME_ONLINE
 import gg.rsmod.game.service.serializer.PlayerSerializerService
@@ -82,6 +84,8 @@ on_login {
     if(!player.timers.exists(DAILY_TIMER)) {
         player.timers[DAILY_TIMER] = 1
     }
+
+    player.timers[PRAYER_INITIALIZATION_TIMER] = 1
 }
 
 /**
@@ -93,6 +97,13 @@ on_login {
 on_timer(key = SAVE_TIMER) {
     player.world.getService(PlayerSerializerService::class.java, searchSubclasses = true)?.saveClientData(player as Client)
     player.timers[SAVE_TIMER] = 200
+}
+
+/**
+ * Sets the prayer varbit to its own value again. This triggers a visual update in the client.
+ */
+on_timer(key = PRAYER_INITIALIZATION_TIMER) {
+    player.setVarbit(PRAYER_VARBIT, player.getVarbit(PRAYER_VARBIT))
 }
 
 /**

--- a/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
@@ -219,6 +219,8 @@ open class Player(world: World) : Pawn(world) {
 
     var lifepoints = 100
 
+    var prayerPoints = 10.0
+
     var hpRestoreMultiplier: Int = 10
 
     var boostedXp: Boolean = false
@@ -875,5 +877,7 @@ open class Player(world: World) : Pawn(world) {
          * and objects.
          */
         const val TILE_VIEW_DISTANCE = 32
+
+        const val PRAYER_VARBIT = 9816
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/model/timer/Timers.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/timer/Timers.kt
@@ -110,3 +110,8 @@ val DAILY_TIMER = TimerKey(persistenceKey = "dailies", tickOffline = true, reset
  * The timer to tick if a player is in an area that requires a light source
  */
 val DARK_ZONE_TIMER = TimerKey()
+
+/**
+ * The timer used to trigger a visual update of the prayer points in the client after login
+ */
+val PRAYER_INITIALIZATION_TIMER = TimerKey()

--- a/game/src/main/kotlin/gg/rsmod/game/service/serializer/json/JsonPlayerSerializer.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/service/serializer/json/JsonPlayerSerializer.kt
@@ -5,12 +5,14 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import de.mkammerer.argon2.Argon2Factory
 import gg.rsmod.game.Server
+import gg.rsmod.game.fs.def.VarbitDef
 import gg.rsmod.game.model.*
 import gg.rsmod.game.model.attr.AttributeKey
 import gg.rsmod.game.model.attr.DOUBLE_ATTRIBUTES
 import gg.rsmod.game.model.attr.LONG_ATTRIBUTES
 import gg.rsmod.game.model.container.ItemContainer
 import gg.rsmod.game.model.entity.Client
+import gg.rsmod.game.model.entity.Player
 import gg.rsmod.game.model.interf.DisplayMode
 import gg.rsmod.game.model.item.Item
 import gg.rsmod.game.model.priv.Privilege
@@ -140,6 +142,9 @@ class JsonPlayerSerializer : PlayerSerializerService() {
                 client.varps.setState(varp.id, varp.state)
             }
             client.lifepoints = data.lifepoints
+            world.definitions.get(VarbitDef::class.java, Player.PRAYER_VARBIT).let { def ->
+                client.prayerPoints = client.varps.getBit(def.varp, def.startBit, def.endBit).toDouble()
+            }
             return PlayerLoadResult.LOAD_ACCOUNT
         } catch (e: Exception) {
             logger.error(e) { "Error when loading player: ${request.username}" }


### PR DESCRIPTION
## What has been done?
Uses the proper varbit for representing prayer points. Fixes altars not working. Properly reset prayer points when entering the abyss.

Uses a 1-tick timer on login to ensure the client displays the correct prayer point value. For some reason, this doesn't work on the login-tick but has to be performed after login.

## Has your code been documented?
Yes