### PR TITLE
fix: drill demon force teleports

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/random_event_handler.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/random_event_handler.plugin.kts
@@ -52,8 +52,7 @@ on_timer(ANTI_CHEAT_TIMER) {
     player.interruptQueues()
     player.stopMovement()
     player.animate(-1)
-    player.queue {
-        player.lock()
+    player.lockingQueue {
         val lastKnownPosition: Tile = player.tile
         val teleportToDrillDemon = Tile(3163, 4821)
         player.attr[LAST_KNOWN_POSITION] = lastKnownPosition
@@ -61,7 +60,6 @@ on_timer(ANTI_CHEAT_TIMER) {
         player.moveTo(teleportToDrillDemon)
         wait(3)
         player.graphic(86)
-        player.unlock()
     }
 
     drillDemon.queue {


### PR DESCRIPTION
## What has been done?
You could skip the drill demon random event by simply running away in time. This change makes sure there's no way to avoid a forced teleport to his area.

## Has your code been documented?
No, simple change to a lockingQueue