### PR TITLE
feat; spawn for 10394 (waterfall dungeon)

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawn_10394.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawn_10394.plugin.kts
@@ -1,0 +1,22 @@
+package gg.rsmod.plugins.content.areas.spawns
+
+spawn_npc(npc = Npcs.SHADOW_SPIDER, x = 2574, z = 9874, walkRadius = 5, direction = Direction.EAST)
+spawn_npc(npc = Npcs.SHADOW_SPIDER, x = 2576, z = 9877, walkRadius = 5, direction = Direction.WEST)
+spawn_npc(npc = Npcs.SHADOW_SPIDER, x = 2578, z = 9876, walkRadius = 5, direction = Direction.EAST)
+spawn_npc(npc = Npcs.SHADOW_SPIDER, x = 2573, z = 9877, walkRadius = 5, direction = Direction.WEST)
+
+spawn_npc(npc = Npcs.SKELETON_MAGE, x = 2587, z = 9880, walkRadius = 5, direction = Direction.WEST)
+spawn_npc(npc = Npcs.SKELETON_MAGE, x = 2586, z = 9884, walkRadius = 5, direction = Direction.NORTH)
+spawn_npc(npc = Npcs.SKELETON_MAGE, x = 2590, z = 9884, walkRadius = 5, direction = Direction.EAST)
+spawn_npc(npc = Npcs.SKELETON_MAGE, x = 2590, z = 9882, walkRadius = 5, direction = Direction.NORTH)
+
+spawn_npc(npc = Npcs.FIRE_GIANT, x = 2582, z = 9893, walkRadius = 5, direction = Direction.NORTH_EAST)
+spawn_npc(npc = Npcs.FIRE_GIANT, x = 2577, z = 9890, walkRadius = 5, direction = Direction.EAST)
+spawn_npc(npc = Npcs.FIRE_GIANT, x = 2565, z = 9885, walkRadius = 5, direction = Direction.EAST)
+spawn_npc(npc = Npcs.FIRE_GIANT_1585, x = 2579, z = 9897, walkRadius = 5, direction = Direction.NORTH_WEST)
+spawn_npc(npc = Npcs.FIRE_GIANT_1585, x = 2580, z = 9890, walkRadius = 5, direction = Direction.SOUTH)
+spawn_npc(npc = Npcs.FIRE_GIANT_1585, x = 2574, z = 9894, walkRadius = 5, direction = Direction.SOUTH_WEST)
+spawn_npc(npc = Npcs.FIRE_GIANT_1586, x = 2576, z = 9896, walkRadius = 5, direction = Direction.EAST)
+spawn_npc(npc = Npcs.FIRE_GIANT_1586, x = 2577, z = 9888, walkRadius = 5, direction = Direction.NORTH_WEST)
+spawn_npc(npc = Npcs.FIRE_GIANT_1586, x = 2563, z = 9887, walkRadius = 5, direction = Direction.EAST)
+spawn_npc(npc = Npcs.FIRE_GIANT_1585, x = 2570, z = 9886, walkRadius = 5, direction = Direction.SOUTH_WEST)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_12693.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_12693.plugin.kts
@@ -6,7 +6,7 @@ package gg.rsmod.plugins.content.areas.spawns
 
 spawn_npc(npc = Npcs.CAVE_BUG_LARVA, x = 3148, z = 9576, walkRadius = 3, direction = Direction.SOUTH)
 spawn_npc(npc = Npcs.CAVE_BUG, x = 3149, z = 9573, walkRadius = 5, direction = Direction.SOUTH)
-spawn_npc(npc = Npcs.CAVE_SLIME, x = 3154, z = 9554, walkRadius = 5, direction = Direction.SOUTH)
+spawn_npc(npc = Npcs.CAVE_SLIME, x = 3149, z = 9553, walkRadius = 5, direction = Direction.SOUTH)
 spawn_npc(npc = Npcs.CAVE_BUG, x = 3149, z = 9574, walkRadius = 7, direction = Direction.SOUTH)
 spawn_npc(npc = Npcs.BIG_FROG, x = 3150, z = 9550, walkRadius = 3, direction = Direction.SOUTH)
 spawn_npc(npc = Npcs.BIG_FROG, x = 3152, z = 9561, walkRadius = 4, direction = Direction.SOUTH)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/lightsource/LightSource.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/lightsource/LightSource.kt
@@ -7,8 +7,14 @@ import gg.rsmod.plugins.api.cfg.Items
  * @author Alycia <https://github.com/alycii>
  */
 enum class LightSource(val raw: Int, val product: Int, val levelRequired: Int, val enclosed: Boolean, val interfaceId: Int) {
+    UNLIT_TORCH(raw = Items.UNLIT_TORCH, product = Items.LIT_TORCH, levelRequired = 1, enclosed = false, interfaceId = 98),
     CANDLE(raw = Items.CANDLE, product = Items.LIT_CANDLE, levelRequired = 1, enclosed = false, interfaceId = 98),
-    BLACK_CANDLE(raw = Items.BLACK_CANDLE, product = Items.LIT_BLACK_CANDLE, levelRequired = 1, enclosed = false, interfaceId = 98);
+    BLACK_CANDLE(raw = Items.BLACK_CANDLE, product = Items.LIT_BLACK_CANDLE, levelRequired = 1, enclosed = false, interfaceId = 98),
+    CANDLE_LANTERN(raw = Items.CANDLE_LANTERN, product = Items.CANDLE_LANTERN_4531, levelRequired = 4, enclosed = false, interfaceId = 98),
+    CANDLE_LANTERN_4532(raw = Items.CANDLE_LANTERN_4532, product = Items.CANDLE_LANTERN_4534, levelRequired = 4, enclosed = false, interfaceId = 98),
+    OIL_LAMP(raw = Items.OIL_LAMP, product = Items.OIL_LAMP_4524, levelRequired = 12, enclosed = false, interfaceId = 98),
+    OIL_LANTERN(raw = Items.OIL_LANTERN, product = Items.OIL_LANTERN_4539, levelRequired = 26, enclosed = false, interfaceId = 98),
+    BULLSEYE_LANTERN(raw = Items.BULLSEYE_LANTERN, product = Items.BULLSEYE_LANTERN_4550, levelRequired = 49, enclosed = false, interfaceId = 98);
 
     companion object {
         fun getActiveLightSource(player: Player): LightSource? {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/other/ice_giant_level_53.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/other/ice_giant_level_53.plugin.kts
@@ -86,9 +86,10 @@ ids.forEach {
             defenceCrush = 2
         }
         anims {
-            block = 4651
-            attack = 4652
-            death = 4653
+
+            attack = 4672
+            block = 4671
+            death = 4673
         }
         aggro {
             radius = 5

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/other/ice_warrior_level_57.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/definitions/other/ice_warrior_level_57.plugin.kts
@@ -72,9 +72,9 @@ ids.forEach {
             defenceRanged = 30
         }
         anims {
-            attack = 391
-            block = 389
-            death = 843
+            attack = 394
+            block = 399
+            death = 836
         }
         aggro {
             radius = 5


### PR DESCRIPTION
## What has been done?

spawns for (waterfall dungeon)

• shadow spiders
• skeleton mages
• fire giants
---------------------------------------------------------------------------------
fix spawn for lumbridge sawm caves
its was stuck in rock

• cave slime
----------------------------------------------------------------------------------
lightsources 

• unlit torch
• white candle lantern
• black candle lantern
• oil lamp
• oil lantern
• bullseye lantern

