### PR TITLE
feat: fix/remove incorrect object examine messages and add new ones

### DIFF
--- a/data/cfg/objs.yml
+++ b/data/cfg/objs.yml
@@ -1,6 +1,7 @@
 - id: 0
+  examine: "I wonder what's inside."
 - id: 1
-  examine: "Big mysterious crate. You wonder what could be inside."
+  examine: "I wonder what's inside."
 - id: 2
   examine: "Looks and smells like a place where goblins live."
 - id: 3
@@ -28,17 +29,17 @@
 - id: 14
   examine: "Intended to keep the goblins away from the mines."
 - id: 15
-  examine: "A broken rail."
+  examine: "Intended to keep the goblins away from the mines."
 - id: 16
-  examine: "A broken rail."
+  examine: "Intended to keep the goblins away from the mines."
 - id: 17
-  examine: "A broken rail."
+  examine: "Intended to keep the goblins away from the mines."
 - id: 18
-  examine: "A broken rail."
+  examine: "Intended to keep the goblins away from the mines."
 - id: 19
-  examine: "A broken rail."
+  examine: "Intended to keep the goblins away from the mines."
 - id: 20
-  examine: "A broken rail."
+  examine: "Intended to keep the goblins away from the mines."
 - id: 21
   examine: "Its eyes stare off into the distance..."
 - id: 22
@@ -128,7 +129,9 @@
 - id: 64
   examine: "Used for storage."
 - id: 65
+  examine: "Surprisingly sturdy looking."
 - id: 66
+  examine: "Surprisingly sturdy looking."
 - id: 67
   examine: "Used for storage."
 - id: 68
@@ -268,18 +271,24 @@
 - id: 143
 - id: 144
 - id: 145
+  examine: "Smelly."
 - id: 146
+  examine: "Smelly."
 - id: 147
+  examine: "Smelly."
 - id: 148
+  examine: "An ornate fountain."
 - id: 149
+  examine: "An ornate fountain."
 - id: 150
 - id: 151
+  examine: "A pipe I can squeeze through."
 - id: 152
   examine: "Smelly."
 - id: 153
   examine: "An ornate fountain."
 - id: 154
-  examine: "It looks possible to scramble up the wall here, with skill."
+  examine: "A pipe I can squeeze through."
 - id: 155
   examine: "Lots of books."
 - id: 156
@@ -441,7 +450,7 @@
 - id: 267
   examine: "Useful for making ships move."
 - id: 268
-  examine: "Useful for making ships move."
+  examine: "Useful for making ships move"
 - id: 269
 - id: 270
 - id: 271
@@ -502,15 +511,15 @@
 - id: 306
   examine: "A used cart seller will probably try and sell it later."
 - id: 307
-  examine: "One horsepower; wooden suspension"
+  examine: "One horse power, wooden suspension. A beauty."
 - id: 308
-  examine: "One horsepower; wooden suspension"
+  examine: "One horse power, wooden suspension. A beauty."
 - id: 309
-  examine: "Dead tree parts piled neatly together."
+  examine: "Dead tree parts piled together neatly."
 - id: 310
-  examine: "A patch of soft, dark brown matter. Probably mud."
+  examine: "A patch of soft dark brown matter. Probably mud."
 - id: 311
-  examine: "A pile of something that I hope is mud."
+  examine: "A pile of something I hope is mud."
 - id: 312
   examine: "Potato-licious!"
 - id: 313
@@ -621,6 +630,7 @@
 - id: 381
   examine: "A good source of books!"
 - id: 382
+  examine: "A woven storage basket."
 - id: 383
   examine: "A woven storage basket."
 - id: 384
@@ -653,6 +663,7 @@
 - id: 398
   examine: "I hope no-one's home..."
 - id: 399
+  examine: "I see dead people."
 - id: 400
   examine: "A small simple gravestone."
 - id: 401
@@ -726,26 +737,41 @@
 - id: 435
   examine: "Bamboo's a versatile material."
 - id: 436
+  examine: "A lump of rock."
 - id: 437
+  examine: "A lump of rock."
 - id: 438
-  examine: "A door."
+  examine: "A lump of rock."
 - id: 439
+  examine: "A lump of rock."
 - id: 440
+  examine: "A big slimy lump of rock."
 - id: 441
+  examine: "A slimy lump of rock."
 - id: 442
+  examine: "A slippery looking rock."
 - id: 443
 - id: 444
+  examine: "A huge lump of rock."
 - id: 445
+  examine: "A huge lump of rock."
 - id: 446
 - id: 447
 - id: 448
 - id: 449
+  examine: "A rocky ledge."
 - id: 450
+  examine: "Stoney!"
 - id: 451
+  examine: "Stoney!"
 - id: 452
+  examine: "Stoney!"
 - id: 453
+  examine: "Stoney!"
 - id: 454
+  examine: "Solid rock from the cave floor."
 - id: 455
+  examine: "Solid rock from the cave floor."
 - id: 456
 - id: 457
 - id: 458
@@ -753,37 +779,60 @@
 - id: 460
 - id: 461
 - id: 462
+  examine: "Looks slippery!"
 - id: 463
+  examine: "Looks slippery!"
 - id: 464
+  examine: "Formed over many years of dripping limestone."
 - id: 465
+  examine: "Formed over many years of dripping limestone."
 - id: 466
+  examine: "Formed over many years of dripping limestone."
 - id: 467
+  examine: "A limestone ceiling growth."
 - id: 468
+  examine: "Limestone floor growth."
 - id: 469
+  examine: "A limestone ceiling growth."
 - id: 470
   depleted: 46319
 - id: 471
+  examine: "A deposit of rocks."
 - id: 472
+  examine: "A deposit of rocks."
 - id: 473
+  examine: "A deposit of rocks."
 - id: 474
+  examine: "A deposit of rocks."
 - id: 475
 - id: 476
 - id: 477
+  examine: "Looks slippery!"
 - id: 478
+  examine: "Looks slippery!"
 - id: 479
+  examine: "A deposit of rocks."
 - id: 480
+  examine: "A deposit of rocks."
 - id: 481
+  examine: "A deposit of rocks."
 - id: 482
+  examine: "A deposit of rocks."
 - id: 483
+  examine: "A deposit of rocks."
 - id: 484
+  examine: "A deposit of rocks."
 - id: 485
+  examine: "A deposit of rocks."
 - id: 486
+  examine: "A deposit of rocks."
 - id: 487
 - id: 488
 - id: 489
 - id: 490
 - id: 491
 - id: 492
+  examine: "A collection of rocks over what looks like a depression."
 - id: 493
 - id: 494
 - id: 495
@@ -799,65 +848,85 @@
 - id: 505
 - id: 506
 - id: 507
+  examine: "A deposit of rocks."
 - id: 508
+  examine: "A deposit of rocks."
 - id: 509
+  examine: "A deposit of rocks."
 - id: 510
+  examine: "A deposit of rocks."
 - id: 511
+  examine: "A rock with a pickaxe and mining tools."
 - id: 512
 - id: 513
 - id: 514
 - id: 515
 - id: 516
+  examine: "A very tall column of ice."
 - id: 517
+  examine: "A deposit of rocks."
 - id: 518
+  examine: "A deposit of rocks."
 - id: 519
+  examine: "A deposit of rocks."
 - id: 520
+  examine: "A deposit of rocks."
 - id: 521
 - id: 522
 - id: 523
+  examine: "Formed over many years of dripping limestone."
 - id: 524
+  examine: "Formed over many years of dripping limestone."
 - id: 525
+  examine: "Formed over many years of dripping limestone."
 - id: 526
+  examine: "Formed over many years of dripping limestone."
 - id: 527
+  examine: "Formed over many years of dripping limestone."
 - id: 528
+  examine: "Formed over many years of dripping limestone."
 - id: 529
+  examine: "A limestone ceiling growth."
 - id: 530
+  examine: "Formed over many years of dripping limestone."
 - id: 531
+  examine: "A limestone ceiling growth."
 - id: 532
-  examine: "Bashed, broken and dumped."
+  examine: "Limestone floor growth."
 - id: 533
+  examine: "A limestone ceiling growth."
 - id: 534
-  examine: "A way out!"
+  examine: "A tooth shaped rock formation protruding from the floor."
 - id: 535
-  examine: "It's even smokier in there..."
 - id: 536
-  examine: "A way out!"
 - id: 537
-  examine: "What could possibly fit through that?"
 - id: 538
-  examine: "A way out!"
 - id: 539
-  examine: "It's covering a little alcove."
+  examine: "A tooth shaped rock formation protruding from the ceiling."
 - id: 540
-  examine: "Allows for equal distribution of spice."
 - id: 541
-  examine: "Allows for equal distribution of spice."
+  examine: "A tooth shaped rock formation protruding from the floor."
 - id: 542
-  examine: "Allows for equal distribution of spice."
+  examine: "A tooth shaped rock formation protruding from the floor."
 - id: 543
-  examine: "Allows for equal distribution of spice."
+  examine: "A tooth shaped rock formation protruding from the ceiling."
 - id: 544
-  examine: "Someone bent defence."
+  examine: "A tooth shaped rock formation protruding from the floor."
 - id: 545
+  examine: "A huge lump of rock."
 - id: 546
+  examine: "Intimidating!"
 - id: 547
 - id: 548
+  examine: "A deposit of rocks."
 - id: 549
+  examine: "A deposit of rocks."
 - id: 550
+  examine: "A deposit of rocks."
 - id: 551
+  examine: "A deposit of rocks."
 - id: 552
 - id: 553
-  examine: "A large door."
 - id: 554
   examine: "Frozen water has formed an icicle here."
 - id: 555
@@ -1074,16 +1143,14 @@
 - id: 673
   depleted: 46323
 - id: 674
-  examine: "It's a <col=ff9040>Small fishing net</col>"
 - id: 675
   depleted: 46325
 - id: 676
 - id: 677
-  examine: "A passage leading into the next chamber of the cave."
 - id: 678
-  examine: "Screams can be heard within."
+  examine: "I see fish."
 - id: 679
-  examine: "Careful out there!"
+  examine: "I can see fish swimming in the water."
 - id: 680
   examine: "I was always forced to play this as a child."
 - id: 681
@@ -1156,7 +1223,6 @@
 - id: 719
 - id: 720
 - id: 721
-  examine: "It looks like there is something caught inside this trap."
 - id: 722
 - id: 723
   examine: "I'm glad this isn't around anymore!"
@@ -1219,17 +1285,15 @@
 - id: 769
 - id: 770
 - id: 771
+  examine: "A map icon."
 - id: 772
 - id: 773
 - id: 774
 - id: 775
 - id: 776
 - id: 777
-  examine: "A large door."
 - id: 778
-  examine: "A large door."
 - id: 779
-  examine: "It's a door made from bamboo."
 - id: 780
 - id: 781
 - id: 782
@@ -1384,7 +1448,7 @@
 - id: 882
   examine: "How dangerous, someone has left this manhole open."
 - id: 883
-  examine: "A wooden gate."
+  examine: "This is supposed to stop people falling down the manhole."
 - id: 884
   examine: "Best used with a bucket."
 - id: 885
@@ -1420,13 +1484,13 @@
 - id: 900
   examine: "Brightens up the room a bit."
 - id: 901
-  examine: "Mmmm decorative!"
+  examine: "I don't know art, but I like it!"
 - id: 902
   examine: "Not bad at all."
 - id: 903
-  examine: "Alas poor unicorn, I knew him."
+  examine: "Alas poor unicorn, I knew him well."
 - id: 904
-  examine: "Probably looked better mounted on the dragon's neck."
+  examine: "The scary-looking head of a scary-looking dragon."
 - id: 905
   examine: "Not what I would pick as wall decoration."
 - id: 906
@@ -1485,7 +1549,7 @@
 - id: 952
 - id: 953
 - id: 954
-  examine: "A large door."
+  examine: "For wiping muddy feet on."
 - id: 955
   examine: "Disturbingly its eyes look everywhere in the room except at you."
 - id: 956
@@ -1668,23 +1732,25 @@
 - id: 1078
   examine: "Karamja Spirits bar - For all your alcohol needs."
 - id: 1079
-  examine: "North to Varrock :"
+  examine: "North to Varrock :: East to Al-Kharid."
 - id: 1080
-  examine: "North road to Draynor Village :"
+  examine: "North road to Draynor Village :: East road to Varrock."
 - id: 1081
   examine: "North to Draynor Village."
 - id: 1082
-  examine: "North to Draynor Manor :"
+  examine: "North to Draynor Manor :: West to Asgarnia."
 - id: 1083
-  examine: "South to the Wizards' Tower :"
+  examine: "South to the Wizards' Tower :: East to Lumbridge."
 - id: 1084
-  examine: "South to Lumbridge :"
+  examine: "South to Lumbridge :: West to Varrock :: East to the Digsite."
 - id: 1085
-  examine: "South to Al-Kharid :"
+  examine: "South to Al-Kharid :: West to Lumbridge :: East to the Digsite."
 - id: 1086
-  examine: "North to Varrock :"
+  examine: "North to Varrock :: East to the Digsite."
 - id: 1087
-  examine: "South to the Wizards' Tower :"
+  examine: ">-
+    South to the Wizards' Tower :: North to Draynor Village :: East to
+    Lumbridge."
 - id: 1088
   examine: "The ideal thing to sit on."
 - id: 1089
@@ -1780,8 +1846,11 @@
 - id: 1142
 - id: 1143
 - id: 1144
+  examine: "A leafy bush."
 - id: 1145
+  examine: "A leafy bush."
 - id: 1146
+  examine: "A leafy bush."
 - id: 1147
   examine: "The abode of a fairy."
 - id: 1148
@@ -1972,54 +2041,57 @@
 - id: 1274
 - id: 1275
 - id: 1276
-  depleted: 1343
   examine: "One of the most common trees in RuneScape."
-- id: 1277
   depleted: 1343
+- id: 1277
   examine: "A healthy young tree."
+  depleted: 1343
 - id: 1278
-  depleted: 7400
   examine: "A commonly found tree."
+  depleted: 7400
 - id: 1279
   examine: "A commonly found tree."
 - id: 1280
-  depleted: 7400
   examine: "A healthy young tree."
+  depleted: 7400
 - id: 1281
+  examine: "A beautiful old oak."
   depleted: 1356
-  examine: "Looks secure."
 - id: 1282
-  depleted: 1347
   examine: "This tree has long been dead."
+  depleted: 1347
 - id: 1283
-  depleted: 1347
   examine: "This tree has long been dead."
+  depleted: 1347
 - id: 1284
-  depleted: 6212
   examine: "This tree has long been dead."
+  depleted: 6212
 - id: 1285
-  depleted: 1347
   examine: "An old weather beaten tree."
+  depleted: 1347
 - id: 1286
-  depleted: 1351
   examine: "It's only useful for firewood now."
+  depleted: 1351
 - id: 1287
   examine: "It's only useful for firewood now."
 - id: 1288
   examine: "It's only useful for firewood now."
 - id: 1289
-  depleted: 1353
   examine: "It's only useful for firewood now."
+  depleted: 1353
 - id: 1290
   examine: "It's only useful for firewood now."
 - id: 1291
-  depleted: 23054
   examine: "It's only useful for firewood now."
+  depleted: 23054
 - id: 1292
   examine: "An ancient magical tree."
 - id: 1293
+  examine: "An ancient sentient tree."
 - id: 1294
+  examine: "An ancient sentient tree."
 - id: 1295
+  examine: "An ancient sentient tree."
 - id: 1296
   examine: "This tree has fallen to the ground."
 - id: 1297
@@ -2039,15 +2111,20 @@
 - id: 1304
   examine: "A tree found in tropical areas."
 - id: 1305
+  examine: "A tree found in tropical areas."
 - id: 1306
+  examine: "The tree shimmers with a magical force."
   depleted: 7401
-  examine: "The door appears to have been torn from its frame."
 - id: 1307
+  examine: "I bet this makes good syrup!"
   depleted: 7400
 - id: 1308
+  examine: "These trees are found near water."
 - id: 1309
+  examine: "A splendid tree."
   depleted: 7402
 - id: 1310
+  examine: "This tree has vines hanging from it."
 - id: 1311
   examine: "This would be good to sleep under."
 - id: 1312
@@ -2057,16 +2134,19 @@
 - id: 1314
   examine: "An unusual tree grows here."
 - id: 1315
+  examine: "A hardy evergreen tree."
   depleted: 1342
 - id: 1316
+  examine: "A hardy evergreen tree."
   depleted: 1355
 - id: 1317
+  examine: "A young sentient tree."
 - id: 1318
-  depleted: 1355
   examine: "This would make good firewood."
+  depleted: 1355
 - id: 1319
-  depleted: 1355
   examine: "This would make good firewood."
+  depleted: 1355
 - id: 1320
   examine: "The branch is infested with moss."
 - id: 1321
@@ -2088,14 +2168,14 @@
 - id: 1329
   examine: "Leaves of a bamboo tree."
 - id: 1330
-  depleted: 1355
   examine: "It's thick with snow."
+  depleted: 1355
 - id: 1331
-  depleted: 1355
   examine: "It's thick with snow."
+  depleted: 1355
 - id: 1332
-  depleted: 1355
   examine: "It's thick with snow."
+  depleted: 1355
 - id: 1333
   examine: "This old tree has been taken over by parasitic plants."
 - id: 1334
@@ -2161,8 +2241,8 @@
 - id: 1364
   examine: "They're just waiting to trip someone up."
 - id: 1365
-  depleted: 1352
   examine: "It's only useful for firewood now."
+  depleted: 1352
 - id: 1366
   examine: "A gnarly old tree root."
 - id: 1367
@@ -2198,12 +2278,13 @@
 - id: 1382
   examine: "I hope I don't trip over any of these."
 - id: 1383
-  depleted: 1358
   examine: "This tree has long been dead."
+  depleted: 1358
 - id: 1384
-  depleted: 1359
   examine: "It's only useful for firewood now."
+  depleted: 1359
 - id: 1385
+  examine: "A gnarly old tree root."
 - id: 1386
   examine: "The roots of this tree are exposed."
 - id: 1387
@@ -2356,113 +2437,69 @@
 - id: 1507
 - id: 1508
 - id: 1509
-  examine: "The door is open."
 - id: 1510
-  examine: "The door is closed."
 - id: 1511
-  examine: "A sturdy wooden door."
 - id: 1512
-  examine: "A sturdy wooden door."
 - id: 1513
-  examine: "A sturdy wooden door."
 - id: 1514
 - id: 1515
 - id: 1516
-  examine: "A sturdy wooden door."
 - id: 1517
-  examine: "A sturdy wooden door."
 - id: 1518
-  examine: "A sturdy wooden door."
 - id: 1519
-  examine: "A sturdy wooden door."
 - id: 1520
-  examine: "A sturdy wooden door."
 - id: 1521
-  examine: "A large double door."
 - id: 1522
-  examine: "A large double door."
 - id: 1523
 - id: 1524
-  examine: "A large double door."
 - id: 1525
-  examine: "A large double door."
 - id: 1526
 - id: 1527
 - id: 1528
 - id: 1529
 - id: 1530
 - id: 1531
-  examine: "The curtain is closed."
 - id: 1532
 - id: 1533
-  examine: "The curtain is closed."
 - id: 1534
-  examine: "The curtain is open."
 - id: 1535
-  examine: "The door is closed."
 - id: 1536
-  examine: "The door is open."
 - id: 1537
-  examine: "The door is closed."
 - id: 1538
-  examine: "The door is open."
 - id: 1539
 - id: 1540
-  examine: "A nicely fitted door."
 - id: 1541
-  examine: "A nicely fitted door."
 - id: 1542
 - id: 1543
-  examine: "An ornately-fashioned door."
 - id: 1544
-  examine: "An elf-fashioned door."
 - id: 1545
 - id: 1546
-  examine: "Solid bars of iron."
 - id: 1547
-  examine: "Solid bars of iron."
 - id: 1548
 - id: 1549
-  examine: "Solid bars of iron."
 - id: 1550
-  examine: "Solid bars of iron."
 - id: 1551
-  examine: "Solid bars of iron."
 - id: 1552
-  examine: "Solid bars of iron."
 - id: 1553
 - id: 1554
 - id: 1555
 - id: 1556
 - id: 1557
 - id: 1558
-  examine: "A wooden gate."
 - id: 1559
-  examine: "A wooden gate."
 - id: 1560
-  examine: "A wooden gate."
 - id: 1561
-  examine: "A wooden gate."
 - id: 1562
-  examine: "A wooden gate."
 - id: 1563
-  examine: "A wooden gate."
 - id: 1564
-  examine: "A wooden gate."
 - id: 1565
 - id: 1566
 - id: 1567
-  examine: "A wooden gate."
 - id: 1568
-  examine: "A wrought iron gate."
 - id: 1569
-  examine: "A wrought iron gate."
 - id: 1570
-  examine: "A wrought iron gate."
 - id: 1571
-  examine: "A wrought iron gate."
 - id: 1572
-  examine: "A wrought iron gate."
 - id: 1573
 - id: 1574
 - id: 1575
@@ -2470,48 +2507,28 @@
 - id: 1577
 - id: 1578
 - id: 1579
-  examine: "I wonder what's under it?"
 - id: 1580
-  examine: "I wonder what's under it?"
 - id: 1581
-  examine: "I wonder what's down there?"
 - id: 1582
-  examine: "I wonder what's down there?"
 - id: 1583
-  examine: "This door has been boarded up."
 - id: 1584
-  examine: "A door to a grand place."
 - id: 1585
-  examine: "A door to a grand place."
 - id: 1586
-  examine: "A door to a grand place."
 - id: 1587
-  examine: "A door to a grand place."
 - id: 1588
-  examine: "The top of the archway."
 - id: 1589
-  examine: "The top of the archway."
 - id: 1590
-  examine: "The top of the archway."
 - id: 1591
-  examine: "The base of the archway."
 - id: 1592
-  examine: "The base of the archway."
 - id: 1593
 - id: 1594
-  examine: "There is something strange about this wall..."
 - id: 1595
-  examine: "There is something strange about this wall..."
 - id: 1596
 - id: 1597
-  examine: "There is something strange about this wall..."
 - id: 1598
-  examine: "There is something strange about this wall..."
 - id: 1599
 - id: 1600
-  examine: "A wrought iron gate."
 - id: 1601
-  examine: "A wrought iron gate."
 - id: 1602
 - id: 1603
 - id: 1604
@@ -2642,88 +2659,99 @@
 - id: 1720
 - id: 1721
 - id: 1722
-  examine: "The door is closed."
+  examine: "I can climb these stairs."
 - id: 1723
-  examine: "Something is strange about this panel."
+  examine: "They go down."
 - id: 1724
+  examine: "I can climb down these stairs."
 - id: 1725
-  examine: "An entranceway into the dungeon."
+  examine: "I can climb up this."
 - id: 1726
-  examine: "The way in."
+  examine: "I can climb down this."
 - id: 1727
-  examine: "A wrought iron gate."
+  examine: "I can climb down this."
 - id: 1728
-  examine: "A wrought iron gate."
+  examine: "I can climb down this."
 - id: 1729
-  examine: "A wrought iron gate."
+  examine: "I can climb this."
 - id: 1730
-  examine: "A wooden gate."
+  examine: "Dare I go up?"
 - id: 1731
-  examine: "A wooden gate."
+  examine: "These stairs look spooky!"
 - id: 1732
-  examine: "The doors to the Magic Guild."
+  examine: "These stairs look spooky!"
 - id: 1733
-  examine: "The doors to the Magic guild."
+  examine: "I can use these stairs to climb down."
 - id: 1734
-  examine: "A strange crack cuts into the wall."
+  examine: "I can climb these stairs."
 - id: 1735
-  examine: "A strange crack cuts into the wall."
+  examine: "A rickety old staircase."
 - id: 1736
-  examine: "A strange crack cuts into the wall."
+  examine: "I can climb down these stairs."
 - id: 1737
-  examine: "A strange crack cuts into the wall."
+  examine: "I can climb up these stairs."
 - id: 1738
-  examine: "What could be down here?"
+  examine: "I can climb up these stairs."
 - id: 1739
-  examine: "A wooden gate."
+  examine: "I can climb up or go down these stairs."
 - id: 1740
-  examine: "A wooden gate."
+  examine: "I can climb down these stairs."
 - id: 1741
-  examine: "Looks a bit tatty..."
+  examine: "I can climb down these stairs."
 - id: 1742
-  examine: "The door is open."
+  examine: "I can climb up these stairs."
 - id: 1743
-  examine: "The door is open."
+  examine: "I can climb up or go down these stairs."
 - id: 1744
+  examine: "I can climb down these stairs."
 - id: 1745
+  examine: "I can climb down these stairs."
 - id: 1746
+  examine: "I can climb down this."
 - id: 1747
+  examine: "I can climb this."
 - id: 1748
+  examine: "I can climb this."
 - id: 1749
-  examine: "Looks a bit tatty..."
+  examine: "I can climb down this."
 - id: 1750
-  examine: "These trees are found near water."
+  examine: "I can climb this."
 - id: 1751
-  examine: "A beautiful old oak."
+  examine: "I can climb this."
 - id: 1752
-  examine: "It's hollow..."
+  examine: "I can't climb this."
 - id: 1753
-  examine: "A splendid tree."
+  examine: "It's useless."
 - id: 1754
+  examine: "I can climb down this."
 - id: 1755
+  examine: "I can climb this."
 - id: 1756
-  examine: "A droopy tree."
+  examine: "I can climb down this."
 - id: 1757
-  examine: "It's hollow..."
+  examine: "I can climb this."
 - id: 1758
-  examine: "These trees are found near water."
+  examine: "Not much use really."
 - id: 1759
-  examine: "I bet this makes good syrup!"
+  examine: "This leads downwards."
 - id: 1760
-  examine: "These trees are found near water."
+  examine: "These can be useful."
 - id: 1761
-  examine: "The tree shimmers with a magical force."
+  examine: "Steps made from natural rock."
 - id: 1762
+  examine: "A rope hangs here."
 - id: 1763
-  examine: "A kitchen sink."
+  examine: "A rope hangs here."
 - id: 1764
-  examine: "I can train on this."
+  examine: "A rope hangs here."
 - id: 1765
+  examine: "I can climb down this."
 - id: 1766
+  examine: "I can climb this."
 - id: 1767
-  examine: "'Pay back all your debts by borrowing more money from us!' Clever."
+  examine: "I can climb down this."
 - id: 1768
-  examine: "Contains quite a lot of someone else's property."
+  examine: "I can climb this."
 - id: 1769
 - id: 1770
 - id: 1771
@@ -2740,6 +2768,7 @@
 - id: 1780
   examine: "These sails use the wind to drive the windmill."
 - id: 1781
+  examine: "I'll need an empty pot so I can collect my flour."
 - id: 1782
   examine: "I'll need an empty pot so I can collect my flour."
 - id: 1783
@@ -2783,6 +2812,7 @@
 - id: 1814
   examine: "I wonder what this does..."
 - id: 1815
+  examine: "I wonder what this does..."
 - id: 1816
   examine: "I wonder what this does..."
 - id: 1817
@@ -3039,27 +3069,28 @@
 - id: 2022
   examine: "A wooden barrel, maybe a way off this rock."
 - id: 2023
-  depleted: 3371
   examine: "An interesting tree with long straight branches."
+  depleted: 3371
 - id: 2024
   examine: "A large bubbling cauldron, smells... Ugh!"
 - id: 2025
-  examine: "If a creature goes inside, the box should then slam shut."
+  examine: "The door is closed."
 - id: 2026
-  examine: "If a creature goes inside, the box should then slam shut."
+  examine: "I can see fish swimming in the water."
 - id: 2027
+  examine: "I can see fish swimming in the water."
 - id: 2028
-  examine: "If a creature goes inside, the box should then slam shut."
+  examine: "I can see fish swimming in the water."
 - id: 2029
-  examine: "If a creature goes inside, the box should then slam shut."
+  examine: "I can see fish swimming in the water."
 - id: 2030
-  examine: "A hot place for forging things in."
+  examine: "I can see fish swimming in the water."
 - id: 2031
-  examine: "It says 'Property of Doric the dwarf' on the side."
+  examine: "I can see fish swimming in the water."
 - id: 2032
-  examine: "This is someone's bedroom door."
+  examine: "It's closed."
 - id: 2033
-  examine: "This is someone's bedroom door."
+  examine: "It's open."
 - id: 2034
   examine: "It's closed."
 - id: 2035
@@ -3161,68 +3192,73 @@
 - id: 2089
   examine: "Ornamental."
 - id: 2090
+  examine: "A rocky outcrop."
   depleted: 450
-  examine: "This chest looks strong."
 - id: 2091
+  examine: "A rocky outcrop."
   depleted: 452
-  examine: "A hardy evergreen tree."
 - id: 2092
+  examine: "A rocky outcrop."
   depleted: 450
-  examine: "A hardy evergreen tree."
 - id: 2093
+  examine: "A rocky outcrop."
   depleted: 452
 - id: 2094
+  examine: "A rocky outcrop."
   depleted: 450
-  examine: "A handy place for filling in forms and paperwork."
 - id: 2095
+  examine: "A rocky outcrop."
   depleted: 452
-  examine: "They say money can't buy happiness."
 - id: 2096
+  examine: "A rocky outcrop."
   depleted: 450
 - id: 2097
+  examine: "A rocky outcrop."
   depleted: 452
-  examine: "Used for fashioning metal items."
 - id: 2098
+  examine: "A rocky outcrop."
   depleted: 450
-  examine: "Various implements for working with metal."
 - id: 2099
+  examine: "A rocky outcrop."
   depleted: 452
 - id: 2100
+  examine: "A rocky outcrop."
   depleted: 450
-  examine: "A tall wooden door."
 - id: 2101
+  examine: "A rocky outcrop."
   depleted: 452
-  examine: "A tall wooden door."
 - id: 2102
+  examine: "A rocky outcrop."
   depleted: 450
-  examine: "A tall wooden door."
 - id: 2103
+  examine: "A rocky outcrop."
   depleted: 452
-  examine: "A tall wooden door."
 - id: 2104
+  examine: "A rocky outcrop."
   depleted: 450
-  examine: "A tall wooden door."
 - id: 2105
+  examine: "A rocky outcrop."
   depleted: 452
-  examine: "A tall wooden door."
 - id: 2106
-  examine: "Looks a bit crumbly, but it'll probably stay up for now."
+  examine: "A rocky outcrop."
 - id: 2107
-  examine: "Danger!"
+  examine: "A rocky outcrop."
 - id: 2108
+  examine: "A rocky outcrop."
   depleted: 450
-  examine: "A big wooden door."
 - id: 2109
+  examine: "A rocky outcrop."
   depleted: 452
 - id: 2110
+  examine: "A rocky outcrop."
 - id: 2111
-  examine: "A big wooden door."
+  examine: "A rocky outcrop."
 - id: 2112
-  examine: "A big wooden door."
+  examine: "The door is closed."
 - id: 2113
-  examine: "A big wooden door."
+  examine: "I can climb down this."
 - id: 2114
-  examine: "I can climb these stairs."
+  examine: "This transports coal!"
 - id: 2115
   examine: "The left hand side of the gate."
 - id: 2116
@@ -3230,44 +3266,53 @@
 - id: 2117
   examine: "It's an old wall."
 - id: 2118
-  examine: "They go down."
+  examine: "Lots of water swirling around - fast."
 - id: 2119
-  examine: "I can climb these stairs."
+  examine: "A rocky outcrop."
 - id: 2120
-  examine: "They go down."
+  examine: "A rocky outcrop."
 - id: 2121
-  examine: "I can climb these stairs."
+  examine: "A rocky outcrop."
 - id: 2122
-  examine: "They go down."
+  examine: "A rocky outcrop."
 - id: 2123
-  examine: "Wow - it's a guinea pig! No, hang on, it's a cave."
+  examine: "A rocky outcrop."
 - id: 2124
-  examine: "A gilt sculpture of a monarch."
+  examine: "A rocky outcrop."
 - id: 2125
+  examine: "A rocky outcrop."
 - id: 2126
+  examine: "A rocky outcrop."
 - id: 2127
-  examine: "It's reassuring to see that the bank's spending money usefully."
+  examine: "A rocky outcrop."
 - id: 2128
+  examine: "A rocky outcrop."
 - id: 2129
+  examine: "A rocky outcrop."
 - id: 2130
+  examine: "A rocky outcrop."
 - id: 2131
+  examine: "A rocky outcrop."
 - id: 2132
+  examine: "A rocky outcrop."
 - id: 2133
-  examine: "For storing valuables."
+  examine: "A rocky outcrop."
 - id: 2134
-  examine: "A nice selection of staves."
+  examine: "A rocky outcrop."
 - id: 2135
-  examine: "Staves in a Barrel."
+  examine: "A rocky outcrop."
 - id: 2136
-  examine: "A nice selection of staves."
+  examine: "A rocky outcrop."
 - id: 2137
-  examine: "A barrel of unfinished staves and pieces of wood."
+  examine: "A rocky outcrop."
 - id: 2138
-  examine: "A selection of staves."
+  examine: "A rocky outcrop."
 - id: 2139
+  examine: "A rocky outcrop."
 - id: 2140
+  examine: "A rocky outcrop."
 - id: 2141
-  examine: "This leads back to the cruel world above."
+  examine: "An open chest."
 - id: 2142
   examine: "An eerie glow permeates the cauldron."
 - id: 2143
@@ -3277,6 +3322,7 @@
 - id: 2145
   examine: "Ooooh! Spooky!"
 - id: 2146
+  examine: "Ooooh! Spooky!"
 - id: 2147
   examine: "Going down?"
 - id: 2148
@@ -3302,31 +3348,46 @@
 - id: 2158
   examine: "A magical portal of teleportation."
 - id: 2159
+  examine: "It's a floating barrel."
 - id: 2160
+  examine: "It's a floating barrel."
 - id: 2161
+  examine: "It's a floating barrel."
 - id: 2162
+  examine: "Smells like fish."
 - id: 2163
+  examine: "Smells like fish."
 - id: 2164
+  examine: "Smells like fish."
 - id: 2165
+  examine: "Smells like fish."
 - id: 2166
+  examine: "Smells like fish."
 - id: 2167
+  examine: "Water is pouring in through the hole."
 - id: 2168
+  examine: "A patch of swamp tar has bunged up the hole."
 - id: 2169
+  examine: "There's a strong wind whipping up the sea."
 - id: 2170
+  examine: "There's a strong wind whipping up the sea."
 - id: 2171
-  examine: "I doubt that was built to last..."
 - id: 2172
+  examine: "A huge net to catch little fish."
 - id: 2173
+  examine: "A huge net to catch little fish."
 - id: 2174
+  examine: "The upper deck can be accessed with this ladder."
 - id: 2175
+  examine: "Back down to the main deck."
 - id: 2176
-  examine: "How do you make a skeleton laugh?"
+  examine: "This old trawler has seen better days."
 - id: 2177
-  examine: "Smells like fish."
+  examine: "This old trawler has seen better days."
 - id: 2178
-  examine: "Smells like fish."
+  examine: "Handy for boarding boats."
 - id: 2179
-  examine: "Smells like fish."
+  examine: "Handy for boarding boats."
 - id: 2180
   examine: "It's a war machine."
 - id: 2181
@@ -3342,30 +3403,33 @@
 - id: 2186
   examine: "Hmmm... I wonder if it's loose enough to get through."
 - id: 2187
-  examine: "I wonder where they will take me."
+  examine: "I can climb down this ladder."
 - id: 2188
-  examine: "The bellows pump air to the fire and make it hotter."
+  examine: "I can climb up this ladder."
 - id: 2189
+  examine: "I can climb up this ladder."
 - id: 2190
-  examine: "I wonder where they will take me."
+  examine: "I can climb down this ladder."
 - id: 2191
-  examine: "I wonder what could be inside."
+  examine: "I wonder what's inside?"
 - id: 2192
+  examine: "I wonder what's inside?"
 - id: 2193
+  examine: "I wonder what's inside?"
 - id: 2194
   examine: "Perhaps I should search it."
 - id: 2195
-  examine: "These would make fine shoes for... um... unicorns."
+  examine: "Perhaps I should search it."
 - id: 2196
-  examine: "Smells like fish."
+  examine: "Perhaps I should search it."
 - id: 2197
-  examine: "Smells like fish."
+  examine: "I wonder what's inside?"
 - id: 2198
-  examine: "Smells like fish."
+  examine: "Perhaps I should search it."
 - id: 2199
-  examine: "It keeps greedy goblins away from the food."
+  examine: "An old gate for locking up undesirables."
 - id: 2200
-  examine: "It keeps greedy goblins away from the food."
+  examine: "An old gate for locking up undesirables."
 - id: 2201
 - id: 2202
 - id: 2203
@@ -3376,17 +3440,20 @@
 - id: 2208
 - id: 2209
 - id: 2210
+  examine: "Looking through it makes far off things look closer!"
   depleted: 5554
-  examine: "Looking through it makes far off things seem closer."
 - id: 2211
   examine: "A weathered old gravestone."
 - id: 2212
-  examine: "Smells like fish."
+  examine: "It's a sack!"
 - id: 2213
-  examine: "Smells like fish."
+  examine: "The bank teller will serve you from here."
 - id: 2214
+  examine: "This booth is for private customers only."
 - id: 2215
+  examine: "This booth is closed."
 - id: 2216
+  examine: "This looks like it's being used to block entrance to the village."
 - id: 2217
   examine: "Something seems to be buried under this."
 - id: 2218
@@ -3479,7 +3546,9 @@
 - id: 2265
   examine: "A sturdy cart for travelling in."
 - id: 2266
+  examine: "The door is closed."
 - id: 2267
+  examine: "The door is closed."
 - id: 2268
   examine: "This leads up to the sleeping area."
 - id: 2269
@@ -3491,109 +3560,126 @@
 - id: 2272
   examine: "It's open."
 - id: 2273
+  examine: "An odd-looking rock with a rope tied to it."
 - id: 2274
-  examine: "It's smoking."
+  examine: "An odd-looking rock with a rope tied to it."
 - id: 2275
+  examine: "An odd-looking rock formation."
 - id: 2276
+  examine: "An odd-looking rock formation."
 - id: 2277
+  examine: "An odd-looking rock formation."
 - id: 2278
+  examine: "An odd-looking rock formation."
 - id: 2279
-  examine: "Handy for a workman."
+  examine: "Holds the rope up. Hopefuly."
 - id: 2280
-  examine: "A powerful lathe."
+  examine: "Holds the rope up. Hopefuly."
 - id: 2281
-  examine: "A powerful drill."
+  examine: "Holds the rope up. Hopefuly."
 - id: 2282
-  examine: "A powerful hearth."
+  examine: "Use this to swing over crevices."
 - id: 2283
-  examine: "For casting large swords."
+  examine: "Use this to swing over crevices."
 - id: 2284
-  examine: "Health & Safety in the Workplace."
+  examine: "This must be climbed over."
 - id: 2285
+  examine: "This must be climbed over."
 - id: 2286
-  examine: "The Lumber Yard."
+  examine: "This must be climbed over."
 - id: 2287
-  examine: "The Dancing Donkey Inn."
+  examine: "A pipe I can squeeze through."
 - id: 2288
-  examine: "The Jolly Boar Inn."
+  examine: "A pipe I can squeeze through."
 - id: 2289
+  examine: "It's hollow..."
   depleted: 2310
-  examine: "Smells like fish."
 - id: 2290
-  examine: "Varrock Swords."
+  examine: "A pipe I can squeeze through."
 - id: 2291
 - id: 2292
-  examine: "Horvik's Smithy."
 - id: 2293
 - id: 2294
-  examine: "The Blue Moon Inn."
+  examine: "A slippery log I can walk across."
 - id: 2295
+  examine: "A slippery log I can walk across."
 - id: 2296
+  examine: "A slippery log I can walk across."
 - id: 2297
-  examine: "Bank of RuneScape."
+  examine: "A slippery log I can walk across."
 - id: 2298
-  examine: "Some kind of training facility."
+  examine: "The irregular surface can be climbed."
 - id: 2299
+  examine: "The irregular surface can be climbed."
 - id: 2300
-  examine: "'Gypsy Aris, fortune-teller. Guaranteed no waiting.'"
+  examine: "The irregular surface can be climbed."
 - id: 2301
+  examine: "Tread carefully!"
 - id: 2302
-  examine: "Cooking Guild."
+  examine: "Tread carefully!"
 - id: 2303
-  examine: "A market stall."
+  examine: "I can just about edge across here."
 - id: 2304
-  examine: "A market stall."
+  examine: "Pointy!"
 - id: 2305
-  examine: "A market stall."
+  examine: "Pointy!"
 - id: 2306
-  examine: "A market stall."
 - id: 2307
-  examine: "A market stall."
+  examine: "A wrought iron gate."
 - id: 2308
-  examine: "A coal scuttle for storing coal."
+  examine: "A wrought iron gate."
 - id: 2309
-  examine: "To stoke the fire."
+  examine: "Solid bars of iron."
 - id: 2310
   examine: "This tree has been cut down."
 - id: 2311
+  examine: "Hop, hop, hoppity hop, and then you fall in molten lava."
   depleted: 10580
 - id: 2312
+  examine: "I can balance on this rope."
 - id: 2313
+  examine: "I can climb up this."
 - id: 2314
-  examine: "Never drink and drive. Of course, what could you possibly drive?"
+  examine: "I can climb down here."
 - id: 2315
-  examine: "Excessive consumption of alcohol is bad for you."
+  examine: "I can climb down here."
 - id: 2316
-  examine: "Do you know what 'cirrhosis of the liver' means?"
+  examine: "I can climb up these stairs."
 - id: 2317
-  examine: "Drinks for sale here."
+  examine: "I can climb up these rocks to another cave."
 - id: 2318
-  examine: "Where everybody knows your username."
+  examine: "I can climb down these rocks to another cave."
 - id: 2319
-  examine: "Have a drop a-fore ye go..."
+  examine: "I can traverse these."
 - id: 2320
-  examine: "Always drink responsibly."
+  examine: "I can traverse these."
 - id: 2321
-  examine: "Wine and whisky don't mix."
+  examine: "I can traverse these."
 - id: 2322
-  examine: "Eat, drink and be merry, for tomorrow we die."
+  examine: "Use this to swing across gaps."
 - id: 2323
+  examine: "Use this to swing across gaps."
 - id: 2324
+  examine: "Use this to swing across gaps."
 - id: 2325
+  examine: "I can swing on this tree."
 - id: 2326
+  examine: "A branch protrudes here."
 - id: 2327
+  examine: "This tree has an unusually long branch on it."
 - id: 2328
+  examine: "A rocky outcrop."
 - id: 2329
 - id: 2330
 - id: 2331
 - id: 2332
-  examine: "A tall table."
+  examine: "A nearly rotten wooden log that crosses the river."
 - id: 2333
-  examine: "A low table."
+  examine: "A rocky outcrop from the running water."
 - id: 2334
-  examine: "The umbrella would be handy if it were sunny."
+  examine: "A rocky outcrop from the running water."
 - id: 2335
-  examine: "There's a hole in the table for an umbrella to go through."
+  examine: "A rocky outcrop from the running water."
 - id: 2336
   examine: "You can see a cauldron directly below."
 - id: 2337
@@ -3603,6 +3689,7 @@
 - id: 2339
   examine: "This door is very sturdy looking."
 - id: 2340
+  examine: "This door is very sturdy looking."
 - id: 2341
   examine: "There is something strange about this wall..."
 - id: 2342
@@ -3622,9 +3709,9 @@
 - id: 2349
   examine: "A large stone block."
 - id: 2350
-  examine: "Used to move earth to and from the dig shaft."
+  examine: "Used to move earth to, and from, the dig shaft."
 - id: 2351
-  examine: "Used to move earth to and from the dig shaft."
+  examine: "Used to move earth to, and from, the dig shaft."
 - id: 2352
   examine: "This leads back up the dig shaft."
 - id: 2353
@@ -3640,6 +3727,7 @@
 - id: 2358
   examine: "A leafy bush."
 - id: 2359
+  examine: "A sealed barrel with a warning sign on it."
 - id: 2360
   examine: "I wonder what's inside..."
 - id: 2361
@@ -3665,20 +3753,20 @@
 - id: 2371
   examine: "A signpost!"
 - id: 2372
-  depleted: 5554
   examine: "Shelves filled with interesting books."
+  depleted: 5554
 - id: 2373
   examine: "A cupboard."
 - id: 2374
   examine: "A cupboard."
 - id: 2375
-  examine: "Used to keep specimens in."
+  examine: "Used to keep specimens on."
 - id: 2376
-  examine: "Soil. Dug up!"
+  examine: "Soil - dug up!"
 - id: 2377
-  examine: "Soil. Dug up!"
+  examine: "Soil - dug up!"
 - id: 2378
-  examine: "Soil. Dug up!"
+  examine: "Soil - dug up!"
 - id: 2379
   examine: "Technically a bed."
 - id: 2380
@@ -3732,14 +3820,14 @@
 - id: 2408
   examine: "I can climb down this."
 - id: 2409
-  depleted: 40355
   examine: "A commonly found tree."
+  depleted: 40355
 - id: 2410
-  depleted: 12004
   examine: "I can climb this."
+  depleted: 12004
 - id: 2411
-  depleted: 7400
   examine: "The door is closed."
+  depleted: 7400
 - id: 2412
   examine: "Handy for boarding the ship."
 - id: 2413
@@ -3749,11 +3837,11 @@
 - id: 2415
   examine: "Handy for boarding the ship."
 - id: 2416
-  examine: "A sturdy wooden door."
+  examine: "Pull me!"
 - id: 2417
-  examine: "A sturdy wooden door."
+  examine: "Place party drop items here."
 - id: 2418
-  examine: "Place party drop items in here."
+  examine: "Place party drop items here."
 - id: 2419
 - id: 2420
 - id: 2421
@@ -3802,10 +3890,10 @@
 - id: 2443
   examine: "Wonder what this pillar is for?"
 - id: 2444
+  examine: "I wonder what's under it?"
 - id: 2445
-  examine: "This leads to somewhere... but where?"
 - id: 2446
-  examine: "This leads to somewhere... but where?"
+  examine: "This leads to somewhere...but where?"
 - id: 2447
   examine: "I reckon I could climb that!"
 - id: 2448
@@ -3818,108 +3906,119 @@
   examine: "There's something behind these roots."
 - id: 2452
 - id: 2453
-  examine: "Smells distressingly of vinegar."
 - id: 2454
 - id: 2455
 - id: 2456
 - id: 2457
 - id: 2458
-  examine: "The scent from the candle fills the tent."
 - id: 2459
-  examine: "The gypsy's crystal ball rests on this table."
 - id: 2460
+  examine: "A portal from this mystical place."
 - id: 2461
+  examine: "A portal from this mystical place."
 - id: 2462
+  examine: "A portal from this mystical place."
 - id: 2463
 - id: 2464
 - id: 2465
-  examine: "Smells like fish."
+  examine: "A portal from this mystical place."
 - id: 2466
-  examine: "Smells like fish."
+  examine: "A portal from this mystical place."
 - id: 2467
-  examine: "Smells like fish."
+  examine: "A portal from this mystical place."
 - id: 2468
-  examine: "Smells like fish."
+  examine: "A portal from this mystical place."
 - id: 2469
-  examine: "Smells like fish."
+  examine: "A portal from this mystical place."
 - id: 2470
-  examine: "Smells like fish."
+  examine: "A portal from this mystical place."
 - id: 2471
-  examine: "Smells like fish."
+  examine: "A portal from this mystical place."
 - id: 2472
-  examine: "Smells like fish."
+  examine: "A portal from this mystical place."
 - id: 2473
-  examine: "Smells like fish."
+  examine: "A portal from this mystical place."
 - id: 2474
-  examine: "Smells like fish."
+  examine: "A portal from this mystical place."
 - id: 2475
-  examine: "Smells like fish."
+  examine: "A portal from this mystical place."
 - id: 2476
-  examine: "It's a floating barrel."
+  examine: "A portal from this mystical place."
 - id: 2477
-  examine: "It's a floating barrel."
+  examine: "A portal from this mystical place."
 - id: 2478
-  examine: "It's a floating barrel."
+  examine: "A mysterious power emanates from this shrine."
 - id: 2479
-  examine: "Smells like fish."
+  examine: "A mysterious power emanates from this shrine."
 - id: 2480
-  examine: "Smells like fish."
+  examine: "A mysterious power emanates from this shrine."
 - id: 2481
-  examine: "Smells like fish."
+  examine: "A mysterious power emanates from this shrine."
 - id: 2482
-  examine: "Smells like fish."
+  examine: "A mysterious power emanates from this shrine."
 - id: 2483
-  examine: "Smells like fish."
+  examine: "A mysterious power emanates from this shrine."
 - id: 2484
-  examine: "Water is pouring in through the hole."
+  examine: "A mysterious power emanates from this shrine."
 - id: 2485
-  examine: "A patch of swamp tar has bunged up the hole."
+  examine: "A mysterious power emanates from this shrine."
 - id: 2486
-  examine: "There's a strong wind whipping up the sea."
+  examine: "A mysterious power emanates from this shrine."
 - id: 2487
-  examine: "There's a strong wind whipping up the sea."
+  examine: "A mysterious power emanates from this shrine."
 - id: 2488
+  examine: "A mysterious power emanates from this shrine."
 - id: 2489
+  examine: "A mysterious power emanates from this shrine."
 - id: 2490
+  examine: "A mysterious power emanates from this shrine."
 - id: 2491
-  examine: "A curious lamp."
+  examine: "The source of all Rune Stones."
 - id: 2492
-  examine: "A lantern hanging from the centre of the tent."
+  examine: "A portal from this mystical place."
 - id: 2493
-  examine: "It looks like me."
+  examine: "A part of an old temple."
 - id: 2494
-  examine: "It must have fallen to the floor."
+  examine: "A part of an old temple."
 - id: 2495
-  examine: "Powered by a pedal."
+  examine: "A part of an old temple."
 - id: 2496
-  examine: "Odd bits of fabric lie on this table."
 - id: 2497
+  examine: "Unusual energy is gathered here."
 - id: 2498
-  examine: "Fine clothes for sale."
+  examine: "Unusual energy is gathered here."
 - id: 2499
-  examine: "Some fabric ready for making clothing."
+  examine: "Unusual energy is gathered here."
 - id: 2500
+  examine: "Unusual energy is gathered here."
 - id: 2501
-  examine: "An oil lamp."
+  examine: "Unusual energy is gathered here."
 - id: 2502
-  examine: "Rolled up fabric."
+  examine: "Unusual energy is gathered here."
 - id: 2503
-  examine: "Rolled up fabric."
+  examine: "An old crumbled pillar."
 - id: 2504
+  examine: "An old crumbled pillar."
 - id: 2505
+  examine: "An old crumbled pillar."
 - id: 2506
+  examine: "An old crumbled pillar."
 - id: 2507
+  examine: "An old crumbled pillar."
 - id: 2508
+  examine: "Broken parts of an old temple."
 - id: 2509
+  examine: "Broken parts of an old temple."
 - id: 2510
+  examine: "Broken parts of an old temple."
 - id: 2511
-  examine: "Looks comfy."
+  examine: "This leads to the practice tower."
 - id: 2512
-  examine: "Some kind of outfit has been chucked on the floor."
+  examine: "This leads back down to the guild."
 - id: 2513
-  examine: "A little black dress and some smelly socks."
+  examine: "I wonder if I can hit a bullseye?"
 - id: 2514
-  examine: "Are these clean or dirty?"
+  examine: "The door to the Ranging Guild."
 - id: 2515
   examine: "I hope it doesn't sink."
 - id: 2516
@@ -3990,42 +4089,55 @@
 - id: 2549
   examine: "A door."
 - id: 2550
-  examine: "Someone's really untidy!"
+  examine: "A secure door."
 - id: 2551
-  examine: "Tatty trousers and an odd sandal."
+  examine: "A secure door."
 - id: 2552
-  examine: "I'm guessing it's for making women's clothes."
+  examine: "A metal gate bars your way."
 - id: 2553
-  examine: "I'm guessing it's for making men's clothes."
+  examine: "A metal gate bars your way."
 - id: 2554
+  examine: "A secure door."
 - id: 2555
+  examine: "A secure door."
 - id: 2556
+  examine: "A secure door."
 - id: 2557
+  examine: "A secure door."
 - id: 2558
+  examine: "A secure door."
 - id: 2559
-  examine: "Handy for mining."
+  examine: "A secure door."
 - id: 2560
+  examine: "Fine silk woven by experts."
 - id: 2561
+  examine: "This stall smells great."
   depleted: 10585
 - id: 2562
+  examine: "Precious stones from around the world."
 - id: 2563
+  examine: "All manner of animal clothing."
 - id: 2564
+  examine: "Spices to tingle your taste buds."
 - id: 2565
+  examine: "Fine silver items are for sale here."
 - id: 2566
+  examine: "I wonder what's inside it."
 - id: 2567
+  examine: "I wonder what's inside it."
 - id: 2568
+  examine: "I wonder what's inside it."
 - id: 2569
-  examine: "These sails use the wind to drive the windmill."
+  examine: "I wonder what's inside it."
 - id: 2570
-  examine: "A huge wooden support."
+  examine: "I wonder what's inside it."
 - id: 2571
-  examine: "These huge stone discs grind grain to make flour."
+  examine: "I wonder what's inside it."
 - id: 2572
-  examine: "These huge stone discs grind grain to make flour."
+  examine: "I wonder what's inside it."
 - id: 2573
-  examine: "When I've ground some flour, I'll be able to collect it here."
+  examine: "I wonder what's inside it."
 - id: 2574
-  examine: "I'll need an empty pot so I can collect my flour."
 - id: 2575
   examine: "A marshy jungle vine."
 - id: 2576
@@ -4049,9 +4161,9 @@
 - id: 2585
   examine: "Rocky walls, you may be able to climb it."
 - id: 2586
-  examine: "Grain goes in here."
+  examine: "It's closed."
 - id: 2587
-  examine: "I wonder what's inside."
+  examine: "I wonder what's inside?"
 - id: 2588
   examine: "It's open."
 - id: 2589
@@ -4089,24 +4201,23 @@
 - id: 2605
   examine: "It's a ladder."
 - id: 2606
-  examine: "There is something strange about this wall."
+  examine: "There is something strange about this wall..."
 - id: 2607
-  examine: "These control the flow of grain from the hopper to the millstones."
+  examine: "It's closed."
 - id: 2608
-  examine: "I can climb up these stairs."
+  examine: "It's closed."
 - id: 2609
+  examine: "A collection of rocks over what looks like a depression."
   depleted: 14832
-  examine: "I can climb up or go down these stairs."
 - id: 2610
+  examine: "A rope hangs here that I can climb."
   depleted: 14833
-  examine: "I can climb down these stairs."
 - id: 2611
+  examine: "It's a ladder."
   depleted: 14834
-  examine: "Mmmm - pie for sale!"
 - id: 2612
   examine: "Wonder what's in here..."
 - id: 2613
-  examine: "Smells kind of funny..."
 - id: 2614
   examine: "Spooky!"
 - id: 2615
@@ -4162,25 +4273,27 @@
 - id: 2641
   examine: "I can climb this."
 - id: 2642
+  examine: "Used for fashioning clay items."
 - id: 2643
+  examine: "Bake your clay items in here."
 - id: 2644
-  examine: "Shelves full of plates and tea cups."
+  examine: "Used for spinning thread."
 - id: 2645
-  examine: "Shelves full of plates and tea cups."
+  examine: "A tray of sand."
 - id: 2646
-  examine: "A picture of some desserts."
+  examine: "A plant cultivated for fibres."
 - id: 2647
-  examine: "A picture of a fruit bowl."
+  examine: "The door to the Crafting Guild."
 - id: 2648
-  examine: "A picture of a dinner."
 - id: 2649
-  examine: "For putting things on."
 - id: 2650
-  examine: "Simple but stylish."
+  examine: "A pile of smelly rotting waste."
 - id: 2651
+  examine: "A sturdy home for bees."
 - id: 2652
   examine: "Looks like this is where waste from the kitchen comes out."
 - id: 2653
+  examine: "It looks like a spiders' nest to me."
 - id: 2654
   examine: "This fountain suits the garden."
 - id: 2655
@@ -4198,6 +4311,7 @@
 - id: 2661
   examine: "Looks like this is where Frank keeps his stuff."
 - id: 2662
+  examine: "Looks like this is where the cook stores flour."
 - id: 2663
   examine: "Some sacks of general garden items."
 - id: 2664
@@ -4205,6 +4319,7 @@
 - id: 2665
   examine: "Luckily it seems able to keep that vicious dog inside."
 - id: 2666
+  examine: "Looks like the killer smashed this to leave the mansion."
 - id: 2667
   examine: "Slaves are using this to pull up barrels of rocks from down below."
 - id: 2668
@@ -4229,11 +4344,15 @@
 - id: 2678
   examine: "A selection of Captain Siad's Books."
 - id: 2679
+  examine: "A sturdy looking desk on which the Captain works."
 - id: 2680
   examine: "A barrel containing rocks and mining debris."
 - id: 2681
   examine: "An empty mining barrel."
 - id: 2682
+  examine: ">-
+    The cart which takes barrels of rocks from the mining encampment to
+    Al-Kharid."
 - id: 2683
   examine: "Gives a lovely view of the desert, complete with metalic bars."
 - id: 2684
@@ -4255,7 +4374,9 @@
 - id: 2692
   examine: "It looks fairly sturdy."
 - id: 2693
-  examine: "This is used by Shantay and his men to take items to the bank on your behalf."
+  examine: ">-
+    This is used by Shantay and his men to take items to the bank on your
+    behalf."
 - id: 2694
   examine: "A rocky rock."
 - id: 2695
@@ -4276,8 +4397,8 @@
 - id: 2703
   examine: "Tracks in the sand."
 - id: 2704
-  depleted: 18961
   examine: "Rocky!"
+  depleted: 18961
 - id: 2705
   examine: "It's a door."
 - id: 2706
@@ -4293,44 +4414,47 @@
 - id: 2711
   examine: "It's a flight of stairs."
 - id: 2712
-  examine: "There are some containers of chemicals here."
+  examine: "The door is closed."
 - id: 2713
-  examine: "There are some containers of chemicals here."
+  examine: "Grain goes in here."
 - id: 2714
-  examine: "Antique desk."
+  examine: "Grain goes in here."
 - id: 2715
-  examine: "Good doggie..."
+  examine: "Grain goes in here."
 - id: 2716
-  examine: "Covered in junk."
+  examine: "Grain goes in here."
 - id: 2717
+  examine: "Grain goes in here."
 - id: 2718
-  examine: "He must be very wise if he keeps a dead bat in his shop."
+  examine: "These control the flow of grain from the hopper to the millstones."
 - id: 2719
+  examine: "These control the flow of grain from the hopper to the millstones."
 - id: 2720
-  examine: "These might have healing properties, or they might just smell funny."
+  examine: "These control the flow of grain from the hopper to the millstones."
 - id: 2721
-  examine: "Doesn't seem to be keeping the herbs fresh."
+  examine: "These control the flow of grain from the hopper to the millstones."
 - id: 2722
-  examine: "Contains apparently useful items, mostly pickled in jars."
+  examine: "These control the flow of grain from the hopper to the millstones."
 - id: 2723
-  examine: "Suitable only for small children."
+  examine: "A spicy meat kebab is cooking here."
 - id: 2724
-  examine: "For drying clothes."
+  examine: "A fire burns brightly here."
 - id: 2725
-  examine: "Coloured bricks, suitable for entertaining young children."
+  examine: "A grand old fireplace."
 - id: 2726
-  examine: "For play-fighting."
+  examine: "A grand old fireplace."
 - id: 2727
-  examine: "In this house, the cat basket probably gets a lot of use."
+  examine: "Something is cooking nicely here."
 - id: 2728
-  examine: "A bunkbed for kids."
+  examine: "Ideal for cooking on."
 - id: 2729
-  examine: "Simple entertainment."
+  examine: "Ideal for cooking on."
 - id: 2730
-  examine: "These smell nice."
+  examine: "Ideal for cooking on."
 - id: 2731
-  examine: "These smell nice."
+  examine: "Ideal for cooking on."
 - id: 2732
+  examine: "Hot!"
 - id: 2733
 - id: 2734
 - id: 2735
@@ -4380,13 +4504,15 @@
 - id: 2779
 - id: 2780
 - id: 2781
+  examine: "A hot place for forging things in."
 - id: 2782
+  examine: "It says \"Property of Doric the dwarf.\" on the side."
 - id: 2783
-  examine: "A nice selection of swords."
+  examine: "Used for fashioning metal items."
 - id: 2784
-  examine: "Break glass in case of emergency."
+  examine: "Various implements for working with metal."
 - id: 2785
-  examine: "An interesting new way to display swords for sale."
+  examine: "A hot place for forging things in."
 - id: 2786
   examine: "An entrance to Gu'Tanoth."
 - id: 2787
@@ -4408,7 +4534,7 @@
 - id: 2795
   examine: "A lever for activating something."
 - id: 2796
-  examine: "This leads to the Watchtower."
+  examine: "This leads to the watchtower."
 - id: 2797
   examine: "This leads downwards."
 - id: 2798
@@ -4448,7 +4574,7 @@
 - id: 2815
   examine: "The gate has been locked shut."
 - id: 2816
-  examine: "A strange-looking rock."
+  examine: "A strange looking rock..."
 - id: 2817
   examine: "I think I can get out here..."
 - id: 2818
@@ -4464,13 +4590,13 @@
 - id: 2823
   examine: "A hole."
 - id: 2824
-  examine: "A hole."
+  examine: "A hole"
 - id: 2825
-  examine: "I hope this leads out."
+  examine: "I hope this leads the way out."
 - id: 2826
-  examine: "I wonder what's inside it..."
+  examine: "I wonder what's inside it?"
 - id: 2827
-  examine: "I wonder what's inside it..."
+  examine: "I wonder what's inside it?"
 - id: 2828
 - id: 2829
 - id: 2830
@@ -4496,6 +4622,7 @@
 - id: 2842
   examine: "It has a special magical quality."
 - id: 2843
+  examine: "This drain leads from the sink to the sewers below."
 - id: 2844
   examine: "This looks like it can be turned."
 - id: 2845
@@ -4548,6 +4675,7 @@
 - id: 2869
   examine: "It's a cupboard."
 - id: 2870
+  examine: "The mouse equivalent of a door."
 - id: 2871
   examine: "I can climb down this."
 - id: 2872
@@ -4579,26 +4707,28 @@
 - id: 2885
   examine: "An antique by anyone's standards."
 - id: 2886
-  examine: "An antique by anyone's standards, however, it might have something interesting in it."
+  examine: ">-
+    An antique by anyone's standards, however, it might have something
+    interesting in it."
 - id: 2887
-  depleted: 17493
   examine: "Looks good for logging."
+  depleted: 17493
 - id: 2888
   examine: "A leafy jungle palm, dense foliage."
 - id: 2889
-  depleted: 4819
   examine: "Home to many unusual creatures."
+  depleted: 4819
 - id: 2890
-  depleted: 4821
   examine: "A leafy tree."
+  depleted: 4821
 - id: 2891
   examine: "This tree has been cut down."
 - id: 2892
-  depleted: 2894
   examine: "A jungle bush, quite common to these areas."
+  depleted: 2894
 - id: 2893
-  depleted: 2894
   examine: "A jungle bush, quite common to these areas."
+  depleted: 2894
 - id: 2894
   examine: "A jungle bush that has been chopped down."
 - id: 2895
@@ -4640,6 +4770,7 @@
 - id: 2914
 - id: 2915
 - id: 2916
+  examine: "A dark cave entrance leading to the surface."
 - id: 2917
 - id: 2918
   examine: "A large crack in the wall."
@@ -4673,9 +4804,13 @@
   examine: "Strangely, there's a locked barrel here, I wonder what's inside."
 - id: 2933
 - id: 2934
-  examine: "A large scaffold platform most likely used for lifting and lowering heavy items."
+  examine: ">-
+    A large scaffold platform most likely used for lifting and lowering heavy
+    items."
 - id: 2935
-  examine: "Used to move earth to, and from, the dig shaft. A rope has been thrown over it."
+  examine: ">-
+    Used to move earth to, and from, the dig shaft. A rope has been thrown over
+    it."
 - id: 2936
   examine: "A sculpted trunk of wood."
 - id: 2937
@@ -4701,10 +4836,12 @@
 - id: 2947
   examine: " A dead Yommi tree sapling, you'll need a tough axe to remove this."
 - id: 2948
-  depleted: 2950
   examine: " A fully grown Yommi tree, it won't get much taller than this."
+  depleted: 2950
 - id: 2949
-  examine: "A dead fully grown Yommi tree, you'll need a tough, sharp axe to remove this."
+  examine: ">-
+             A dead fully grown Yommi tree, you'll need a tough, sharp axe to remove
+             this."
 - id: 2950
   examine: "A felled adult Yommi tree, perhaps you should trim those branches?"
 - id: 2951
@@ -4714,7 +4851,9 @@
 - id: 2953
   examine: "A rotten Yommi tree log, it was left too long in the damp jungle air."
 - id: 2954
-  examine: "A beautifully crafted totem pole carved from the trunk of the sacred Yommi tree."
+  examine: ">-
+    A beautifully crafted totem pole carved from the trunk of the sacred Yommi
+    tree."
 - id: 2955
   examine: "A rotten totem pole, it was left to rot in the jungle."
 - id: 2956
@@ -4758,10 +4897,11 @@
 - id: 2976
   examine: "This tree is particularly leafy."
 - id: 2977
+  examine: "A large pile of sand"
 - id: 2978
-  examine: "A display case containing weapons."
+  examine: "A medium pile of sand"
 - id: 2979
-  examine: "A display case containing weapons."
+  examine: "A small pile of sand"
 - id: 2980
   examine: "Some beautiful flowers."
 - id: 2981
@@ -4797,9 +4937,7 @@
 - id: 2996
   examine: "I wonder what's inside."
 - id: 2997
-  examine: "A display case containing weapons."
 - id: 2998
-  examine: "A dirty table covered with used pots and plates."
 - id: 2999
 - id: 3000
   examine: "These obviously mean keep out!"
@@ -4817,66 +4955,79 @@
 - id: 3012
 - id: 3013
 - id: 3014
-  examine: "Far too dirty to use."
+  examine: "A nicely fitted door."
 - id: 3015
-  examine: "A small pile of dirty dishes."
+  examine: "A wooden gate."
 - id: 3016
-  examine: "A pile of dirty dishes."
+  examine: "A wooden gate."
 - id: 3017
-  examine: "A pile of dirty dishes."
+  examine: "A nicely fitted door."
 - id: 3018
-  examine: "A display case containing weapons."
+  examine: "A nicely fitted door."
 - id: 3019
-  examine: "Fine armour for the discerning customer."
+  examine: "A nicely fitted door."
 - id: 3020
-  examine: "Fine combat kit for the discerning customer."
+  examine: "A wrought iron gate."
 - id: 3021
-  examine: "Fine swords for the discerning customer."
+  examine: "A wrought iron gate."
 - id: 3022
+  examine: "A wrought iron gate."
 - id: 3023
+  examine: "A wrought iron gate."
 - id: 3024
-  examine: "Lets you reach things on high shelves."
+  examine: "A closed door."
 - id: 3025
+  examine: "A closed door."
 - id: 3026
-  examine: "A shelf for storing stuff."
+  examine: "A closed door."
 - id: 3027
+  examine: "A closed door."
   depleted: 3227
-  examine: "A shelf for storing stuff."
 - id: 3028
-  examine: "A shelf for storing stuff."
+  examine: "I can climb this."
 - id: 3029
-  examine: "The shop counter."
+  examine: "I can climb down this."
 - id: 3030
+  examine: "I can climb this."
 - id: 3031
+  examine: "I can climb down this."
 - id: 3032
+  examine: "I can see fish swimming in the water."
   depleted: 3227
-  examine: "It's amazing how many people want to advertise their bank sales."
 - id: 3033
+  examine: "One of the most common trees in RuneScape."
   depleted: 1342
 - id: 3034
+  examine: "One of the most common trees in RuneScape."
   depleted: 7400
 - id: 3035
+  examine: "One of the most common trees in RuneScape."
 - id: 3036
+  examine: "One of the most common trees in RuneScape."
 - id: 3037
+  examine: "A beautiful old oak."
   depleted: 1355
-  examine: "A hardy evergreen pine."
 - id: 3038
+  examine: "Hot!"
   depleted: 3227
 - id: 3039
+  examine: "Ideal for cooking on."
 - id: 3040
+  examine: "It's closed."
   depleted: 3227
-  examine: "A display case containing longbows."
 - id: 3041
+  examine: "It's open."
   depleted: 3227
-  examine: "A workbench for making and repairing bows."
 - id: 3042
+  examine: "A rocky outcrop."
   depleted: 33402
 - id: 3043
+  examine: "A rocky outcrop."
   depleted: 3431
 - id: 3044
-  examine: "A display case containing weapons."
+  examine: "A hot place for forging things in."
 - id: 3045
-  examine: "A crate for storing and transporting long items."
+  examine: "The bank teller will serve you from here."
 - id: 3046
   examine: "These obviously mean keep out!"
 - id: 3047
@@ -5047,6 +5198,7 @@
 - id: 3192
   examine: "You can see the last 50 fights on here."
 - id: 3193
+  examine: "Used to store players' items whilst they duel."
 - id: 3194
   examine: "Use for quick access to your bank."
 - id: 3195
@@ -5054,9 +5206,9 @@
 - id: 3196
   examine: "Not much use for anything except scrap."
 - id: 3197
-  examine: "A huge net to catch little fish."
+  examine: "Entrance to the Duel Arena."
 - id: 3198
-  examine: "A huge net to catch little fish."
+  examine: "Entrance to the Duel Arena."
 - id: 3199
   examine: "A wooden double bed."
 - id: 3200
@@ -5066,18 +5218,15 @@
   examine: "Access to the duel arena."
 - id: 3204
 - id: 3205
-  examine: "A crate for storing and transporting long items."
+  examine: "I can climb down this."
 - id: 3206
   examine: "A barrel full of staffs..."
 - id: 3207
 - id: 3208
 - id: 3209
-  examine: "A pile of wood used for making bows."
 - id: 3210
-  examine: "A barrel of feathers for making bows."
 - id: 3211
 - id: 3212
-  examine: "Tells you roughly where to aim."
 - id: 3213
   examine: "It looks like I can squeeze through here."
 - id: 3214
@@ -5108,8 +5257,8 @@
 - id: 3228
   examine: "Best avoided."
 - id: 3229
-  depleted: 3281
   examine: "Best avoided."
+  depleted: 3281
 - id: 3230
   examine: "Looks suspicious."
 - id: 3231
@@ -5117,8 +5266,8 @@
 - id: 3232
   examine: "Formed over many years."
 - id: 3233
-  depleted: 3281
   examine: "Best avoided."
+  depleted: 3281
 - id: 3234
   examine: "Looks suspicious."
 - id: 3235
@@ -5142,8 +5291,8 @@
 - id: 3244
   examine: "The base of a platform."
 - id: 3245
-  depleted: 3281
   examine: "The base of a platform."
+  depleted: 3281
 - id: 3246
   examine: "The base of a platform."
 - id: 3247
@@ -5192,8 +5341,8 @@
 - id: 3272
   examine: "I wonder what's inside."
 - id: 3273
-  depleted: 3281
   examine: "I wonder what's inside."
+  depleted: 3281
 - id: 3274
   examine: "I wonder what's inside."
 - id: 3275
@@ -5219,7 +5368,7 @@
 - id: 3293
   depleted: 11865
 - id: 3294
-  examine: "A hot furnace."
+  examine: "A hot place for forging things in."
 - id: 3295
   examine: "It's covered in strange writing."
 - id: 3296
@@ -5231,8 +5380,8 @@
 - id: 3299
   examine: "It's covered in strange writing."
 - id: 3300
-  depleted: 11865
   examine: "It's covered in strange writing."
+  depleted: 11865
 - id: 3301
   examine: "It's covered in strange writing."
 - id: 3302
@@ -5370,10 +5519,15 @@
 - id: 3387
 - id: 3388
 - id: 3389
+  examine: "A good source of books!"
 - id: 3390
+  examine: "A strange crack cuts into the wall."
 - id: 3391
+  examine: "A strange crack cuts into the wall."
 - id: 3392
+  examine: "A strange crack cuts into the wall."
 - id: 3393
+  examine: "A strange crack cuts into the wall."
 - id: 3394
   examine: "A wooden crate for storage."
 - id: 3395
@@ -5393,20 +5547,28 @@
 - id: 3402
   examine: "Used for fashioning metal items."
 - id: 3403
+  examine: "A pile of Elemental rock."
 - id: 3404
+  examine: "A valve to start and stop the flow of water."
 - id: 3405
+  examine: "A valve to start and stop the flow of water."
 - id: 3406
   examine: "This lever can be operated."
 - id: 3407
+  examine: "It spins."
 - id: 3408
   examine: "It spins."
 - id: 3409
   examine: "This lever can be operated."
 - id: 3410
+  examine: "Big bellows."
 - id: 3411
+  examine: "Big bellows."
 - id: 3412
 - id: 3413
+  examine: "A furnace with an air blast pipe."
 - id: 3414
+  examine: "A small trough full of lava."
 - id: 3415
   examine: "I can climb down these stairs."
 - id: 3416
@@ -5418,7 +5580,6 @@
 - id: 3420
 - id: 3421
 - id: 3422
-  examine: "Unpowered machinery"
 - id: 3423
 - id: 3424
 - id: 3425
@@ -5426,9 +5587,10 @@
 - id: 3427
 - id: 3428
 - id: 3429
+  examine: "Water powered machinery."
 - id: 3430
 - id: 3431
-  examine: "Tells you roughly where to aim."
+  examine: "Stoney!"
 - id: 3432
   examine: "I wonder what's under it?"
 - id: 3433
@@ -5645,7 +5807,7 @@
 - id: 3576
   examine: "Walk the plank! Ya land lubber!"
 - id: 3577
-  examine: "I see dead people."
+  examine: "Walk the plank! Ya land lubber!"
 - id: 3578
   examine: "It's a small step for a player, a giant leap for player kind."
 - id: 3579
@@ -5705,53 +5867,44 @@
 - id: 3622
 - id: 3623
 - id: 3624
-  examine: "Maybe it's for shooting at?"
 - id: 3625
-  examine: "All books about runes..."
 - id: 3626
+  examine: "It looks very sturdy."
 - id: 3627
-  examine: "A shelf of esoteric junk."
 - id: 3628
-  examine: "Nicely fitted shelves."
+  examine: "It looks very sturdy."
 - id: 3629
+  examine: "It looks very sturdy."
 - id: 3630
+  examine: "It looks very sturdy."
 - id: 3631
+  examine: "It looks very sturdy."
 - id: 3632
-  examine: "Generally used for sitting."
+  examine: "It looks very sturdy."
 - id: 3633
-  examine: "What pulls these?"
 - id: 3634
+  examine: "A shrine of the gods!"
 - id: 3635
+  examine: "I wonder what's inside..."
 - id: 3636
+  examine: "It looks empty."
 - id: 3637
 - id: 3638
 - id: 3639
 - id: 3640
-  examine: "A handy source of water."
 - id: 3641
-  examine: "A pretty water feature."
 - id: 3642
-  examine: "A statue of a famous knight."
 - id: 3643
-  examine: "A statue of a famous old knight."
 - id: 3644
-  examine: "Animal feeder."
+  examine: "That's really bright!"
 - id: 3645
-  examine: "It's like a land rudder."
 - id: 3646
-  examine: "Best used with a bucket."
 - id: 3647
-  examine: "Rows of sharp pointy spears."
 - id: 3648
-  examine: "Living in the big city isn't easy."
 - id: 3649
-  examine: "Count the rings and see how long it lived."
 - id: 3650
-  examine: "A cave."
 - id: 3651
-  examine: "Looks like this part of the entrance is blocked by rubble."
 - id: 3652
-  examine: "A cave."
 - id: 3653
 - id: 3654
 - id: 3655
@@ -5762,7 +5915,7 @@
 - id: 3660
 - id: 3661
 - id: 3662
-  examine: "I hope it wasn't anyone I knew."
+  examine: "Smells more like \"innocent villager\" stew to me..."
 - id: 3663
 - id: 3664
 - id: 3665
@@ -5882,15 +6035,11 @@
 - id: 3750
 - id: 3751
 - id: 3752
-  examine: "A cave."
+  examine: "Unusual energy is gathered here."
 - id: 3753
-  examine: "A pile of large rocks."
 - id: 3754
-  examine: "A pile of large rocks."
 - id: 3755
-  examine: "Ruined stonework."
 - id: 3756
-  examine: "There is a very, very old picture carved in this..."
 - id: 3757
   examine: "Looks like a small cave."
 - id: 3758
@@ -6017,12 +6166,13 @@
 - id: 3826
   examine: "A tooth shaped rock formation protruding from the floor."
 - id: 3827
+  examine: "How am I going to get down there?"
 - id: 3828
-  examine: "I can climb down this rope."
+  examine: "How am I going to get down there?"
 - id: 3829
   examine: "I hope this holds!"
 - id: 3830
-  examine: "This compost bin contains compostable items (1/15)."
+  examine: "How am I going to get down there?"
 - id: 3831
   examine: "How am I going to get down there?"
 - id: 3832
@@ -6031,45 +6181,25 @@
   examine: "It's moving..."
 - id: 3834
 - id: 3835
-  examine: "This compost bin contains compostable items (2/15)."
 - id: 3836
-  examine: "This compost bin contains compostable items (3/15)."
 - id: 3837
-  examine: "This compost bin contains compostable items (4/15)."
 - id: 3838
-  examine: "This compost bin contains compostable items (5/15)."
 - id: 3839
-  examine: "This compost bin contains compostable items (6/15)."
 - id: 3840
-  examine: "This compost bin contains compostable items (7/15)."
 - id: 3841
-  examine: "This compost bin contains compostable items (8/15)."
 - id: 3842
-  examine: "This compost bin contains compostable items (9/15)."
 - id: 3843
-  examine: "This compost bin contains compostable items (10/15)."
 - id: 3844
-  examine: "This compost bin contains compostable items (11/15)."
 - id: 3845
-  examine: "This compost bin contains compostable items (12/15)."
 - id: 3846
-  examine: "This compost bin contains compostable items (13/15)."
 - id: 3847
-  examine: "This compost bin contains compostable items (14/15)."
 - id: 3848
-  examine: "This compost bin is full of compostable items."
 - id: 3849
-  examine: "Vegetation is rotting in here to make compost."
 - id: 3850
-  examine: "The compost is ready."
 - id: 3851
-  examine: "This compost bin contains compost (1/15)."
 - id: 3852
-  examine: "This compost bin contains compost (2/15)."
 - id: 3853
-  examine: "This compost bin contains compost (3/15)."
 - id: 3854
-  examine: "This compost bin contains compost (4/15)."
 - id: 3855
 - id: 3856
   examine: "It's a half buried crate."
@@ -6103,19 +6233,19 @@
 - id: 3877
 - id: 3878
 - id: 3879
-  depleted: 3884
   examine: "A tree."
+  depleted: 3884
 - id: 3880
   examine: "It's a tree stump."
 - id: 3881
-  depleted: 3884
   examine: "A tree."
+  depleted: 3884
 - id: 3882
+  examine: "A tree."
   depleted: 3884
-  examine: "A tree."
 - id: 3883
-  depleted: 3880
   examine: "A tree."
+  depleted: 3880
 - id: 3884
   examine: "It's a tree stump."
 - id: 3885
@@ -6344,15 +6474,15 @@
 - id: 4026
   examine: "A still for fractionalizing oils."
 - id: 4027
+  examine: "A pile of lime rock."
   depleted: 4029
-  examine: "A dead palm stump."
 - id: 4028
+  examine: "A pile of lime rock."
   depleted: 4029
-  examine: "A dead tree."
 - id: 4029
-  examine: "A dead tree."
+  examine: "A pile of lime rock."
 - id: 4030
-  examine: "A terribly tall tropical tree."
+  examine: "A pile of lime rock."
 - id: 4031
   examine: "Looks like a stone doorway to me."
 - id: 4032
@@ -6397,12 +6527,12 @@
 - id: 4057
   examine: "These fat fungi take up so much room."
 - id: 4058
-  examine: "Some clothes hang here to dry."
+  examine: "A pipe I can squeeze through."
 - id: 4059
-  examine: "Some clothes hang here to dry."
+  examine: "I can balance on this rope."
 - id: 4060
+  examine: "It's hollow..."
   depleted: 4061
-  examine: "The upper deck can be accessed with this ladder."
 - id: 4061
   examine: "This tree has been cut down."
 - id: 4062
@@ -6412,7 +6542,7 @@
 - id: 4064
   examine: "This table has seen better days."
 - id: 4065
-  examine: "It looks very ornamental in a practical 'solid rock' way."
+  examine: "Welcome to Mort'ton"
 - id: 4066
   examine: "Welcome to Mort'ton"
 - id: 4067
@@ -6557,9 +6687,9 @@
 - id: 4138
   examine: "Items are for sale here."
 - id: 4139
-  examine: "Back down to the main deck."
+  examine: "Entrance to the Duel Arena."
 - id: 4140
-  examine: "This old trawler has seen better days."
+  examine: "Entrance to the Duel Arena."
 - id: 4141
   examine: "This seems to be some kind of shrine."
 - id: 4142
@@ -6623,9 +6753,7 @@
 - id: 4172
   examine: "An appliance for cooking with."
 - id: 4173
-  examine: "I wonder what's down there?"
 - id: 4174
-  examine: "I wonder what's under it?"
 - id: 4175
   examine: "Kind of funny smelling..."
 - id: 4176
@@ -6801,8 +6929,9 @@
 - id: 4302
 - id: 4303
 - id: 4304
-  examine: "A hot furnace."
+  examine: "A hot place for forging things in."
 - id: 4305
+  examine: "A hot place for forging things in."
 - id: 4306
   examine: "Used for fashioning metal items."
 - id: 4307
@@ -6864,7 +6993,7 @@
 - id: 4351
   examine: "I can hear the sea with this."
 - id: 4352
-  examine: "A half-buried bowl."
+  examine: "It is a buried Bowl."
 - id: 4353
 - id: 4354
 - id: 4355
@@ -6971,21 +7100,13 @@
 - id: 4422
   examine: "A spiky barricade."
 - id: 4423
-  examine: "A large double door."
 - id: 4424
-  examine: "A large double door."
 - id: 4425
-  examine: "A large double door."
 - id: 4426
-  examine: "A large double door."
 - id: 4427
-  examine: "A large double door."
 - id: 4428
-  examine: "A large double door."
 - id: 4429
-  examine: "A large double door."
 - id: 4430
-  examine: "A large double door."
 - id: 4431
   examine: "A large broken door."
 - id: 4432
@@ -7040,21 +7161,13 @@
 - id: 4464
   examine: "There are some pickaxes on this table."
 - id: 4465
-  examine: "An elf-fashioned door."
 - id: 4466
-  examine: "An elf-fashioned door."
 - id: 4467
-  examine: "The door is closed."
 - id: 4468
-  examine: "The door is open."
 - id: 4469
-  examine: "Only the Saradomin team may pass."
 - id: 4470
-  examine: "Only the Zamorak team may pass."
 - id: 4471
-  examine: "I wonder what's under it?"
 - id: 4472
-  examine: "I wonder what's under it?"
 - id: 4473
 - id: 4474
 - id: 4475
@@ -7071,33 +7184,39 @@
 - id: 4484
   examine: "Keep track of which team has the most victories."
 - id: 4485
+  examine: "I could climb this if I wanted."
 - id: 4486
 - id: 4487
-  examine: "Some clothes hang here to dry."
+  examine: "A big wooden door."
 - id: 4488
-  examine: "Flying vermin."
 - id: 4489
-  examine: "Flying vermin."
 - id: 4490
-  examine: "A trophy of a mighty slayer!"
+  examine: "A big wooden door."
 - id: 4491
-  examine: "A trophy of a master fisher."
+  examine: "A big wooden door."
 - id: 4492
-  examine: "A trophy of a master fisher."
+  examine: "A big wooden door."
 - id: 4493
+  examine: "I can climb these stairs."
 - id: 4494
+  examine: "They go down."
 - id: 4495
+  examine: "I can climb these stairs."
 - id: 4496
+  examine: "They go down."
 - id: 4497
+  examine: "I can climb these stairs."
 - id: 4498
+  examine: "They go down."
 - id: 4499
+  examine: "Wow - it's a guinea pig! No, hang on, it's a cave."
 - id: 4500
+  examine: "This leads back to the cruel world above."
 - id: 4501
 - id: 4502
 - id: 4503
 - id: 4504
 - id: 4505
-  examine: "Pots and pans."
 - id: 4506
 - id: 4507
 - id: 4508
@@ -7106,60 +7225,39 @@
 - id: 4511
 - id: 4512
 - id: 4513
+  examine: "I doubt that was built to last..."
 - id: 4514
 - id: 4515
-  examine: "You can build a chair here."
 - id: 4516
-  examine: "You can build a chair here."
 - id: 4517
-  examine: "You can build a chair here."
 - id: 4518
-  examine: "You can build a rug here."
+  examine: "How do you make a skeleton laugh?"
 - id: 4519
-  examine: "You can build a rug here."
+  examine: "Tickle his funny bone."
 - id: 4520
-  examine: "You can build a rug here."
+  examine: "Clearly has been relaxing too long...."
 - id: 4521
-  examine: "You can build a bookcase here."
 - id: 4522
-  examine: "You can build a bookcase here."
 - id: 4523
-  examine: "You can build a fireplace here."
 - id: 4524
-  examine: "You can build curtains here"
 - id: 4525
-  examine: "Use this to leave the house."
 - id: 4526
-  examine: "Rocky!"
 - id: 4527
-  examine: "A home for tiny fish and frogs."
 - id: 4528
-  examine: "What a naughty little imp!"
 - id: 4529
-  examine: "What horrors lurk below?"
 - id: 4530
 - id: 4531
-  examine: "One of the most common trees in RuneScape."
 - id: 4532
-  examine: "One of the most common trees in RuneScape."
 - id: 4533
-  examine: "A beautiful oak tree."
 - id: 4534
-  examine: "A lovely addition to the garden."
 - id: 4535
-  examine: "A lovely addition to the garden."
 - id: 4536
-  examine: "A lovely addition to the garden."
 - id: 4537
-  examine: "The tree shimmers with a magical force."
 - id: 4538
-  examine: "A spooky addition to the garden."
 - id: 4539
-  examine: "A lovely addition to the garden."
 - id: 4540
-  examine: "A lovely addition to the garden."
 - id: 4541
-  examine: "A lovely addition to the garden."
+  examine: "Did that thing just twitch?"
 - id: 4542
 - id: 4543
   examine: "A strange wall with objects engraved upon it."
@@ -7173,7 +7271,7 @@
 - id: 4548
 - id: 4549
 - id: 4550
-  examine: "Safety!"
+  examine: "I can jump off this one."
 - id: 4551
   examine: "I can jump off this one."
 - id: 4552
@@ -7191,7 +7289,7 @@
 - id: 4558
   examine: "I can jump off this one."
 - id: 4559
-  examine: "It looks barren"
+  examine: "I can jump off this one."
 - id: 4560
 - id: 4561
 - id: 4562
@@ -7287,32 +7385,21 @@
   examine: "They go up."
 - id: 4628
 - id: 4629
-  examine: "A large double door."
 - id: 4630
-  examine: "A large double door."
 - id: 4631
-  examine: "A large double door."
 - id: 4632
-  examine: "A large double door."
 - id: 4633
-  examine: "A large double door."
 - id: 4634
-  examine: "A large double door."
 - id: 4635
 - id: 4636
-  examine: "An ornately fashioned door."
 - id: 4637
-  examine: "An ornately fashioned door."
 - id: 4638
-  examine: "An ornately fashioned door."
 - id: 4639
-  examine: "An ornately fashioned door."
 - id: 4640
-  examine: "An ornately fashioned door."
 - id: 4641
   examine: "Mmm...beer!"
 - id: 4642
-  examine: "Some helpful people have placed notes on here, how nice."
+  examine: "Has some board games news on it."
 - id: 4643
   examine: "The ladder to the Runelink challenge room for experienced players."
 - id: 4644
@@ -7355,17 +7442,16 @@
 - id: 4667
 - id: 4668
 - id: 4669
-  examine: "A statue of the hero Arrav."
+  examine: "A statue of Arrav (the Fountain of Heroes has moved downstairs.)"
 - id: 4670
-  examine: "A statue of the hero Camorra."
+  examine: "A statue of Camorra (the Fountain of Heroes has moved downstairs.)"
 - id: 4671
   examine: "A good source of books!"
 - id: 4672
-  examine: "The door into the throne room."
 - id: 4673
 - id: 4674
-  depleted: 7400
   examine: "I bet this makes good syrup!"
+  depleted: 7400
 - id: 4675
   examine: "Scented herbs."
 - id: 4676
@@ -7427,9 +7513,7 @@
   examine: "A doorway made from bamboo."
 - id: 4711
 - id: 4712
-  examine: "It's a trapdoor."
 - id: 4713
-  examine: "It's an open trapdoor."
 - id: 4714
   examine: "A wooden crate for storage."
 - id: 4715
@@ -7476,9 +7560,7 @@
 - id: 4741
 - id: 4742
 - id: 4743
-  examine: "It's a bamboo ladder."
 - id: 4744
-  examine: "It's a bamboo ladder."
 - id: 4745
   examine: "Looks good for jumping off."
 - id: 4746
@@ -7515,23 +7597,15 @@
 - id: 4766
   examine: "It's a sheer wall of fire, rising as high as you can see."
 - id: 4767
-  examine: "The contents of this pyre are rapidly bubbling and burning."
 - id: 4768
-  examine: "It's a wall of bricks."
 - id: 4769
-  examine: "It's a pile of bricks."
 - id: 4770
-  examine: "It's a pile of bricks."
 - id: 4771
   examine: "A rather dapper little monkey sitting on a throne."
 - id: 4772
-  examine: "It's a bamboo ladder."
 - id: 4773
-  examine: "It's a bamboo ladder."
 - id: 4774
-  examine: "It's a bamboo ladder."
 - id: 4775
-  examine: "It's a bamboo ladder."
 - id: 4776
   examine: "It's a bamboo ladder."
 - id: 4777
@@ -7543,7 +7617,6 @@
 - id: 4780
   examine: "It's a bamboo ladder."
 - id: 4781
-  examine: "It's a bamboo ladder."
 - id: 4782
 - id: 4783
 - id: 4784
@@ -7582,7 +7655,6 @@
 - id: 4805
 - id: 4806
 - id: 4807
-  examine: "It's a door made from bamboo."
 - id: 4808
 - id: 4809
 - id: 4810
@@ -7600,13 +7672,13 @@
 - id: 4817
   examine: "A jungle palm with dense foliage."
 - id: 4818
-  depleted: 4819
   examine: "This is a fairly tall tree with sparse foliage."
+  depleted: 4819
 - id: 4819
   examine: "This was a fairly tall tree with sparse foliage."
 - id: 4820
-  depleted: 4821
   examine: "A leafy tree."
+  depleted: 4821
 - id: 4821
   examine: "This was a fairly tall tree with sparse foliage."
 - id: 4822
@@ -7715,9 +7787,7 @@
 - id: 4878
   examine: "This table has a scimitar on it."
 - id: 4879
-  examine: "It's a trapdoor."
 - id: 4880
-  examine: "It's an open trapdoor."
 - id: 4881
   examine: "I can climb up this."
 - id: 4882
@@ -7733,7 +7803,6 @@
 - id: 4887
   examine: "Looks suspicious."
 - id: 4888
-  examine: "It's a trapdoor."
 - id: 4889
   examine: "I can climb up this."
 - id: 4890
@@ -7858,9 +7927,7 @@
 - id: 4962
   examine: "The door is closed."
 - id: 4963
-  examine: "A large double door."
 - id: 4964
-  examine: "A large double door."
 - id: 4965
   examine: "I can climb down this."
 - id: 4966
@@ -7884,47 +7951,60 @@
 - id: 4975
   examine: "An old crate for storage."
 - id: 4976
-  examine: "This old trawler has seen better days."
+  examine: "A distinctive layer in the rock strata."
 - id: 4977
-  examine: "Handy for boarding boats."
+  examine: "A distinctive layer in the rock strata."
 - id: 4978
-  examine: "Handy for boarding boats."
+  examine: "A distinctive layer in the rock strata."
 - id: 4979
-  examine: "A fully-grown herb."
+  examine: "A distinctive layer in the rock strata."
 - id: 4980
-  examine: "A fully-grown herb."
+  examine: "A distinctive layer in the rock strata."
 - id: 4981
-  examine: "A fully-grown herb."
+  examine: "A distinctive layer in the rock strata."
 - id: 4982
-  examine: "A fully-grown herb."
+  examine: "A distinctive layer in the rock strata."
 - id: 4983
-  examine: "Tickle his funny bone."
+  examine: "A distinctive layer in the rock strata."
 - id: 4984
-  examine: "Clearly has been relaxing too long...."
+  examine: "A distinctive layer in the rock strata."
 - id: 4985
+  examine: "A distinctive layer in the rock strata."
 - id: 4986
+  examine: "A distinctive layer in the rock strata."
 - id: 4987
+  examine: "A distinctive layer in the rock strata."
 - id: 4988
+  examine: "A distinctive layer in the rock strata."
 - id: 4989
+  examine: "A distinctive layer in the rock strata."
 - id: 4990
+  examine: "A distinctive layer in the rock strata."
 - id: 4991
+  examine: "A distinctive layer in the rock strata."
 - id: 4992
+  examine: "A distinctive layer in the rock strata."
 - id: 4993
+  examine: "A distinctive layer in the rock strata."
 - id: 4994
+  examine: "A distinctive layer in the rock strata."
 - id: 4995
+  examine: "A distinctive layer in the rock strata."
 - id: 4996
+  examine: "A distinctive layer in the rock strata."
 - id: 4997
 - id: 4998
 - id: 4999
 - id: 5000
 - id: 5001
-  examine: "This cave has been boarded up."
 - id: 5002
   examine: "Useful for passing over inaccessible areas."
 - id: 5003
+  examine: "It's old and pretty broken."
 - id: 5004
+  examine: "A well used tree."
 - id: 5005
-  examine: "A terribly tall tropical tree."
+  examine: "A well used tree."
 - id: 5006
   examine: "These flowers only grow in one place in the mountains."
 - id: 5007
@@ -7986,7 +8066,7 @@
 - id: 5046
   examine: "A small cave entrance."
 - id: 5047
-  examine: "Tooth shaped limestones, growing from the floor upward."
+  examine: "Limestone ceiling growth."
 - id: 5048
   examine: "A limestone ceiling growth."
 - id: 5049
@@ -8028,7 +8108,7 @@
 - id: 5070
 - id: 5071
 - id: 5072
-  examine: "A large pillar."
+  examine: "A Large Pillar"
 - id: 5073
 - id: 5074
 - id: 5075
@@ -8039,57 +8119,62 @@
 - id: 5080
 - id: 5081
 - id: 5082
+  examine: "An overgrown dungeon entrance."
 - id: 5083
-  examine: "A watermill, how charming."
+  examine: "A closed overgrown dungeon entrance."
 - id: 5084
-  examine: "A sunset."
+  examine: "The way to go when I get scared."
 - id: 5085
-  examine: "A view of mountains."
 - id: 5086
-  examine: "A river winding through a valley."
 - id: 5087
 - id: 5088
+  examine: "I hope I don't fall off this."
 - id: 5089
 - id: 5090
+  examine: "I hope I don't fall off this."
 - id: 5091
 - id: 5092
 - id: 5093
 - id: 5094
-  examine: "'A Beginner's Guide to Killing Things', by Ali Morrisane."
+  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 5095
+  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 5096
-  examine: "Where there's smoke, there's pollution."
+  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 5097
-  examine: "It's venting."
+  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 5098
-  examine: "Unregulated carbon emissions - how irresponsible!"
+  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 5099
+  examine: "A pipe I can squeeze through."
 - id: 5100
+  examine: "A pipe I can squeeze through."
 - id: 5101
 - id: 5102
 - id: 5103
-  examine: "Decorated in the colours of Varrock."
+  examine: "Thick vines blocking your way."
 - id: 5104
+  examine: "Thick vines blocking your way."
 - id: 5105
+  examine: "Thick vines blocking your way."
 - id: 5106
-  examine: "For storage."
+  examine: "Thick vines blocking your way."
 - id: 5107
-  examine: "For storage."
+  examine: "Thick vines blocking your way."
 - id: 5108
-  examine: "I wonder what's inside."
 - id: 5109
-  examine: "Perhaps I should search it."
 - id: 5110
-  examine: "For storage."
+  examine: "I can jump from this stepping stone."
 - id: 5111
-  examine: "Small wooden boxes."
+  examine: "I can jump from this stepping stone."
 - id: 5112
-  examine: "RuneScape, land of a thousand barrels."
+  examine: "Not good for eating."
 - id: 5113
-  examine: "For storage."
+  examine: "I doubt that's edible."
 - id: 5114
-  examine: "Somewhere there's a very busy cooper."
+  examine: "I doubt that's edible."
 - id: 5115
+  examine: "I doubt that's edible."
 - id: 5116
   examine: "A statue of a big monster."
 - id: 5117
@@ -8098,74 +8183,64 @@
 - id: 5119
 - id: 5120
 - id: 5121
-  examine: "A lovely addition to the garden."
 - id: 5122
-  examine: "A splendid barrel."
+  examine: "Now that's what I call slimline!"
 - id: 5123
-  examine: "A wooden barrel for storage."
+  examine: "He looks very relaxed."
 - id: 5124
+  examine: "Now he's just too thin."
 - id: 5125
-  examine: "A pretty fountain."
+  examine: "He hasn't eaten in a long time."
 - id: 5126
-  examine: "A lovely addition to the garden."
+  examine: "A tall wooden door."
 - id: 5127
-  examine: "The tree shimmers with a magical force."
+  examine: "Danger!"
 - id: 5128
-  examine: "A plant."
+  examine: "A tall wooden door."
 - id: 5129
-  examine: "A plant."
 - id: 5130
-  examine: "A plant."
+  examine: "Looks like whoever uses this has claws on their hands."
 - id: 5131
-  examine: "A plant."
 - id: 5132
-  examine: "A plant."
 - id: 5133
-  examine: "A plant."
+  examine: "A hurdle."
 - id: 5134
-  examine: "A plant."
+  examine: "A hurdle."
 - id: 5135
-  examine: "A plant."
+  examine: "A hurdle."
 - id: 5136
-  examine: "A plant."
+  examine: "A climbing wall made from skulls."
 - id: 5137
-  examine: "A plant."
 - id: 5138
-  examine: "A plant."
+  examine: "A very slippery stepping stone."
 - id: 5139
-  examine: "A plant."
+  examine: "A scary zip line for teeth??"
 - id: 5140
-  examine: "A little orange flower."
+  examine: "A scary zip line for teeth??"
 - id: 5141
-  examine: "Lonely as a cloud."
+  examine: "A scary zip line for teeth??"
 - id: 5142
-  examine: "The bluebells are coming!"
+  examine: "A scary zip line for teeth??"
 - id: 5143
-  examine: "A little orange flower."
+  examine: "A scary zip line for teeth??"
 - id: 5144
-  examine: "Lonely as a cloud."
+  examine: "A scary zip line for teeth??"
 - id: 5145
-  examine: "The bluebells are coming!"
+  examine: "A scary zip line for teeth??"
 - id: 5146
-  examine: "A great big sunny flower."
+  examine: "A goal."
 - id: 5147
-  examine: "Lovely flowers."
+  examine: "A goal."
 - id: 5148
-  examine: "They smell lovely."
+  examine: "A goal."
 - id: 5149
-  examine: "Great big sunny flowers."
 - id: 5150
-  examine: "Lovely flowers."
 - id: 5151
-  examine: "They smell lovely."
 - id: 5152
-  examine: "They mark a square."
+  examine: "A pipe I can squeeze through."
 - id: 5153
-  examine: "Would probably not stop a charging rhinoceros."
 - id: 5154
-  examine: "Very rural."
 - id: 5155
-  examine: "A little bleak."
 - id: 5156
   examine: "This may be worth opening."
 - id: 5157
@@ -8212,7 +8287,9 @@
 - id: 5179
   examine: "Mmm.. scented candles."
 - id: 5180
+  examine: "I wouldn't eat there!"
 - id: 5181
+  examine: "I wouldn't eat there!"
 - id: 5182
 - id: 5183
   examine: "Looks wooden. Feels wooden. I wonder is it wooden?"
@@ -8317,43 +8394,60 @@
 - id: 5258
   examine: "These may hurt."
 - id: 5259
-  examine: "A terribly tall tropical tree."
 - id: 5260
-  examine: "A terribly tall tropical tree."
 - id: 5261
-  examine: "This tree no doubt contains dangerous insects."
 - id: 5262
-  examine: "This tree no doubt contains dangerous insects."
+  examine: "These stairs were carved out of the rock of the cavern."
 - id: 5263
-  examine: "This tree no doubt contains dangerous insects."
+  examine: "These stairs were carved out of the rock of the cavern."
 - id: 5264
+  examine: "I can climb this."
 - id: 5265
+  examine: "I can climb up here."
 - id: 5266
+  examine: "I can go below decks with this ladder."
 - id: 5267
-  examine: "Dead palm leaves."
 - id: 5268
-  examine: "Dead palm leaves."
 - id: 5269
-  examine: "I can climb up these stairs."
+  examine: "I can't see a rock!"
 - id: 5270
-  examine: "I can climb down these stairs."
+  examine: "I wonder what's inside."
 - id: 5271
+  examine: "I wonder what's inside."
 - id: 5272
+  examine: "I wonder what's inside."
 - id: 5273
+  examine: "Perhaps I should search it."
 - id: 5274
+  examine: "High above here is a tattered flag, blowing in the wind."
 - id: 5275
+  examine: "An appliance for cooking with."
 - id: 5276
+  examine: "The bank teller will serve you from here."
 - id: 5277
+  examine: "This booth is closed."
 - id: 5278
+  examine: "The resting place of Necrovarus' mortal body."
 - id: 5279
+  examine: "The resting place of Necrovarus' mortal body."
 - id: 5280
+  examine: "I can climb these stairs."
 - id: 5281
+  examine: "They go down."
 - id: 5282
+  examine: ">-
+    A ghastly fountain filled with slime and bones, the source of Necrovarus'
+    power."
 - id: 5283
+  examine: "It's a small Ectofuntus."
 - id: 5284
+  examine: "A big grinding thing."
 - id: 5285
+  examine: "The tatty gangplank of a tatty ship."
 - id: 5286
+  examine: "The tatty gangplank of a tatty ship."
 - id: 5287
+  examine: "Seen better days."
 - id: 5288
 - id: 5289
 - id: 5290
@@ -8561,19 +8655,33 @@
 - id: 5459
 - id: 5460
 - id: 5461
+  examine: "A subterranean pool of ectoplasm."
 - id: 5462
+  examine: "A subterranean pool of ectoplasm."
 - id: 5463
+  examine: "A subterranean pool of ectoplasm."
 - id: 5464
+  examine: "A subterranean pool of ectoplasm."
 - id: 5465
+  examine: "A subterranean pool of ectoplasm."
 - id: 5466
+  examine: "A subterranean pool of ectoplasm."
 - id: 5467
+  examine: "A subterranean pool of ectoplasm."
 - id: 5468
+  examine: "A subterranean pool of ectoplasm."
 - id: 5469
+  examine: "A subterranean pool of ectoplasm."
 - id: 5470
+  examine: "A subterranean pool of ectoplasm."
 - id: 5471
+  examine: "A subterranean pool of ectoplasm."
 - id: 5472
+  examine: "A subterranean pool of ectoplasm."
 - id: 5473
+  examine: "A subterranean pool of ectoplasm."
 - id: 5474
+  examine: "A subterranean pool of ectoplasm."
 - id: 5475
 - id: 5476
 - id: 5477
@@ -8592,9 +8700,7 @@
 - id: 5489
   examine: "The finest rings."
 - id: 5490
-  examine: "I wonder what's under it?"
 - id: 5491
-  examine: "I wonder what's down there?"
 - id: 5492
 - id: 5493
   examine: "I can climb this."
@@ -8676,11 +8782,13 @@
 - id: 5550
   examine: "A cure for nettle stings."
 - id: 5551
+  examine: "A droopy tree."
 - id: 5552
+  examine: "These trees are found near water."
 - id: 5553
-  examine: "Cave exit."
+  examine: "These trees are found near water."
 - id: 5554
-  examine: "A suit of armour with a Varrock shield."
+  examine: "This is what is left of a willow tree."
 - id: 5555
   examine: "I don't know art, but I like it!"
 - id: 5556
@@ -8710,9 +8818,9 @@
 - id: 5571
   examine: "An empty home for chickens."
 - id: 5572
-  examine: "A lovely, bare chicken coop."
+  examine: "A lovely bare chicken coop."
 - id: 5573
-  examine: "A lovely, bare chicken coop."
+  examine: "A lovely bare chicken coop."
 - id: 5574
   examine: "Full of animal feed."
 - id: 5575
@@ -8812,9 +8920,9 @@
   examine: "A standard of Lumbridge Castle."
 - id: 5630
 - id: 5631
-  examine: "Marks the boundary of the garden."
+  examine: "Glowing embers."
 - id: 5632
-  examine: "Just like in Varrock palace!"
+  examine: "Glowing embers."
 - id: 5633
 - id: 5634
 - id: 5635
@@ -8850,7 +8958,6 @@
 - id: 5665
 - id: 5666
 - id: 5667
-  examine: "A sturdy wooden door."
 - id: 5668
 - id: 5669
 - id: 5670
@@ -9015,21 +9122,13 @@
 - id: 5798
   examine: "It's a large crack in the wall."
 - id: 5799
-  examine: "It's a trapdoor."
 - id: 5800
-  examine: "It's a trapdoor."
 - id: 5801
-  examine: "It's a trapdoor."
 - id: 5802
-  examine: "It's a trapdoor."
 - id: 5803
-  examine: "It's an open trapdoor."
 - id: 5804
-  examine: "It's an open trapdoor."
 - id: 5805
-  examine: "It's an open trapdoor."
 - id: 5806
-  examine: "It's an open trapdoor."
 - id: 5807
 - id: 5808
   examine: "An incredibly detailed stone sculpture."
@@ -9039,11 +9138,14 @@
   examine: "Helps the Seers predict the weather."
 - id: 5811
 - id: 5812
+  examine: "I can climb this."
 - id: 5813
   examine: "I can climb down this."
 - id: 5814
 - id: 5815
-  examine: "A candle, a lens and some sort of crystal all precariously balanced together."
+  examine: ">-
+    A candle, a lens and some sort of crystal all precariously balanced
+    together."
 - id: 5816
   examine: "A beacon so gnome gliders can safely land."
 - id: 5817
@@ -9054,8 +9156,10 @@
   examine: "A beacon so gnome gliders can safely land."
 - id: 5820
 - id: 5821
+  examine: "Fly Gnome Air."
 - id: 5822
 - id: 5823
+  examine: "This shop deals in antique swords."
 - id: 5824
 - id: 5825
   examine: "Fly Gnome Air."
@@ -9071,6 +9175,7 @@
 - id: 5833
 - id: 5834
 - id: 5835
+  examine: "Don't want to close this, I might not be able to get back down."
 - id: 5836
 - id: 5837
 - id: 5838
@@ -9104,7 +9209,9 @@
 - id: 5854
   examine: "Someone put a plank on top of the stone! Clever..."
 - id: 5855
-  examine: "The pool looks very peaceful. You can also hear faint singing coming from it."
+  examine: ">-
+    The pool looks very peaceful. You can also hear faint singing coming from
+    it."
 - id: 5856
   examine: "The legendary White Pearl fruit is growing on these thorny bushes!"
 - id: 5857
@@ -9116,6 +9223,7 @@
 - id: 5860
   examine: "Very pointy, very sharp."
 - id: 5861
+  examine: "This is the place where you buried Asleif."
 - id: 5862
   examine: "This is the place where you buried Asleif."
 - id: 5863
@@ -9170,7 +9278,9 @@
 - id: 5896
   examine: "Uh oh, someone is going to be in trouble!"
 - id: 5897
-  examine: "The pool looks very peaceful. You can also hear faint singing coming from it."
+  examine: ">-
+    The pool looks very peaceful. You can also hear faint singing coming from
+    it."
 - id: 5898
 - id: 5899
 - id: 5900
@@ -9185,7 +9295,6 @@
   examine: "This tree has been cut down."
 - id: 5906
 - id: 5907
-  examine: "Very posh!"
 - id: 5908
 - id: 5909
   examine: "A still for making lamp oil."
@@ -9252,6 +9361,7 @@
 - id: 5961
 - id: 5962
 - id: 5963
+  examine: "Flying in mid-air!"
 - id: 5964
   examine: "Flying in mid-air!"
 - id: 5965
@@ -9298,10 +9408,12 @@
   examine: "A rock."
 - id: 5988
 - id: 5989
-- id: 5992
+  examine: "A mineral vein that looks distinctly like gold."
+  depleted: 5992
 - id: 5990
-  examine: "A collapsed mineral deposit."
+  examine: "A mineral vein that looks distinctly like gold."
 - id: 5991
+  examine: "A mineral vein that looks distinctly like gold."
 - id: 5992
 - id: 5993
 - id: 5994
@@ -9311,7 +9423,6 @@
 - id: 5998
   examine: "Functions like an open door..."
 - id: 5999
-  examine: "A mineral vein that looks distinctly like gold."
 - id: 6000
 - id: 6001
 - id: 6002
@@ -9574,6 +9685,7 @@
 - id: 6176
   examine: "Oblong boxes. You hope there isn't anything other than salt inside."
 - id: 6177
+  examine: "Big mysterious crates. You wonder what could be inside."
 - id: 6178
   examine: "Wooden crates, contents unknown."
 - id: 6179
@@ -9611,11 +9723,9 @@
 - id: 6195
   examine: "Used for sitting."
 - id: 6196
-  examine: "Useful for a dwarf."
 - id: 6197
   examine: "Useful for a dwarf."
 - id: 6198
-  examine: "Useful for a dwarf."
 - id: 6199
   examine: "Useful for a dwarf."
 - id: 6200
@@ -9787,7 +9897,9 @@
 - id: 6302
   examine: "A throne from which you have removed the gems."
 - id: 6303
+  examine: "A statuette of a golem, facing left."
 - id: 6304
+  examine: "A statuette of a golem, facing right."
 - id: 6305
 - id: 6306
 - id: 6307
@@ -9797,6 +9909,7 @@
 - id: 6309
   examine: "The statuette is missing from this alcove."
 - id: 6310
+  examine: "Not good for eating."
 - id: 6311
   examine: "Not good for eating."
 - id: 6312
@@ -9914,7 +10027,7 @@
 - id: 6400
 - id: 6401
 - id: 6402
-  examine: "Tooth shaped limestones, growing from the floor upward."
+  examine: "A limestone ceiling growth."
 - id: 6403
   examine: "A tooth shaped rock formation protruding from the floor."
 - id: 6404
@@ -9948,21 +10061,27 @@
   examine: "I wonder what's inside?"
 - id: 6421
 - id: 6422
+  examine: "A magical aura seems to shimmer over the glass..."
 - id: 6423
   examine: "A magical aura seems to shimmer over the glass..."
 - id: 6424
+  examine: "A magical aura seems to shimmer over the glass..."
 - id: 6425
   examine: "A magical aura seems to shimmer over the glass..."
 - id: 6426
+  examine: "A magical aura seems to shimmer over the glass..."
 - id: 6427
   examine: "A magical aura seems to shimmer over the glass..."
 - id: 6428
+  examine: "A magical aura seems to shimmer over the glass..."
 - id: 6429
   examine: "A magical aura seems to shimmer over the glass..."
 - id: 6430
+  examine: "A magical aura seems to shimmer over the glass..."
 - id: 6431
   examine: "A magical aura seems to shimmer over the glass..."
 - id: 6432
+  examine: "A magical aura seems to shimmer over the glass..."
 - id: 6433
   examine: "A magical aura seems to shimmer over the glass..."
 - id: 6434
@@ -9978,6 +10097,7 @@
 - id: 6439
   examine: "Climb this rope to go up."
 - id: 6440
+  examine: "Looks like a small cave."
 - id: 6441
   examine: "Looks like a small cave."
 - id: 6442
@@ -10141,6 +10261,7 @@
 - id: 6549
   examine: "A well down into the pyramid."
 - id: 6550
+  examine: "A portal that leads you out of the pyramid."
 - id: 6551
   examine: "A portal that leads you out of the pyramid."
 - id: 6552
@@ -10155,6 +10276,7 @@
 - id: 6558
 - id: 6559
 - id: 6560
+  examine: "A ladder that's almost not there at all..."
 - id: 6561
   examine: "A ladder that's almost not there at all..."
 - id: 6562
@@ -10162,8 +10284,8 @@
 - id: 6564
 - id: 6565
 - id: 6566
+  examine: "Gate like?"
 - id: 6567
-  examine: "ALL of the numbers."
 - id: 6568
   examine: "Garments for the discerning."
 - id: 6569
@@ -10233,9 +10355,8 @@
 - id: 6614
   examine: "A large door with a hieroglyph of a cat."
 - id: 6615
-  examine: "Looks like Watson's ideas board."
+  examine: "Gate like?"
 - id: 6616
-  examine: "These things get everywhere."
 - id: 6617
 - id: 6618
 - id: 6619
@@ -10275,8 +10396,11 @@
   examine: "Has a lid shaped like a bug. Disgusting! I think there's a stomach inside."
 - id: 6640
 - id: 6641
-  examine: "Has a lid shaped like an ape. Eeew! I think it contains someone's intestines."
+  examine: ">-
+    Has a lid shaped like an ape. Eeew! I think it contains someone's
+    intestines."
 - id: 6642
+  examine: "Holds the ceiling up."
 - id: 6643
   examine: "Opens into another area, come on, I know this."
 - id: 6644
@@ -10305,7 +10429,7 @@
 - id: 6656
   examine: "Rolls of colourful cloth."
 - id: 6657
-  examine: "A conveniently located bush."
+  examine: "An ancient giant serpent."
 - id: 6658
   examine: "A tunnel leading upwards."
 - id: 6659
@@ -10327,14 +10451,14 @@
   examine: "The wall is not weeping at the moment."
 - id: 6668
 - id: 6669
+  examine: "Stone with blue veins."
   depleted: 6947
-  examine: "Stone with blue veins."
 - id: 6670
+  examine: "Stone with blue veins."
   depleted: 6948
-  examine: "Stone with blue veins."
 - id: 6671
-  depleted: 452
   examine: "Stone with blue veins."
+  depleted: 452
 - id: 6672
   examine: "They don't look too easy to climb."
 - id: 6673
@@ -10368,202 +10492,178 @@
 - id: 6700
 - id: 6701
 - id: 6702
-  examine: "Cave exit."
+  examine: "I can climb these stairs."
 - id: 6703
-  examine: "A pile of large rocks."
+  examine: "I can climb these stairs."
 - id: 6704
-  examine: "A pile of large rocks."
+  examine: "I can climb these stairs."
 - id: 6705
-  examine: "Grow well in the dark."
+  examine: "I can climb these stairs."
 - id: 6706
-  examine: "Grow well in the dark."
+  examine: "I can climb these stairs."
 - id: 6707
-  examine: "A rock."
+  examine: "I can climb these stairs."
 - id: 6708
-  examine: "A small rock."
+  examine: "I can climb this."
 - id: 6709
-  examine: "A rock."
+  examine: "I wonder what is awaiting me on the other side?"
 - id: 6710
+  examine: "I wonder what is awaiting me on the other side?"
 - id: 6711
+  examine: "I wonder what is awaiting me on the other side?"
 - id: 6712
+  examine: "I wonder what is awaiting me on the other side?"
 - id: 6713
+  examine: "I wonder what is awaiting me on the other side?"
 - id: 6714
+  examine: "I wonder what is awaiting me on the other side?"
 - id: 6715
+  examine: "I wonder what is awaiting me on the other side?"
 - id: 6716
 - id: 6717
+  examine: "A crude torch stuck in the ground."
 - id: 6718
+  examine: "A crude torch stuck in the ground."
 - id: 6719
+  examine: "I'm sure he died of natural causes. Like a massive dragon or something..."
 - id: 6720
+  examine: "A crude torch stuck in the ground."
 - id: 6721
+  examine: "A crude torch stuck in the ground."
 - id: 6722
 - id: 6723
 - id: 6724
 - id: 6725
 - id: 6726
+  examine: "I wonder what awaits me on the other side?"
 - id: 6727
-  examine: "Like a living wall."
 - id: 6728
-  examine: "Like a living wall."
+  examine: "I wonder what awaits me on the other side?"
 - id: 6729
-  examine: "Like a living wall."
 - id: 6730
-  examine: "Like a living wall."
 - id: 6731
-  examine: "Like a living wall."
 - id: 6732
-  examine: "Like a living wall."
+  examine: "I wonder what awaits me on the other side?"
 - id: 6733
-  examine: "Like a living wall."
+  examine: "I wonder what awaits me on the other side?"
 - id: 6734
-  examine: "Like a living wall."
+  examine: "I wonder what awaits me on the other side?"
 - id: 6735
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6736
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6737
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6738
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6739
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6740
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6741
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6742
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6743
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6744
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6745
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6746
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6747
-  examine: "Like a living wall."
+  examine: "A crude torch stuck in the ground."
 - id: 6748
-  examine: "Run for it! It's a gazebo!"
+  examine: "A crude torch stuck in the ground."
 - id: 6749
-  examine: "Like a tiny private waterfall."
+  examine: "A crude torch stuck in the ground."
 - id: 6750
-  examine: "A sculpture of flowing water."
+  examine: "A crude torch stuck in the ground."
 - id: 6751
-  examine: "Two little fishes forever spew water into the pond."
+  examine: "A crude torch stuck in the ground."
 - id: 6752
-  examine: "It's not the best chair but you think it would take your weight."
+  examine: "A crude torch stuck in the ground."
 - id: 6753
-  examine: "The ideal thing to sit on."
+  examine: "A crude torch stuck in the ground."
 - id: 6754
-  examine: "A comfortable seat."
+  examine: "A crude torch stuck in the ground."
 - id: 6755
-  examine: "A comfortable seat."
+  examine: "A crude torch stuck in the ground."
 - id: 6756
-  examine: "A comfortable seat."
+  examine: "A crude torch stuck in the ground."
 - id: 6757
-  examine: "A comfortable seat."
+  examine: "A crude torch stuck in the ground."
 - id: 6758
-  examine: "A comfortable seat."
+  examine: "A crude torch stuck in the ground."
 - id: 6759
-  examine: "It's an ugly rug, but better than a bare floor."
+  examine: "A crude torch stuck in the ground."
 - id: 6760
-  examine: "It's an ugly rug, but better than a bare floor."
+  examine: "A crude torch stuck in the ground."
 - id: 6761
-  examine: "It's an ugly rug, but better than a bare floor."
+  examine: "A crude torch stuck in the ground."
 - id: 6762
-  examine: "The handkerchief of giants!"
+  examine: "A crude torch stuck in the ground."
 - id: 6763
-  examine: "The handkerchief of giants!"
+  examine: "A crude torch stuck in the ground."
 - id: 6764
-  examine: "The handkerchief of giants!"
+  examine: "A crude torch stuck in the ground."
 - id: 6765
-  examine: "An opulent rug woven with gold leaf."
+  examine: "A crude torch stuck in the ground."
 - id: 6766
-  examine: "An opulent rug woven with gold leaf."
+  examine: "A crude torch stuck in the ground."
 - id: 6767
-  examine: "An opulent rug woven with gold leaf."
+  examine: "A crude torch stuck in the ground."
 - id: 6768
-  examine: "A good source of books!"
 - id: 6769
-  examine: "A good source of books!"
 - id: 6770
-  examine: "A good source of books!"
 - id: 6771
-  examine: "A good source of scrolls!"
+  examine: "A large stone coffin."
 - id: 6772
-  examine: "A good source of scrolls!"
+  examine: "A large stone coffin."
 - id: 6773
-  examine: "A good source of scrolls!"
+  examine: "A large stone coffin."
 - id: 6774
-  examine: "The curtain is open."
+  examine: "A large stone chest."
 - id: 6775
-  examine: "The curtain is open."
+  examine: "A large stone chest."
 - id: 6776
-  examine: "The curtain is open."
+  examine: "Looks like he's been dead a while now..."
 - id: 6777
-  examine: "A wooden decoration, perhaps to cover a hole in the wall?"
+  examine: "I don't think he'd mind us checking for his wallet now..."
 - id: 6778
-  examine: "An oak decoration to make the wall less bare."
+  examine: "I'm sure he died of natural causes. Like a massive dragon or something..."
 - id: 6779
-  examine: "A teak decoration to make the room more grand."
 - id: 6780
-  examine: "You can light a fire here."
 - id: 6781
-  examine: "A fire burns cosily in the grate."
 - id: 6782
-  examine: "You can light a fire here."
 - id: 6783
-  examine: "A fire burns cosily in the grate."
 - id: 6784
-  examine: "You can light a fire here."
 - id: 6785
-  examine: "A fire burns cosily in the grate."
 - id: 6786
-  examine: "Hammer, chisel, saw and shears."
 - id: 6787
-  examine: "Bucket, spade, tinderbox and knife."
 - id: 6788
-  examine: "Needle, apron and glassblowing pipe."
 - id: 6789
-  examine: "A selection of jewellery moulds."
 - id: 6790
-  examine: "Farming tools."
 - id: 6791
-  examine: "You can make furniture here."
+  examine: "The groundskeeper's bed."
 - id: 6792
-  examine: "You can make furniture here."
 - id: 6793
-  examine: "You can make furniture here."
 - id: 6794
-  examine: "You can make furniture here."
 - id: 6795
-  examine: "You can make furniture here."
 - id: 6796
-  examine: "You can do delicate crafting here."
 - id: 6797
-  examine: "You can do delicate crafting here."
 - id: 6798
-  examine: "You can do delicate crafting here."
 - id: 6799
-  examine: "You can do delicate crafting here."
 - id: 6800
-  examine: "You can repair broken staffs and arrows here."
 - id: 6801
-  examine: "You can sharpen rusty swords here."
 - id: 6802
-  examine: "You can repair armour here."
 - id: 6803
-  examine: "You can add a plume to your helmet here."
 - id: 6804
-  examine: "You can paint your logo onto your heraldic shield here."
 - id: 6805
-  examine: "You can make a banner with your logo on here."
 - id: 6806
-  examine: "A wooden stool."
 - id: 6807
-  examine: "An oak stool."
 - id: 6808
-  examine: "A wallhanging."
 - id: 6809
 - id: 6810
 - id: 6811
@@ -10577,25 +10677,32 @@
 - id: 6819
 - id: 6820
 - id: 6821
+  examine: "A large stone coffin."
 - id: 6822
+  examine: "A large stone coffin."
 - id: 6823
+  examine: "A large stone coffin."
 - id: 6824
+  examine: "It's locked."
 - id: 6825
 - id: 6826
 - id: 6827
+  examine: "It might still work..."
 - id: 6828
 - id: 6829
 - id: 6830
-  examine: "Did that thing just twitch?"
 - id: 6831
 - id: 6832
 - id: 6833
 - id: 6834
 - id: 6835
+  examine: "Danger... weak surface beyond gate. Digging may lead to cave-ins."
 - id: 6836
+  examine: "Sturdy metal bars."
 - id: 6837
 - id: 6838
 - id: 6839
+  examine: "Smells pretty bad!"
 - id: 6840
   examine: "It looks as this is where some wall fungus used to be."
 - id: 6841
@@ -10663,6 +10770,7 @@
   examine: "I wonder what this item contains."
 - id: 6878
 - id: 6879
+  examine: "A barricade made of skulls and bones which has been crushed."
 - id: 6880
   examine: "A barricade made of skulls and bones."
 - id: 6881
@@ -10675,6 +10783,7 @@
 - id: 6885
 - id: 6886
 - id: 6887
+  examine: "A sick, frail old man."
 - id: 6888
   examine: "A sick, frail old man."
 - id: 6889
@@ -10690,6 +10799,7 @@
 - id: 6894
   examine: "A good source of books!"
 - id: 6895
+  examine: "A crude torch stuck in the ground."
 - id: 6896
   examine: "A crude torch stuck in the ground."
 - id: 6897
@@ -10717,6 +10827,7 @@
 - id: 6912
   examine: "A narrow hole in the wall."
 - id: 6913
+  examine: "Rubble is blocking the passage."
 - id: 6914
   examine: "A narrow hole in the wall."
 - id: 6915
@@ -10770,23 +10881,24 @@
 - id: 6941
 - id: 6942
 - id: 6943
+  examine: "A rocky outcrop."
   depleted: 6947
-  examine: "The bank teller will serve you from here."
 - id: 6944
+  examine: "A rocky outcrop."
   depleted: 6948
 - id: 6945
+  examine: "A rocky outcrop."
   depleted: 6947
-  examine: "The bank teller will serve you from here."
 - id: 6946
+  examine: "A rocky outcrop."
   depleted: 6948
-  examine: "This booth is for private customers only."
 - id: 6947
-  examine: "This booth is closed."
+  examine: "A rocky outcrop."
 - id: 6948
-  examine: "Lets you put items into your bank."
+  examine: "A rocky outcrop."
 - id: 6949
 - id: 6950
-  examine: "I don't think I can get through this way."
+  examine: "I dont think i can get through this way."
 - id: 6951
   examine: "An eye-wrenching nexus of utter negation!"
 - id: 6952
@@ -10908,6 +11020,7 @@
 - id: 7030
   examine: "A steam powered cart."
 - id: 7031
+  examine: "A fine piece of sculpting."
 - id: 7032
   examine: "A fine piece of sculpting."
 - id: 7033
@@ -10937,16 +11050,21 @@
 - id: 7047
 - id: 7048
 - id: 7049
+  examine: "A wooden gate."
 - id: 7050
+  examine: "A wooden gate."
 - id: 7051
+  examine: "A wooden gate."
 - id: 7052
+  examine: "A wooden gate."
 - id: 7053
   examine: "Lots of seeds here."
 - id: 7054
-  examine: "It's a Notice"
 - id: 7055
 - id: 7056
+  examine: "I can climb down these stairs."
 - id: 7057
+  examine: "I can climb up these stairs."
 - id: 7058
   examine: "Filled to the brim with knowledge."
 - id: 7059
@@ -11035,64 +11153,85 @@
 - id: 7102
   examine: "A staff as used by Saradominist magi."
 - id: 7103
+  examine: "There is a powerful presence about these ruins..."
 - id: 7104
+  examine: "There is a powerful presence about these ruins..."
 - id: 7105
+  examine: "There is a powerful presence about these ruins..."
 - id: 7106
+  examine: "There is a powerful presence about these ruins..."
 - id: 7107
+  examine: "There is a powerful presence about these ruins..."
 - id: 7108
-  examine: "Sheets of paper lying on the floor."
+  examine: "There is a powerful presence about these ruins..."
 - id: 7109
-  examine: "Someone should really try tidying this place."
+  examine: "There is a powerful presence about these ruins..."
 - id: 7110
-  examine: "Hopefully this leads to a sewer."
+  examine: "There is a powerful presence about these ruins..."
 - id: 7111
-  examine: "Hopefully this leads to a sewer."
+  examine: "There is a powerful presence about these ruins..."
 - id: 7112
-  examine: "Hopefully this leads to a sewer."
+  examine: "There is a powerful presence about these ruins..."
 - id: 7113
+  examine: "There is a powerful presence about these ruins..."
 - id: 7114
+  examine: "There is a powerful presence about these ruins..."
 - id: 7115
+  examine: "There is a powerful presence about these ruins..."
 - id: 7116
+  examine: "There is a powerful presence about these ruins..."
 - id: 7117
+  examine: "There is a powerful presence about these ruins..."
 - id: 7118
+  examine: "There is a powerful presence about these ruins..."
 - id: 7119
+  examine: "There is a powerful presence about these ruins..."
 - id: 7120
+  examine: "There is a powerful presence about these ruins..."
 - id: 7121
+  examine: "There is a powerful presence about these ruins..."
 - id: 7122
+  examine: "There is a powerful presence about these ruins..."
 - id: 7123
+  examine: "There is a powerful presence about these ruins..."
 - id: 7124
+  examine: "There is a powerful presence about these ruins..."
 - id: 7125
+  examine: "There is a powerful presence about these ruins..."
 - id: 7126
+  examine: "There is a powerful presence about these ruins..."
 - id: 7127
-  examine: "All hail the glorious victors!"
+  examine: "There is a powerful presence about these ruins..."
 - id: 7128
+  examine: "There is a powerful presence about these ruins..."
 - id: 7129
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7130
-  examine: "Scattered rotten food."
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7131
-  examine: "Scattered rotten food."
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7132
-  examine: "Scattered rotten food."
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7133
-  examine: "What a good place for a dead rat!"
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7134
-  examine: "Fungal growth."
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7135
-  examine: "To be eaten with caution."
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7136
-  examine: "Pretty 'shrooms."
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7137
-  examine: "Not suitable for indoor use."
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7138
-  examine: "The colours of Varrock."
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7139
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7140
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7141
-  examine: "This tells you which way is which."
+  examine: "A tear in the dimensional weave of the Abyss."
 - id: 7142
-  examine: "Something smells very unpleasant down there."
 - id: 7143
-  examine: "A grand fountain."
 - id: 7144
 - id: 7145
 - id: 7146
@@ -11103,81 +11242,72 @@
 - id: 7151
 - id: 7152
 - id: 7153
+  examine: "A tunnel through the abyss."
 - id: 7154
+  examine: "A tunnel through the abyss."
 - id: 7155
 - id: 7156
+  examine: "This seems to be blocking the exit..."
 - id: 7157
 - id: 7158
+  examine: "I could probably break this up with a pickaxe."
 - id: 7159
+  examine: "I could probably break this up with a pickaxe. Oh wait, I just did."
 - id: 7160
+  examine: "Pickaxe power!"
 - id: 7161
+  examine: "They don't look that solid, an axe could help me chop them down."
   depleted: 7163
 - id: 7162
+  examine: "They don't look that solid, an axe could help me chop them down."
 - id: 7163
+  examine: "I cannot tell a lie. I chopped them down."
 - id: 7164
+  examine: "If I'm agile enough I might be able to squeeze through..."
 - id: 7165
-  examine: "For sitting on."
+  examine: "I could probably burn this away with a tinderbox."
 - id: 7166
+  examine: "I could probably burn this with fire."
 - id: 7167
-  examine: "A wooden stool."
+  examine: "Burnt open."
 - id: 7168
-  examine: "A poorly made stool."
+  examine: "I could probably distract these with thievery."
 - id: 7169
-  examine: "A small wooden table."
+  examine: "I could probably distract these with thievery."
 - id: 7170
-  examine: "There are a few books on this shelf."
+  examine: "I could probably distract these with thievery."
 - id: 7171
-  examine: "Some shelves."
+  examine: "An unstable portal across the dimensions..."
 - id: 7172
 - id: 7173
 - id: 7174
 - id: 7175
-  examine: "A nice sturdy-looking table."
 - id: 7176
-  examine: "A mountain of knowledge."
 - id: 7177
-  examine: "A mountain of knowledge."
 - id: 7178
-  examine: "A mountain of knowledge."
 - id: 7179
-  examine: "A mountain of knowledge."
 - id: 7180
-  examine: "A mountain of knowledge."
 - id: 7181
-  examine: "A mountain of knowledge."
 - id: 7182
-  examine: "Where people may put themselves."
 - id: 7183
-  examine: "Ideal for cooking on."
 - id: 7184
-  examine: "Ideal for cooking on."
 - id: 7185
-  examine: "A fire burns cosily in the grate."
 - id: 7186
 - id: 7187
-  examine: "Where people may put themselves."
 - id: 7188
-  examine: "Looks snug."
 - id: 7189
-  examine: "Looks snug."
+  examine: "Abyssal Tendrils."
 - id: 7190
-  examine: "Good for sleeping in."
+  examine: "Abyssal Tendrils."
 - id: 7191
-  examine: "Good for sleeping in."
+  examine: "Abyssal Tendrils."
 - id: 7192
-  examine: "For keeping things in."
 - id: 7193
-  examine: "For keeping clothes in."
 - id: 7194
-  examine: "For keeping things in."
 - id: 7195
-  examine: "For keeping things in."
 - id: 7196
-  examine: "Bedroom furniture."
 - id: 7197
-  examine: "A fancy place to store clothes."
 - id: 7198
-  examine: "A fancy place to store clothes."
 - id: 7199
 - id: 7200
 - id: 7201
@@ -11208,9 +11338,7 @@
 - id: 7221
   examine: "This leads downwards."
 - id: 7222
-  examine: "This way to the viewing gallery."
 - id: 7223
-  examine: "This way to the viewing gallery."
 - id: 7224
   examine: "I'll never be able to dodge that!"
 - id: 7225
@@ -11278,9 +11406,7 @@
 - id: 7258
   examine: "An opening into the crumbling wall."
 - id: 7259
-  examine: "This way to exit."
 - id: 7260
-  examine: "This way to exit."
 - id: 7261
 - id: 7262
 - id: 7263
@@ -11300,16 +11426,20 @@
   examine: "Lets me walk through walls..."
 - id: 7275
 - id: 7276
+  examine: "He looks hungry, but I don't think he'll do anything while I'm here."
 - id: 7277
   examine: "He looks hungry, but I don't think he'll do anything while I'm here."
 - id: 7278
   examine: "He's no longer looks hungry, although perhaps a little guilty-looking."
 - id: 7279
 - id: 7280
+  examine: "He's looking at the grain..."
 - id: 7281
   examine: "He's looking at the grain..."
 - id: 7282
+  examine: "A sack full of grain."
 - id: 7283
+  examine: "A sack full of grain."
 - id: 7284
   examine: "A sack full of grain."
 - id: 7285
@@ -11323,17 +11453,29 @@
 - id: 7289
   examine: "A mystical teleport."
 - id: 7290
+  examine: "Lets me walk through walls..."
 - id: 7291
+  examine: "Lets me walk through walls..."
 - id: 7292
+  examine: "Lets me walk through walls..."
 - id: 7293
+  examine: "Lets me walk through walls..."
 - id: 7294
+  examine: "Lets me walk through walls..."
 - id: 7295
+  examine: "Lets me walk through walls..."
 - id: 7296
+  examine: "Lets me walk through walls..."
 - id: 7297
+  examine: "Lets me walk through walls..."
 - id: 7298
+  examine: "Lets me walk through walls..."
 - id: 7299
+  examine: "Lets me walk through walls..."
 - id: 7300
+  examine: "Lets me walk through walls..."
 - id: 7301
+  examine: "Lets me walk through walls..."
 - id: 7302
   examine: "Lets me walk through walls..."
 - id: 7303
@@ -11479,6 +11621,7 @@
   examine: "Sit back and relax..."
 - id: 7389
 - id: 7390
+  examine: "Designed specifically to ruin your health."
 - id: 7391
   examine: "A rolled up magic carpet."
 - id: 7392
@@ -11488,6 +11631,7 @@
 - id: 7394
   examine: "A magic carpet."
 - id: 7395
+  examine: "A leafy tree."
 - id: 7396
   examine: "The infamous carpet of '76."
 - id: 7397
@@ -11495,178 +11639,193 @@
 - id: 7398
   examine: "A leafy tree."
 - id: 7399
-  examine: "Great for sleeping in."
+  examine: "This is what is left of a willow tree."
 - id: 7400
-  examine: "A bed fit for a king, hopefully."
+  examine: "This is what is left of a maple tree."
 - id: 7401
-  examine: "Simple but stylish."
+  examine: "This is what is left of a magic tree."
 - id: 7402
-  examine: "Fit for a king."
+  examine: "This is what is left of a yew tree."
 - id: 7403
-  examine: "Fit for a king."
+  examine: "An empty barrel."
 - id: 7404
-  examine: "A comfortable seat."
+  examine: "A barrel full of mushed apples."
 - id: 7405
-  examine: "A teak dining table."
 - id: 7406
-  examine: "A teak dining table."
+  examine: "This tap runs from the apple crushing barrel."
 - id: 7407
-  examine: "A nice table."
+  examine: "An empty ale barrel."
 - id: 7408
-  examine: "A nice table."
+  examine: "A barrel of bad ale."
 - id: 7409
-  examine: "The bank teller will serve you from here."
+  examine: "A barrel of unfermented liquid."
 - id: 7410
-  examine: "The bank teller will serve you from here."
+  examine: "A barrel of bad cider."
 - id: 7411
+  examine: "A barrel of Dwarven Stout."
 - id: 7412
+  examine: "A barrel of mature Dwarven Stout."
 - id: 7413
+  examine: "A barrel of Asgarnian Ale."
 - id: 7414
+  examine: "A barrel of mature Asgarnian Ale."
 - id: 7415
+  examine: "A barrel of Greenmans Ale."
 - id: 7416
+  examine: "A barrel of mature Greenmans Ale."
 - id: 7417
-  examine: "A nice table."
+  examine: "A barrel of Wizards Mind Bomb."
 - id: 7418
-  examine: "The seat of power."
+  examine: "A barrel of mature Wizards Mind Bomb."
 - id: 7419
-  examine: "The perfect place to store things."
+  examine: "A barrel of Dragon Bitter."
 - id: 7420
-  examine: "The perfect place to store things."
+  examine: "A barrel of mature Dragon Bitter."
 - id: 7421
-  examine: "For cooking food."
+  examine: "A barrel of Moonlight Mead."
 - id: 7422
-  examine: "Running water - a nice feature."
+  examine: "A barrel of mature Moonlight Mead."
 - id: 7423
-  examine: "A nicely carved larder to keep food cool."
+  examine: "A barrel of Axeman's Folly."
 - id: 7424
-  examine: "To help you do your hair."
+  examine: "A barrel of mature Axeman's Folly."
 - id: 7425
-  examine: "Looking good!"
+  examine: "A barrel of Chef's Delight."
 - id: 7426
+  examine: "A barrel of mature Chef's Delight."
 - id: 7427
-  examine: "A privacy aid!"
+  examine: "A barrel of Slayer's Respite."
 - id: 7428
-  examine: "Running water - very nice!"
+  examine: "A barrel of mature Slayer's Respite."
 - id: 7429
-  examine: "It's got soap on it."
+  examine: "A barrel of Cider."
 - id: 7430
-  examine: "For sitting on."
+  examine: "A barrel of mature Cider."
 - id: 7431
-  examine: "A good source of books!"
 - id: 7432
 - id: 7433
-  examine: "A basic oak chair."
+  examine: "Goes up and down!"
 - id: 7434
-  examine: "No little mouse to be seen."
 - id: 7435
 - id: 7436
+  examine: "A wooden barrel."
 - id: 7437
+  examine: "This vat is empty."
 - id: 7438
-  examine: "A very untidy workplace."
+  examine: "This vat is filled with water."
 - id: 7439
-  examine: "An elegant chair."
+  examine: "This vat is filled with bad ale."
 - id: 7440
-  examine: "A very untidy workplace."
+  examine: "This vat is filled with bad cider."
 - id: 7441
-  examine: "For being tucked up as snug as a bug in a rug."
+  examine: "This vat contains a mixture of water and barley malt."
 - id: 7442
-  examine: "For clothes and handy stuff."
+  examine: "This controls the flow of ale to the barrel."
 - id: 7443
-  examine: "For clothes and handy stuff."
+  examine: "This controls the flow of ale to the barrel."
 - id: 7444
-  examine: "Da da da dummm, da da da dummm."
+  examine: "This vat contains a mixture of water, barley malt, and Hammerstone hops."
 - id: 7445
-  examine: "Time for a recital?"
+  examine: "Dwarven Stout is fermenting in this vat."
 - id: 7446
-  examine: "Very broken."
+  examine: "Dwarven Stout is fermenting in this vat."
 - id: 7447
+  examine: "This vat is filled with Dwarven Stout."
 - id: 7448
+  examine: "This vat is filled with mature Dwarven Stout."
 - id: 7449
+  examine: "This vat contains a mixture of water, barley malt, and Asgarnian hops."
 - id: 7450
+  examine: "Asgarnian Ale is fermenting in this vat."
 - id: 7451
+  examine: "Asgarnian Ale is fermenting in this vat."
 - id: 7452
-  examine: "This transports coal!"
+  examine: "This vat is filled with Asgarnian Ale."
 - id: 7453
-  examine: "A rocky outcrop."
+  examine: "This vat is filled with mature Asgarnian Ale."
 - id: 7454
-  examine: "A rocky outcrop."
+  examine: "This vat contains a mixture of water, barley malt, and Harralander."
 - id: 7455
-  examine: "A rocky outcrop."
+  examine: "Greenmans Ale is fermenting in this vat."
 - id: 7456
-  examine: "A rocky outcrop."
+  examine: "Greenmans Ale is fermenting in this vat."
 - id: 7457
-  examine: "A rocky outcrop."
+  examine: "This vat is filled with Greenmans Ale."
 - id: 7458
-  examine: "A rocky outcrop."
+  examine: "This vat is filled with mature Greenmans Ale."
 - id: 7459
-  examine: "A rocky outcrop."
+  examine: "This vat contains a mixture of water, barley malt, and Yanillian hops."
 - id: 7460
-  examine: "A rocky outcrop."
+  examine: "Wizards Mind Bomb is fermenting in this vat."
 - id: 7461
-  examine: "A rocky outcrop."
+  examine: "Wizards Mind Bomb is fermenting in this vat."
 - id: 7462
-  examine: "A rocky outcrop."
+  examine: "This vat is filled with Wizards Mind Bomb."
 - id: 7463
-  examine: "A rocky outcrop."
+  examine: "This vat is filled with mature Wizards Mind Bomb."
 - id: 7464
-  examine: "A rocky outcrop."
+  examine: "This vat contains a mixture of water, barley malt, and Krandorian hops."
 - id: 7465
-  examine: "A pile of lime rock."
+  examine: "Dragon Bitter is fermenting in this vat."
 - id: 7466
-  examine: "A pile of lime rock."
+  examine: "Dragon Bitter is fermenting in this vat."
 - id: 7467
-  examine: "A rocky outcrop."
+  examine: "This vat is filled with Dragon Bitter."
 - id: 7468
-  examine: "Stoney!"
+  examine: "This vat is filled with mature Dragon Bitter."
 - id: 7469
-  examine: "Stoney!"
+  examine: "This vat contains a mixture of water, barley malt, and Bittercap mushrooms."
 - id: 7470
-  examine: "Stoney!"
+  examine: "Moonlight Mead is fermenting in this vat."
 - id: 7471
-  examine: "The source of all Rune Stones."
+  examine: "Moonlight Mead is fermenting in this vat."
 - id: 7472
-  examine: "A portal from this mystical place."
+  examine: "This vat is filled with Moonlight Mead."
 - id: 7473
-  examine: "A portal from this mystical place."
+  examine: "This vat is filled with mature Moonlight Mead."
 - id: 7474
-  examine: "A portal from this mystical place."
+  examine: "This vat contains a mixture of water, barley malt, and oak roots."
 - id: 7475
-  examine: "A portal from this mystical place."
+  examine: "Axeman's Folly is fermenting in this vat."
 - id: 7476
-  examine: "A portal from this mystical place."
+  examine: "Axeman's Folly is fermenting in this vat."
 - id: 7477
+  examine: "This vat is filled with Axeman's Folly."
 - id: 7478
+  examine: "This vat is filled with mature Axeman's Folly."
 - id: 7479
+  examine: "This vat contains a mixture of water, barley malt, and chocolate dust."
 - id: 7480
+  examine: "Chef's Delight is fermenting in this vat."
 - id: 7481
+  examine: "Chef's Delight is fermenting in this vat."
 - id: 7482
-  examine: "A poorly made stool."
+  examine: "This vat is filled with Chef's Delight."
 - id: 7483
-  examine: "A fire with a thin stew cooking in a pot."
+  examine: "This vat is filled with mature Chef's Delight."
 - id: 7484
-  examine: "A rocky outcrop."
+  examine: "This vat contains a mixture of water, barley malt, and Wildblood hops."
 - id: 7485
-  examine: "A rocky outcrop."
+  examine: "Slayer's Respite is fermenting in this vat."
 - id: 7486
-  examine: "A rocky outcrop."
+  examine: "Slayer's Respite is fermenting in this vat."
 - id: 7487
-  examine: "A rocky outcrop."
+  examine: "This vat is filled with Slayer's Respite."
 - id: 7488
-  examine: "A rocky outcrop."
+  examine: "This vat is filled with mature Slayer's Respite."
 - id: 7489
-  examine: "A rocky outcrop."
+  examine: "This vat contains some apple mush."
 - id: 7490
-  examine: "A rocky outcrop."
+  examine: "Cider is fermenting in this vat."
 - id: 7491
-  examine: "A rocky outcrop."
+  examine: "Cider is fermenting in this vat."
 - id: 7492
-  examine: "A rocky outcrop."
+  examine: "This vat is filled with cider."
 - id: 7493
-  examine: "A rocky outcrop."
+  examine: "This vat is filled with mature cider."
 - id: 7494
-  examine: "A rocky outcrop."
+  examine: "Items are for sale here."
 - id: 7495
-  examine: "A rocky outcrop."
 - id: 7496
   examine: "Items are for sale here."
 - id: 7497
@@ -11784,6 +11943,7 @@
 - id: 7571
   examine: "This Deadly Nightshade has died."
 - id: 7572
+  examine: "You can grow bushes in this Farming patch."
 - id: 7573
   examine: "You can grow bushes in this Farming patch."
 - id: 7574
@@ -11793,9 +11953,13 @@
 - id: 7576
   examine: "You can grow bushes in this Farming patch."
 - id: 7577
+  examine: "A cadavaberry bush is growing in this Farming patch."
 - id: 7578
+  examine: "A cadavaberry bush is growing in this Farming patch."
 - id: 7579
+  examine: "A cadavaberry bush is growing in this Farming patch."
 - id: 7580
+  examine: "A cadavaberry bush is growing in this Farming patch."
 - id: 7581
   examine: "A cadavaberry bush is growing in this Farming patch."
 - id: 7582
@@ -12177,6 +12341,7 @@
 - id: 7770
   examine: "This cactus has died."
 - id: 7771
+  examine: "You can grow a Calquat Tree in this Farming patch."
 - id: 7772
   examine: "You can grow a Calquat Tree in this Farming patch."
 - id: 7773
@@ -12248,46 +12413,71 @@
 - id: 7806
   examine: "A Calquat tree stump."
 - id: 7807
+  examine: "Turns vegetation into compost."
 - id: 7808
   examine: "Turns vegetation into compost."
 - id: 7809
+  examine: "This compost bin contains compostable items."
 - id: 7810
+  examine: "This compost bin is full of compostable items."
 - id: 7811
-  examine: "Help yourself to useful stuff for the Tournament."
+  examine: "This compost bin contains supercompostable items."
 - id: 7812
+  examine: "This compost bin is full of supercompostable items."
 - id: 7813
   examine: "Turns vegetation into compost."
 - id: 7814
-  examine: "Shrine to the glory of Saradomin."
+  examine: "This compost bin contains compost."
 - id: 7815
+  examine: "This compost bin is full of compost."
 - id: 7816
+  examine: "This compost bin contains super compost."
 - id: 7817
+  examine: "This compost bin is full of super compost."
 - id: 7818
+  examine: "Turns vegetation into compost."
 - id: 7819
-  examine: "This way to become a quitter."
+  examine: "This compost bin contains compostable items."
 - id: 7820
-  examine: "This way to become a quitter."
+  examine: "This compost bin is full of compostable items."
 - id: 7821
-  examine: "This will sink into the ground when the battle begins."
+  examine: "This compost bin contains supercompostable items."
 - id: 7822
-  examine: "It's sinking!"
+  examine: "This compost bin is full of supercompostable items."
 - id: 7823
+  examine: "Turns vegetation into compost."
 - id: 7824
+  examine: "This compost bin contains compost."
 - id: 7825
+  examine: "This compost bin is full of compost."
 - id: 7826
+  examine: "This compost bin contains super compost."
 - id: 7827
+  examine: "This compost bin is full of super compost."
 - id: 7828
+  examine: "This compost bin contains tomatoes."
 - id: 7829
+  examine: "This compost bin is full of tomatoes."
 - id: 7830
+  examine: "This compost bin contains rotten tomatoes."
 - id: 7831
+  examine: "This compost bin is full of rotten tomatoes."
 - id: 7832
+  examine: "This compost bin contains tomatoes."
 - id: 7833
+  examine: "This compost bin is full of tomatoes."
 - id: 7834
+  examine: "This compost bin contains rotten tomatoes."
 - id: 7835
+  examine: "This compost bin is full of rotten tomatoes."
 - id: 7836
+  examine: "You can grow flowers in this Farming patch."
 - id: 7837
+  examine: "You can grow flowers in this Farming patch."
 - id: 7838
+  examine: "You can grow flowers in this Farming patch."
 - id: 7839
+  examine: "You can grow flowers in this Farming patch."
 - id: 7840
   examine: "You can grow flowers in this Farming patch."
 - id: 7841
@@ -12303,9 +12493,13 @@
 - id: 7846
   examine: "You can grow flowers in this Farming patch."
 - id: 7847
+  examine: "A limpwurt plant is growing in this patch."
 - id: 7848
+  examine: "A limpwurt plant is growing in this patch."
 - id: 7849
+  examine: "A limpwurt plant is growing in this patch."
 - id: 7850
+  examine: "A limpwurt plant is growing in this patch."
 - id: 7851
   examine: "A limpwurt plant is growing in this patch."
 - id: 7852
@@ -12487,8 +12681,8 @@
 - id: 7940
   examine: "An apple tree is growing in this fruit tree patch."
 - id: 7941
-  depleted: 7961
   examine: "A fully grown apple tree."
+  depleted: 7961
 - id: 7942
   examine: "There is a single apple on this apple tree."
 - id: 7943
@@ -12530,9 +12724,13 @@
 - id: 7961
   examine: "This apple tree has been cut down."
 - id: 7962
+  examine: "A pineapple plant has been planted in this fruit tree patch."
 - id: 7963
+  examine: "A pineapple plant has been planted in this fruit tree patch."
 - id: 7964
+  examine: "A pineapple plant has been planted in this fruit tree patch."
 - id: 7965
+  examine: "A pineapple plant has been planted in this fruit tree patch."
 - id: 7966
   examine: "A pineapple plant has been planted in this fruit tree patch."
 - id: 7967
@@ -12546,8 +12744,8 @@
 - id: 7971
   examine: "A pineapple plant is growing in this fruit tree patch."
 - id: 7972
-  depleted: 7992
   examine: "A fully grown pineapple plant."
+  depleted: 7992
 - id: 7973
   examine: "There is a single pineapple on this pineapple plant."
 - id: 7974
@@ -12603,8 +12801,8 @@
 - id: 7999
   examine: "A fully grown banana tree."
 - id: 8000
-  depleted: 8019
   examine: "A fully grown banana tree."
+  depleted: 8019
 - id: 8001
   examine: "There is a single banana on this banana tree."
 - id: 8002
@@ -12656,8 +12854,8 @@
 - id: 8025
   examine: "A curry tree is growing in this fruit tree patch."
 - id: 8026
-  depleted: 8046
   examine: "A fully grown curry tree."
+  depleted: 8046
 - id: 8027
   examine: "There is a single curry leaf on this curry tree."
 - id: 8028
@@ -12719,8 +12917,8 @@
 - id: 8056
   examine: "An orange tree is growing in this fruit tree patch."
 - id: 8057
-  depleted: 8077
   examine: "A fully grown orange tree."
+  depleted: 8077
 - id: 8058
   examine: "There is a single orange on this orange tree."
 - id: 8059
@@ -12746,8 +12944,8 @@
 - id: 8069
   examine: "This orange tree looks like it could do with pruning with secateurs."
 - id: 8070
-  depleted: 8077
   examine: "This orange tree looks like it could do with pruning with secateurs."
+  depleted: 8077
 - id: 8071
   examine: "This orange tree has become diseased and died."
 - id: 8072
@@ -12775,8 +12973,8 @@
 - id: 8083
   examine: "A palm tree is growing in this fruit tree patch."
 - id: 8084
-  depleted: 8104
   examine: "A fully grown palm tree."
+  depleted: 8104
 - id: 8085
   examine: "There is a single coconut on this palm tree."
 - id: 8086
@@ -12830,8 +13028,8 @@
 - id: 8110
   examine: "A papaya tree is growing in this fruit tree patch."
 - id: 8111
-  depleted: 8131
   examine: "A fully grown papaya tree"
+  depleted: 8131
 - id: 8112
   examine: "There is a single papaya fruit on this tree."
 - id: 8113
@@ -12909,9 +13107,13 @@
 - id: 8149
   examine: "These herbs have become diseased and died."
 - id: 8150
+  examine: "Asgarnian hop seeds have been sown in this farming patch."
 - id: 8151
+  examine: "Asgarnian hop seeds have been sown in this farming patch."
 - id: 8152
+  examine: "Asgarnian hop seeds have been sown in this farming patch."
 - id: 8153
+  examine: "Asgarnian hop seeds have been sown in this farming patch."
 - id: 8154
   examine: "Asgarnian hop seeds have been sown in this farming patch."
 - id: 8155
@@ -12951,9 +13153,13 @@
 - id: 8172
   examine: "These Asgarnian Hop plants have died from disease."
 - id: 8173
+  examine: "Hammerstone Hop seeds have been sown in this farming patch."
 - id: 8174
+  examine: "Hammerstone Hop seeds have been sown in this farming patch."
 - id: 8175
+  examine: "Hammerstone Hop seeds have been sown in this farming patch."
 - id: 8176
+  examine: "Hammerstone Hop seeds have been sown in this farming patch."
 - id: 8177
   examine: "Hammerstone Hop seeds have been sown in this farming patch."
 - id: 8178
@@ -13275,7 +13481,9 @@
 - id: 8336
   examine: "These Bittercap mushrooms have become diseased and died."
 - id: 8337
+  examine: "You can grow a Spirit Tree in this Farming patch."
 - id: 8338
+  examine: "You can grow a Spirit Tree in this Farming patch."
 - id: 8339
   examine: "You can grow a Spirit Tree in this Farming patch."
 - id: 8340
@@ -13363,15 +13571,25 @@
 - id: 8381
   examine: "Oh dear, your spirit tree has died."
 - id: 8382
+  examine: "You can grow trees in this Farming patch."
 - id: 8383
+  examine: "You can grow trees in this Farming patch."
 - id: 8384
+  examine: "You can grow trees in this Farming patch."
 - id: 8385
+  examine: "You can grow trees in this Farming patch."
 - id: 8386
+  examine: "You can grow trees in this Farming patch."
 - id: 8387
+  examine: "You can grow trees in this Farming patch."
 - id: 8388
+  examine: "You can grow trees in this Farming patch."
 - id: 8389
+  examine: "You can grow trees in this Farming patch."
 - id: 8390
+  examine: "You can grow trees in this Farming patch."
 - id: 8391
+  examine: "You can grow trees in this Farming patch."
 - id: 8392
   examine: "You can grow trees in this Farming patch."
 - id: 8393
@@ -13407,8 +13625,8 @@
 - id: 8408
   examine: "A fully grown Magic Tree."
 - id: 8409
-  depleted: 8410
   examine: "A fully grown Magic Tree."
+  depleted: 8410
 - id: 8410
   examine: "You can uproot this stump with a spade."
 - id: 8411
@@ -13460,8 +13678,8 @@
 - id: 8434
   examine: "This Magic Tree has become diseased and died."
 - id: 8435
-  depleted: 7400
   examine: "A Maple tree sapling has been planted in this tree patch."
+  depleted: 7400
 - id: 8436
   examine: "A Maple tree is growing in this tree patch."
 - id: 8437
@@ -13479,8 +13697,8 @@
 - id: 8443
   examine: "A fully grown Maple tree."
 - id: 8444
-  depleted: 8445
   examine: "A fully grown Maple tree."
+  depleted: 8445
 - id: 8445
   examine: "You can uproot this stump with a spade."
 - id: 8446
@@ -13526,8 +13744,8 @@
 - id: 8466
   examine: "A fully grown Oak tree."
 - id: 8467
-  depleted: 8468
   examine: "A fully grown Oak tree."
+  depleted: 8468
 - id: 8468
   examine: "You can uproot this stump with a spade."
 - id: 8469
@@ -13565,8 +13783,8 @@
 - id: 8487
   examine: "A fully grown Willow tree."
 - id: 8488
-  depleted: 8489
   examine: "A fully grown Willow tree."
+  depleted: 8489
 - id: 8489
   examine: "You can uproot this stump with a spade."
 - id: 8490
@@ -13616,8 +13834,8 @@
 - id: 8512
   examine: "A fully grown Yew tree."
 - id: 8513
-  depleted: 8514
   examine: "A fully grown Yew tree."
+  depleted: 8514
 - id: 8514
   examine: "You can uproot this tree stump with a spade."
 - id: 8515
@@ -13691,13 +13909,21 @@
 - id: 8549
   examine: "These cabbages have become diseased and died."
 - id: 8550
+  examine: "Potato seeds have been planted in this allotment."
 - id: 8551
+  examine: "Potato seeds have been planted in this allotment."
 - id: 8552
+  examine: "Potato seeds have been planted in this allotment."
 - id: 8553
+  examine: "Potato seeds have been planted in this allotment."
 - id: 8554
+  examine: "Potato seeds have been planted in this allotment."
 - id: 8555
+  examine: "Potato seeds have been planted in this allotment."
 - id: 8556
+  examine: "Potato seeds have been planted in this allotment."
 - id: 8557
+  examine: "Potato seeds have been planted in this allotment."
 - id: 8558
   examine: "Potato seeds have been planted in this allotment."
 - id: 8559
@@ -13743,7 +13969,7 @@
 - id: 8579
   examine: "You can grow fruit and vegetables here."
 - id: 8580
-  examine: "Some onion seeds have been sown in this allotment."
+  examine: "Some onion seeds have sown in this allotment."
 - id: 8581
   examine: "Some onion plants are growing in this allotment."
 - id: 8582
@@ -13753,7 +13979,7 @@
 - id: 8584
   examine: "There are some fully grown onions in this allotment."
 - id: 8585
-  examine: "Some onion seeds have been sown in this allotment."
+  examine: "Some onion seeds have sown in this allotment."
 - id: 8586
   examine: "Some onion plants are growing in this allotment."
 - id: 8587
@@ -13969,9 +14195,7 @@
 - id: 8693
 - id: 8694
 - id: 8695
-  examine: "The door is closed."
 - id: 8696
-  examine: "The door is open."
 - id: 8697
 - id: 8698
 - id: 8699
@@ -13981,9 +14205,9 @@
 - id: 8701
   examine: "Someone's been preparing meat."
 - id: 8702
-  examine: "A barrel for collecting rainwater."
+  examine: "A barrel for collecting rain water."
 - id: 8703
-  examine: "A barrel for collecting rainwater."
+  examine: "A barrel for collecting rain water."
 - id: 8704
 - id: 8705
 - id: 8706
@@ -14012,24 +14236,22 @@
 - id: 8723
 - id: 8724
 - id: 8725
-  examine: "A pile of lime rock."
+  examine: "A little rock."
 - id: 8726
-  examine: "A pile of lime rock."
+  examine: "A small chunk of rock."
 - id: 8727
-  examine: "A rocky outcrop."
+  examine: "They're not floating, even though it may look like they are!"
 - id: 8728
+  examine: "A deposit of rocks."
 - id: 8729
-  examine: "Roughly carved from slabs of ice."
+  examine: "A deposit of rocks."
 - id: 8730
-  examine: "It's been bent over to provide the springing action for the net trap below."
+  examine: "A deposit of rocks."
 - id: 8731
-  examine: "Theoretically, it should close around anything that trips the trigger string."
+  examine: "A deposit of rocks."
 - id: 8732
-  examine: "A young tree, probably quite flexible."
 - id: 8733
-  examine: "A young tree, probably quite flexible."
 - id: 8734
-  examine: "It looks like there's something caught in it."
 - id: 8735
 - id: 8736
 - id: 8737
@@ -14113,21 +14335,13 @@
 - id: 8785
   examine: "I can climb this."
 - id: 8786
-  examine: "The door is closed."
 - id: 8787
-  examine: "The door is closed."
 - id: 8788
-  examine: "The door is closed."
 - id: 8789
-  examine: "The door is closed."
 - id: 8790
-  examine: "The door is open."
 - id: 8791
-  examine: "The door is open."
 - id: 8792
-  examine: "The door is open."
 - id: 8793
-  examine: "The door is open."
 - id: 8794
 - id: 8795
   examine: "Makes gnomes taller."
@@ -14160,13 +14374,9 @@
 - id: 8809
   examine: "A pile of rotten apples!"
 - id: 8810
-  examine: "A wooden gate."
 - id: 8811
-  examine: "A wooden gate."
 - id: 8812
-  examine: "A wooden gate."
 - id: 8813
-  examine: "A wooden gate."
 - id: 8814
   examine: "A well slept in bed."
 - id: 8815
@@ -14176,13 +14386,9 @@
 - id: 8817
   examine: "A well slept in bed."
 - id: 8818
-  examine: "The door is closed."
 - id: 8819
-  examine: "The door is open."
 - id: 8820
-  examine: "Solid iron bars."
 - id: 8821
-  examine: "Solid iron bars."
 - id: 8822
 - id: 8823
 - id: 8824
@@ -14229,6 +14435,7 @@
 - id: 8858
 - id: 8859
 - id: 8860
+  examine: "This is a special hops patch."
 - id: 8861
   examine: "This is a special hops patch."
 - id: 8862
@@ -14393,11 +14600,11 @@
 - id: 8960
   examine: "There must be some trick to opening this..."
 - id: 8961
-  examine: "A mechanical stone thrower."
+  examine: "It's opening..."
 - id: 8962
-  examine: "An unfinished mace trap."
-- id: 8963
   examine: "Apparently there was some trick to opening it!"
+- id: 8963
+  examine: "Not as difficult to walk through as it was a minute ago."
 - id: 8964
 - id: 8965
 - id: 8966
@@ -14405,73 +14612,59 @@
 - id: 8967
   examine: "A sturdy looking door, propped shut with a support."
 - id: 8968
-  examine: "An unfinished mace trap."
 - id: 8969
 - id: 8970
 - id: 8971
 - id: 8972
-  examine: "It looks like there's something caught in it."
+  examine: "A portal back to the real world..."
 - id: 8973
-  examine: "Something has triggered this trap but it looks like it must have escaped."
+  examine: "One of the most common trees in RuneScape."
 - id: 8974
-  examine: "Something has triggered this trap but it looks like it must have escaped."
+  examine: "A commonly found tree."
 - id: 8975
-  examine: "The magical pressures of this place have warped the runestone into an incredibly dense material."
 - id: 8976
-  examine: "The runestone has been mined to depletion."
 - id: 8977
 - id: 8978
 - id: 8979
 - id: 8980
 - id: 8981
 - id: 8982
-  examine: "A glowing pinball post!"
 - id: 8983
-  examine: "A glowing pinball post!"
 - id: 8984
-  examine: "A glowing pinball post!"
 - id: 8985
-  examine: "It looks like there's something caught in it."
+  examine: "Steam seems to be condensing into the pot. Neat trick!"
 - id: 8986
-  examine: "It looks like there's something caught in it."
+  examine: "I can see fish swimming in the water. Well, they sort of look like fish..."
 - id: 8987
-  examine: "Something has triggered this trap but it looks like it must have escaped."
+  examine: "A portal that leads... somewhere?"
 - id: 8988
-  examine: "Something has triggered this trap but it looks like it must have escaped."
+  examine: "I wonder what's inside..."
 - id: 8989
-  examine: "It's been bent over to provide the springing action for the net trap below."
+  examine: "Someone's looking through the chest."
 - id: 8990
-  examine: "A young tree, probably quite flexible."
 - id: 8991
-  examine: "A young tree, probably quite flexible."
 - id: 8992
-  examine: "Theoretically, it should close around anything that trips the trigger string."
 - id: 8993
-  examine: "It looks like there's something caught in it."
 - id: 8994
-  examine: "A glowing pinball post!"
 - id: 8995
-  examine: "A glowing pinball post!"
 - id: 8996
-  examine: "It looks like there's something caught in it."
 - id: 8997
-  examine: "Something has triggered this trap but it looks like it must have escaped."
 - id: 8998
-  examine: "Something has triggered this trap but it looks like it must have escaped."
+  examine: "An appendage for activating something."
 - id: 8999
-  examine: "It's been bent over to provide the springing action for the net trap below."
+  examine: "An appendage for activating something."
 - id: 9000
-  examine: "A young tree, probably quite flexible."
+  examine: "An appendage for activating something."
 - id: 9001
-  examine: "A young tree, probably quite flexible."
+  examine: "An appendage for activating something."
 - id: 9002
-  examine: "Theoretically, it should close around anything that trips the trigger string."
+  examine: "An appendage for activating something."
 - id: 9003
-  examine: "It looks like there's something caught in it."
+  examine: "An appendage for activating something."
 - id: 9004
-  examine: "It looks like there's something caught in it."
+  examine: "An appendage for activating something."
 - id: 9005
-  examine: "Something has triggered this trap but it looks like it must have escaped."
+  examine: "An appendage for activating something."
 - id: 9006
   examine: "A place to cremate the dead. Needs a body."
 - id: 9007
@@ -14527,15 +14720,15 @@
 - id: 9032
   examine: "Gems encrusted in stone."
 - id: 9033
-  examine: "Many plants such as this usually have exotic tubers."
+  examine: "Many rare plants such as this usually have exotic tubers."
 - id: 9034
-  depleted: 9035
   examine: "A beautiful old mahogany tree."
+  depleted: 9035
 - id: 9035
   examine: "This once was a beautiful tree."
 - id: 9036
-  depleted: 9037
   examine: "A beautiful old teak tree."
+  depleted: 9037
 - id: 9037
   examine: "This tree has been cut down."
 - id: 9038
@@ -14571,6 +14764,7 @@
 - id: 9055
 - id: 9056
 - id: 9057
+  examine: "He's stocking rune caskets."
 - id: 9058
   examine: "He's not stocking much."
 - id: 9059
@@ -14586,12 +14780,15 @@
 - id: 9064
   examine: "A wooden crate."
 - id: 9065
+  examine: "A wooden crate containing fez hats."
 - id: 9066
   examine: "A wooden crate containing caskets."
 - id: 9067
+  examine: "A wooden crate containing fez hats."
 - id: 9068
   examine: "A wooden crate containing Blackjacks."
 - id: 9069
+  examine: "boxy"
 - id: 9070
   examine: "A wooden crate containing fez hats."
 - id: 9071
@@ -14611,11 +14808,11 @@
 - id: 9078
   examine: "Mmmm pretty!"
 - id: 9079
-  examine: "A glowing pinball post!"
+  examine: "These dyed fabrics are drying off."
 - id: 9080
-  examine: "A glowing pinball post!"
+  examine: "These dyed fabrics are drying off."
 - id: 9081
-  examine: "A glowing pinball post!"
+  examine: "These dyed fabrics are drying off."
 - id: 9082
   examine: "Items for making clothes are kept on here."
 - id: 9083
@@ -14637,6 +14834,7 @@
 - id: 9091
   examine: "Bars come out of the blast furnace here."
 - id: 9092
+  examine: "Your bars will come out here."
 - id: 9093
   examine: "Your bars will come out here."
 - id: 9094
@@ -14646,7 +14844,6 @@
 - id: 9096
   examine: "Your bars are ready to take."
 - id: 9097
-  examine: "They power the conveyor belt."
 - id: 9098
   examine: "The foreman refers to it as 'Bertha'."
 - id: 9099
@@ -14708,11 +14905,8 @@
   examine: "A way upwards."
 - id: 9139
 - id: 9140
-  examine: "The gate is closed."
 - id: 9141
-  examine: "The gate is closed."
 - id: 9142
-  examine: "The gate is open."
 - id: 9143
   examine: "Used for getting water."
 - id: 9144
@@ -14742,7 +14936,6 @@
 - id: 9157
   examine: "Someone's gold-trimmed this Saradomin armour!"
 - id: 9158
-  examine: "Something has triggered this trap but it looks like it must have escaped."
 - id: 9159
   examine: "Lit to remember the souls of the departed."
 - id: 9160
@@ -14770,7 +14963,9 @@
 - id: 9173
   examine: "These delphiniums are fully grown."
 - id: 9174
+  examine: "You can grow a pink rose bush in this patch."
 - id: 9175
+  examine: "You can grow a pink rose bush in this patch."
 - id: 9176
 - id: 9177
   examine: "You can grow a pink rose bush in this patch."
@@ -14814,6 +15009,7 @@
   examine: "This pink rosebush is fully grown."
 - id: 9197
 - id: 9198
+  examine: "A plantpot of pink orchids."
 - id: 9199
   examine: "A plantpot of pink orchids."
 - id: 9200
@@ -14914,20 +15110,23 @@
 - id: 9249
   examine: "An expertly carved statue of a former King of Misthalin."
 - id: 9250
+  examine: "These grapevines look much healthier now."
 - id: 9251
+  examine: "These grapevines look much healthier now."
 - id: 9252
 - id: 9253
 - id: 9254
+  examine: "These grapevines are suffering from some strange disease."
 - id: 9255
   examine: "These grapevines look much healthier now."
 - id: 9256
   examine: "These grapevines are suffering from some strange disease."
 - id: 9257
-  examine: "It's been bent over to provide the springing action for the net trap below."
+  examine: "Some wild-looking grass."
 - id: 9258
-  examine: "A glowing pinball post!"
+  examine: "Some wild-looking grass."
 - id: 9259
-  examine: "A glowing pinball post!"
+  examine: "Some wild-looking grass."
 - id: 9260
   examine: "Some red roses."
 - id: 9261
@@ -14968,68 +15167,92 @@
 - id: 9292
   examine: "An expertly carved statue of a former Queen of Misthalin."
 - id: 9293
-  examine: "The way out."
+  examine: "A pipe I can squeeze through."
 - id: 9294
+  examine: "Funny looking holes that don't look too inviting."
 - id: 9295
+  examine: "A pipe I can squeeze through."
 - id: 9296
+  examine: "A rocky outcrop."
 - id: 9297
+  examine: "A rocky outcrop."
 - id: 9298
 - id: 9299
+  examine: "Ornate railing."
 - id: 9300
+  examine: "Wooden fencing."
 - id: 9301
+  examine: "A well constructed castle wall."
 - id: 9302
+  examine: "A rather strategically placed hole, which appears to be in the ground."
 - id: 9303
+  examine: "A rocky outcrop."
 - id: 9304
+  examine: "A rocky outcrop."
 - id: 9305
+  examine: "A rocky outcrop."
 - id: 9306
+  examine: "A rocky outcrop."
 - id: 9307
+  examine: "A well weathered wall."
 - id: 9308
+  examine: "A well weathered wall."
 - id: 9309
+  examine: "A tunnel leading under the wall."
 - id: 9310
+  examine: "A tunnel leading under the wall."
 - id: 9311
+  examine: "An underwall tunnel."
 - id: 9312
+  examine: "An underwall tunnel."
 - id: 9313
-  examine: "A mat for exercises."
+  examine: "Looks suspicious."
 - id: 9314
+  examine: "A wall jutting out into the path."
 - id: 9315
+  examine: "I can jump from this stepping stone."
 - id: 9316
-  examine: "The door is closed."
+  examine: "A rocky outcrop."
 - id: 9317
-  examine: "The door is closed."
+  examine: "A rocky outcrop."
 - id: 9318
-  examine: "The door is closed."
 - id: 9319
-  examine: "The door is closed."
+  examine: "A chain rope - looks pretty painful if you slip."
 - id: 9320
+  examine: "A chain rope - looks pretty painful if you slip."
 - id: 9321
+  examine: "A few rocks short of a wall - very crevice like."
 - id: 9322
+  examine: "The foam from the river makes this log very slippy."
 - id: 9323
+  examine: "The foam from the river makes this log very slippy."
 - id: 9324
-  examine: "Looks like fun."
+  examine: "The foam from the river makes this log very slippy."
 - id: 9325
-  examine: "How cute, they've drawn their daddies."
+  examine: "Just another crack in the wall."
 - id: 9326
-  examine: "Everything a growing monster needs to know about runes."
+  examine: "Funny looking holes that don't look too inviting."
 - id: 9327
-  examine: "A growing monster's guide to the world."
+  examine: "They seem to fit in the with the rocky surroundings, so as not to stick out."
 - id: 9328
-  examine: "Those are funny-looking coats."
+  examine: "A slippery well worn log."
 - id: 9329
-  examine: "Probably has class supplies."
+  examine: "A slippery well worn log."
 - id: 9330
-  examine: "Filled with work material and supplies."
+  examine: "A slippery well worn log."
 - id: 9331
-  examine: "Filled with work material and supplies."
+  examine: "A rocky outcrop."
 - id: 9332
-  examine: "Their idea of a class pet."
+  examine: "A rocky outcrop."
 - id: 9333
-  examine: "Perpetual motion at work."
 - id: 9334
-  examine: "A well-used blackboard."
+  examine: "Used to be ornate, now it's a little bit vandalised."
 - id: 9335
-  examine: "No use crying over spilt ink."
+  examine: "A rocky outcrop."
 - id: 9336
+  examine: "A rocky outcrop."
 - id: 9337
+  examine: "Used to be ornate, now it's a little bit vandalised."
 - id: 9338
   examine: "Should scare off the birds..."
 - id: 9339
@@ -15037,120 +15260,90 @@
 - id: 9340
   examine: "Should scare off the birds..."
 - id: 9341
-  examine: "A young tree, probably quite flexible."
 - id: 9342
-  examine: "A young tree, probably quite flexible."
 - id: 9343
-  examine: "Theoretically, it should close around anything that trips the trigger string."
 - id: 9344
-  examine: "The trap has been sprung but has failed to catch anything."
 - id: 9345
-  examine: "A simple device for catching birds."
 - id: 9346
-  examine: "A simple device for catching birds."
 - id: 9347
-  examine: "A simple device for catching birds."
 - id: 9348
-  examine: "There's something caught in it."
 - id: 9349
-  examine: "A simple device for catching birds."
 - id: 9350
 - id: 9351
 - id: 9352
 - id: 9353
 - id: 9354
+  examine: "This looks like the way out."
   depleted: 9389
-  examine: "A recently filled in grave."
 - id: 9355
+  examine: "A cave deep into the volcano."
   depleted: 11862
-  examine: "A recently filled in grave."
 - id: 9356
-  examine: "A recently filled in grave."
+  examine: "A cave deeper into the volcano."
 - id: 9357
-  examine: "A recently filled in grave."
+  examine: "A cave deeper into the volcano."
 - id: 9358
-  examine: "A recently filled in grave."
+  examine: "A cave deep into the volcano."
 - id: 9359
-  examine: "This will show me who is supposed to go here."
+  examine: "This looks like the way out."
 - id: 9360
-  examine: "This will show me who is supposed to go here."
 - id: 9361
-  examine: "This will show me who is supposed to go here."
 - id: 9362
-  examine: "This will show me who is supposed to go here."
 - id: 9363
-  examine: "This will show me who is supposed to go here."
 - id: 9364
-  examine: "A grave with a coffin in."
 - id: 9365
-  examine: "A grave with a coffin in."
 - id: 9366
+  examine: "The barrier of heat is down."
   depleted: 11864
-  examine: "A grave with a coffin in."
 - id: 9367
-  examine: "A grave with a coffin in."
+  examine: "A barrier of heat."
 - id: 9368
-  examine: "For private parties."
+  examine: "A barrier of heat."
 - id: 9369
-  examine: "For private parties."
+  examine: "A barrier of heat."
 - id: 9370
 - id: 9371
 - id: 9372
 - id: 9373
-  examine: "There's something caught in it."
 - id: 9374
-  examine: "A simple device for catching birds."
+  examine: "Hot enough to cook your breakfast on."
 - id: 9375
-  examine: "There's something caught in it."
 - id: 9376
-  examine: "A simple device for catching birds."
 - id: 9377
-  examine: "There's something caught in it."
+  examine: "An egg incubated in the lava."
 - id: 9378
-  examine: "A simple device for catching birds."
+  examine: "An egg incubated in the lava."
 - id: 9379
-  examine: "There's something caught in it."
+  examine: "An egg incubated in the lava."
 - id: 9380
-  examine: "If a creature goes inside, the box should then slam shut."
+  examine: "Who's the man?"
 - id: 9381
-  examine: "If a creature goes inside, the box should then slam shut."
+  examine: "A wooden crate."
 - id: 9382
-  examine: "It looks like there is something caught inside this trap."
+  examine: "Some wooden crates."
 - id: 9383
-  examine: "It looks like there is something caught inside this trap."
 - id: 9384
-  examine: "It looks like there is something caught inside this trap."
 - id: 9385
-  examine: "This trap has been triggered by something."
 - id: 9386
-  examine: "If a creature goes inside, the box should then slam shut."
 - id: 9387
   depleted: 10951
-  examine: "If a creature goes inside, the box should then slam shut."
 - id: 9388
   depleted: 11855
-  examine: "If a creature goes inside, the box should then slam shut."
 - id: 9389
-  examine: "If a creature goes inside, the box should then slam shut."
 - id: 9390
-  examine: "If a creature goes inside, the box should then slam shut."
+  examine: "A natural forge using volcanic heat."
 - id: 9391
-  examine: "If a creature goes inside, the box should then slam shut."
+  examine: "I spy with my little eye..."
 - id: 9392
-  examine: "If a creature goes inside, the box should then slam shut."
 - id: 9393
-  examine: "If a creature goes inside, the box should then slam shut."
 - id: 9394
-  examine: "If a creature goes inside, the box should then slam shut."
 - id: 9395
-  examine: "If a creature goes inside, the box should then slam shut."
 - id: 9396
-  examine: "If a creature goes inside, the box should then slam shut."
 - id: 9397
-  examine: "If a creature goes inside, the box should then slam shut."
 - id: 9398
-  examine: "A nicely fitted door."
+  examine: "Lets you put items into your bank."
 - id: 9399
+  examine: "Weeds."
 - id: 9400
   examine: "Sparse weeds."
 - id: 9401
@@ -15242,11 +15435,11 @@
 - id: 9468
 - id: 9469
 - id: 9470
-  examine: "A wooden gate."
+  examine: "I can climb these stairs."
 - id: 9471
-  examine: "This is what is left of a willow tree."
+  examine: "They go down."
 - id: 9472
-  examine: "I wonder what this does..."
+  examine: "What could be down here?"
 - id: 9473
 - id: 9474
 - id: 9475
@@ -15291,7 +15484,7 @@
 - id: 9509
   examine: "Lovely comfy-looking big bed."
 - id: 9510
-  examine: "East to Draynor Village :"
+  examine: "East to Draynor Village :: South to Rimmington :: South-east to Port Sarim."
 - id: 9511
 - id: 9512
 - id: 9513
@@ -15578,87 +15771,87 @@
 - id: 9707
   examine: "This must let me out of the arena somehow..."
 - id: 9708
+  examine: "A rocky outcrop."
   depleted: 9723
-  examine: "A wooden gate."
 - id: 9709
+  examine: "A rocky outcrop."
   depleted: 9724
-  examine: "A nicely fitted door."
 - id: 9710
+  examine: "A rocky outcrop."
   depleted: 9725
-  examine: "A nicely fitted door."
 - id: 9711
+  examine: "A rocky outcrop."
   depleted: 9723
-  examine: "This is what is left of a willow tree."
 - id: 9712
-  examine: "This is what is left of a maple tree."
+  examine: "A rocky outcrop."
 - id: 9713
+  examine: "A rocky outcrop."
   depleted: 9725
-  examine: "This is what is left of a magic tree."
 - id: 9714
+  examine: "A rocky outcrop."
   depleted: 9723
-  examine: "This is what is left of a yew tree."
 - id: 9715
-  examine: "This tree has vines hanging from it."
+  examine: "A rocky outcrop."
 - id: 9716
+  examine: "A rocky outcrop."
   depleted: 9725
-  examine: "A nicely fitted door."
 - id: 9717
+  examine: "A rocky outcrop."
   depleted: 9723
-  examine: "A wrought iron gate."
 - id: 9718
+  examine: "A rocky outcrop."
   depleted: 9724
-  examine: "A wrought iron gate."
 - id: 9719
+  examine: "A rocky outcrop."
   depleted: 9725
-  examine: "A wrought iron gate."
 - id: 9720
+  examine: "A rocky outcrop."
   depleted: 9723
-  examine: "A wrought iron gate."
 - id: 9721
-  examine: "A closed door."
+  examine: "A rocky outcrop."
 - id: 9722
+  examine: "A rocky outcrop."
   depleted: 9725
-  examine: "A closed door."
 - id: 9723
-  examine: "A closed door."
+  examine: "A rocky outcrop."
 - id: 9724
-  examine: "A closed door."
+  examine: "A rocky outcrop."
 - id: 9725
-  examine: "I can climb this."
+  examine: "A rocky outcrop."
 - id: 9726
-  examine: "I can climb down this."
+  examine: "A rocky outcrop."
 - id: 9727
-  examine: "I can climb this."
+  examine: "A rocky outcrop."
 - id: 9728
-  examine: "I can climb down this."
+  examine: "A rocky outcrop."
 - id: 9729
-  examine: "I can see fish swimming in the water."
+  examine: "A rocky outcrop."
 - id: 9730
-  examine: "One of the most common trees in RuneScape."
+  examine: "A rocky outcrop."
 - id: 9731
-  examine: "One of the most common trees in RuneScape."
+  examine: "A rocky outcrop."
 - id: 9732
-  examine: "One of the most common trees in RuneScape."
+  examine: "A rocky outcrop."
 - id: 9733
-  examine: "One of the most common trees in RuneScape."
+  examine: "A rocky outcrop."
 - id: 9734
-  examine: "A beautiful old oak."
+  examine: "A rocky outcrop."
 - id: 9735
-  examine: "Hot!"
+  examine: "A rocky outcrop."
 - id: 9736
-  examine: "Ideal for cooking on."
+  examine: "A rocky outcrop."
 - id: 9737
-  examine: "It's closed."
+  examine: "A rocky outcrop."
 - id: 9738
-  examine: "I know what this does..."
+  examine: "An old crumbled pillar."
 - id: 9739
-  examine: "Leads to another section of the cave."
+  examine: "An old crumbled pillar."
 - id: 9740
-  examine: "Leads to another section of the cave."
+  examine: "An old crumbled pillar."
 - id: 9741
-  examine: "A dry stone wall."
+  examine: "Smells like fish."
 - id: 9742
-  examine: "I can climb this."
+  examine: "Smells like fish."
 - id: 9743
 - id: 9744
   examine: "I can climb up here."
@@ -15671,6 +15864,7 @@
 - id: 9749
   examine: "A Lever."
 - id: 9750
+  examine: "A repowered crystal."
 - id: 9751
   examine: "A crystal that was broken a long time ago."
 - id: 9752
@@ -15924,43 +16118,77 @@
 - id: 9937
   examine: "There are holes passing through this pillar."
 - id: 9938
+  examine: "There are holes passing through this pillar."
 - id: 9939
+  examine: "There are holes passing through this pillar."
 - id: 9940
+  examine: "There are holes passing through this pillar."
 - id: 9941
+  examine: "There are holes passing through this pillar."
 - id: 9942
+  examine: "There are holes passing through this pillar."
 - id: 9943
+  examine: "There are holes passing through this pillar."
 - id: 9944
+  examine: "There are holes passing through this pillar."
 - id: 9945
+  examine: "There are holes passing through this pillar."
 - id: 9946
+  examine: "There are holes passing through this pillar."
 - id: 9947
+  examine: "There are holes passing through this pillar."
 - id: 9948
+  examine: "There are holes passing through this pillar."
 - id: 9949
+  examine: "There are holes passing through this pillar."
 - id: 9950
+  examine: "There are holes passing through this pillar."
 - id: 9951
+  examine: "There are holes passing through this pillar."
 - id: 9952
+  examine: "There are holes passing through this pillar."
 - id: 9953
+  examine: "There are holes passing through this pillar."
 - id: 9954
+  examine: "There are holes passing through this pillar."
 - id: 9955
+  examine: "There are holes passing through this pillar."
 - id: 9956
+  examine: "There are holes passing through this pillar."
 - id: 9957
+  examine: "There are holes passing through this pillar."
 - id: 9958
+  examine: "There are holes passing through this pillar."
 - id: 9959
+  examine: "There are holes passing through this pillar."
 - id: 9960
+  examine: "There are holes passing through this pillar."
 - id: 9961
+  examine: "There are holes passing through this pillar."
 - id: 9962
+  examine: "There are holes passing through this pillar."
 - id: 9963
+  examine: "There are holes passing through this pillar."
 - id: 9964
+  examine: "There are holes passing through this pillar."
 - id: 9965
+  examine: "There are holes passing through this pillar."
 - id: 9966
+  examine: "There are holes passing through this pillar."
 - id: 9967
+  examine: "There are holes passing through this pillar."
 - id: 9968
+  examine: "There are holes passing through this pillar."
 - id: 9969
+  examine: "There are holes passing through this pillar."
 - id: 9970
+  examine: "There are holes passing through this pillar."
 - id: 9971
 - id: 9972
 - id: 9973
   examine: "There are holes passing through this pillar."
 - id: 9974
+  examine: "A cave wall."
 - id: 9975
   examine: "I can climb down these."
 - id: 9976
@@ -16070,82 +16298,69 @@
 - id: 10041
   examine: "The legs probably aren't a natural feature of the tree."
 - id: 10042
-  examine: "I can climb down this."
 - id: 10043
-  examine: "A door."
 - id: 10044
 - id: 10045
-  examine: "The door is closed."
 - id: 10046
 - id: 10047
-  examine: "It looks like it gets pretty narrow further in there."
 - id: 10048
-  examine: "Leads into Diango's workshop."
 - id: 10049
-  examine: "A grave with a coffin in."
 - id: 10050
-  examine: "An empty grave."
 - id: 10051
-  examine: "An empty grave."
 - id: 10052
-  examine: "An empty grave."
 - id: 10053
-  examine: "An empty grave."
 - id: 10054
-  examine: "An empty grave."
+  examine: "Sounds like there's liquid inside."
 - id: 10055
-  examine: "Not the best place to live."
+  examine: "I won't be leaving that way then."
 - id: 10056
-  examine: "This tree has long been dead."
+  examine: "I won't be leaving that way then."
 - id: 10057
-  examine: "This tree has been cut down."
+  examine: "Flag, pole... Yep, it's a flagpole."
 - id: 10058
-  examine: "Warm, but the draughts don't help very much."
 - id: 10059
 - id: 10060
-  examine: "The clerks and tellers will serve you here."
 - id: 10061
-  examine: "The clerks and tellers will serve you here."
 - id: 10062
+  examine: "This must be climbed over."
 - id: 10063
+  examine: "A pipe I can squeeze through."
 - id: 10064
 - id: 10065
 - id: 10066
 - id: 10067
 - id: 10068
-  examine: "The priests use this to transport victims to the place of sacrifice."
 - id: 10069
 - id: 10070
+  examine: "A mat for exercises."
 - id: 10071
+  examine: "A mat for exercises."
 - id: 10072
-  examine: "Perhaps you might like to go in this direction."
 - id: 10073
-  examine: "Perhaps you can get a grip here and climb the wall."
 - id: 10074
-  examine: "This would be easier if the rope were under more tension!"
 - id: 10075
-  examine: "This would be easier if the rope were under more tension!"
 - id: 10076
+  examine: "A mat for exercises."
 - id: 10077
-  examine: "How's your balance?"
+  examine: "A mat for exercises."
 - id: 10078
-  examine: "It's open."
+  examine: "A mat for exercises."
 - id: 10079
-  examine: "A rocky outcrop."
+  examine: "A mat for exercises."
 - id: 10080
-  examine: "A rocky outcrop."
+  examine: "I wonder if I can hit a bullseye?"
 - id: 10081
-  examine: "Stony!"
+  examine: "One of the most common trees in RuneScape."
 - id: 10082
-  examine: "A hot place for forging things in."
+  examine: "A commonly found tree."
 - id: 10083
-  examine: "The bank teller will serve you from here."
+  examine: "A beautiful old oak."
 - id: 10084
-  examine: "Time for a big leap."
+  examine: "Hay There."
 - id: 10085
-  examine: "Try not to belly-flop."
+  examine: "A pile of straw."
 - id: 10086
-  examine: "A handy way down."
+  examine: "Some hay."
 - id: 10087
   examine: "It looks like an ordinary fishing spot, just infinitely more sinister..."
 - id: 10088
@@ -16158,9 +16373,9 @@
   examine: "A fish-filled water tank in the floor."
 - id: 10092
 - id: 10093
-  examine: "Perhaps you can get a grip here and climb the wall."
+  examine: "Turns milk into other dairy products."
 - id: 10094
-  examine: "Perhaps you can get a grip here and climb the wall."
+  examine: "Turns milk into other dairy products."
 - id: 10095
 - id: 10096
 - id: 10097
@@ -16260,6 +16475,7 @@
 - id: 10163
   examine: "Ah! Definitely where the farming kit is stored."
 - id: 10164
+  examine: "This lever can't be operated right now."
 - id: 10165
   examine: "Throw the lever! Mwuhahahaha!"
 - id: 10166
@@ -16375,7 +16591,7 @@
 - id: 10229
   examine: "A sturdy iron frame, for climbing up and down."
 - id: 10230
-  examine: "The ancient horrors lie below."
+  examine: "A sturdy iron frame, for climbing up and down."
 - id: 10231
 - id: 10232
 - id: 10233
@@ -16388,9 +16604,13 @@
 - id: 10240
 - id: 10241
 - id: 10242
+  examine: "Once upon a time this was used to make pottery."
 - id: 10243
+  examine: "Once upon a time this was used to make pottery."
 - id: 10244
+  examine: "Once upon a time this was used to make pottery."
 - id: 10245
+  examine: "Once upon a time this was used to make pottery."
 - id: 10246
   examine: "Once upon a time this was used to make pottery."
 - id: 10247
@@ -16398,6 +16618,7 @@
 - id: 10248
   examine: "There was a lot of pottery made here a long time ago."
 - id: 10249
+  examine: "Eric's been killed by stones falling from the ceiling!"
 - id: 10250
   examine: "Eric's been killed by stones falling from the ceiling!"
 - id: 10251
@@ -16418,17 +16639,11 @@
 - id: 10259
   examine: "Generally used for sitting."
 - id: 10260
-  examine: "The door is closed."
 - id: 10261
-  examine: "The door is open."
 - id: 10262
-  examine: "The door is closed."
 - id: 10263
-  examine: "The door is open."
 - id: 10264
-  examine: "The door is closed."
 - id: 10265
-  examine: "The door is open."
 - id: 10266
 - id: 10267
   examine: "A battle-weathered shield."
@@ -16439,6 +16654,7 @@
 - id: 10271
   examine: "A display of various relics."
 - id: 10272
+  examine: "Some sacks here..."
 - id: 10273
   examine: "A collection of rare books."
 - id: 10274
@@ -16446,6 +16662,7 @@
 - id: 10275
 - id: 10276
 - id: 10277
+  examine: "It's a crate."
 - id: 10278
   examine: "Looks like it's been out of use for some time."
 - id: 10279
@@ -16459,7 +16676,7 @@
 - id: 10283
   examine: "Maybe I can swim across here!"
 - id: 10284
-  examine: "This would be easier if the rope were under more tension!"
+  examine: "Looks like this grain has been eaten by rats!"
 - id: 10285
 - id: 10286
   examine: "Looks like this grain has been eaten by rats!"
@@ -16530,7 +16747,7 @@
 - id: 10320
   examine: "Big enough for a cat to get in."
 - id: 10321
-  examine: "How dangerous - someone has left this manhole open."
+  examine: "How dangerous, someone has left this manhole open."
 - id: 10322
   examine: "I can climb down this."
 - id: 10323
@@ -16538,11 +16755,8 @@
 - id: 10324
   examine: "I could climb down this."
 - id: 10325
-  examine: "A magical device that enables one to walk through walls."
 - id: 10326
-  examine: "A locked door."
 - id: 10327
-  examine: "A magical device that enables one to walk through walls."
 - id: 10328
 - id: 10329
 - id: 10330
@@ -16570,26 +16784,22 @@
 - id: 10345
   examine: "Observe the rats."
 - id: 10346
-  examine: "A home for rats."
+  examine: "A rats home."
 - id: 10347
-  examine: "A home for rats."
+  examine: "A rats home."
 - id: 10348
-  examine: "A home for rats."
+  examine: "A rats home."
 - id: 10349
-  examine: "A home for rats."
+  examine: "A rats home."
 - id: 10350
-  examine: "A home for rats."
+  examine: "A rats home."
 - id: 10351
 - id: 10352
-  examine: "Try not to belly-flop."
 - id: 10353
 - id: 10354
 - id: 10355
-  examine: "Maybe I could swing on this hanging cable."
 - id: 10356
-  examine: "A zip line"
 - id: 10357
-  examine: "Leaves of a tropical tree."
 - id: 10358
   examine: "Lovely comfy-looking big bed."
 - id: 10359
@@ -16597,7 +16807,6 @@
 - id: 10360
   examine: "A pile of rolled up magic carpets."
 - id: 10361
-  examine: "A wonderful device that enables one to walk through walls."
 - id: 10362
   examine: "I bet there's a needle in it somewhere."
 - id: 10363
@@ -16648,12 +16857,16 @@
 - id: 10393
 - id: 10394
 - id: 10395
+  examine: "It looks like water once ran here."
 - id: 10396
+  examine: "It looks like water once ran here."
 - id: 10397
+  examine: "It looks like water once ran here."
 - id: 10398
 - id: 10399
 - id: 10400
 - id: 10401
+  examine: "It looks like water once ran here."
 - id: 10402
   examine: "It looks like water once ran here."
 - id: 10403
@@ -16847,13 +17060,13 @@
 - id: 10526
   examine: "They go down."
 - id: 10527
-  examine: "A zip line"
+  examine: "A tall wooden door."
 - id: 10528
-  examine: "A zip line"
+  examine: "A tall wooden door."
 - id: 10529
-  examine: "A zip line"
+  examine: "A tall wooden door."
 - id: 10530
-  examine: "A zip line"
+  examine: "A tall wooden door."
 - id: 10531
 - id: 10532
 - id: 10533
@@ -16900,57 +17113,66 @@
 - id: 10558
   examine: "I wonder what's under it?"
 - id: 10559
-  examine: "I wonder what's down there?"
 - id: 10560
   examine: "I can climb this."
 - id: 10561
 - id: 10562
-  examine: "A handy bank chest."
+  examine: "It's open."
 - id: 10563
+  examine: "A banner proclaiming your victory over the Earth Warrior Champion!"
 - id: 10564
   examine: "A banner proclaiming your victory over the Earth Warrior Champion!"
 - id: 10565
+  examine: "A banner proclaiming your victory over the Ghoul Champion!"
 - id: 10566
   examine: "A banner proclaiming your victory over the Ghoul Champion!"
 - id: 10567
+  examine: "A banner proclaiming your victory over the Giant Champion!"
 - id: 10568
   examine: "A banner proclaiming your victory over the Giant Champion!"
 - id: 10569
 - id: 10570
   examine: "A banner proclaiming your victory over the Goblin Champion!"
 - id: 10571
+  examine: "A banner proclaiming your victory over the Hobgoblin Champion!"
 - id: 10572
   examine: "A banner proclaiming your victory over the Hobgoblin Champion!"
 - id: 10573
-- id: 10574
-  depleted: 19003
   examine: "A banner proclaiming your victory over the Imp Champion!"
+- id: 10574
+  examine: "A banner proclaiming your victory over the Imp Champion!"
+  depleted: 19003
 - id: 10575
+  examine: "A banner proclaiming your victory over the Jogre Champion!"
   depleted: 19004
 - id: 10576
-  depleted: 19005
   examine: "A banner proclaiming your victory over the Jogre Champion!"
+  depleted: 19005
 - id: 10577
+  examine: "A banner proclaiming your victory over the Lesser Demon Champion!"
   depleted: 10580
 - id: 10578
-  depleted: 10581
   examine: "A banner proclaiming your victory over the Lesser Demon Champion!"
+  depleted: 10581
 - id: 10579
+  examine: "A banner proclaiming your victory over the Skeleton Champion!"
   depleted: 10582
 - id: 10580
   examine: "A banner proclaiming your victory over the Skeleton Champion!"
 - id: 10581
+  examine: "A banner proclaiming your victory over the Zombie Champion!"
 - id: 10582
   examine: "A banner proclaiming your victory over the Zombie Champion!"
 - id: 10583
-  examine: "This would be easier if the rope were under more tension!"
+  examine: "A rocky outcrop."
 - id: 10584
+  examine: "A rocky outcrop."
 - id: 10585
-  examine: "You might be able to grab it."
+  examine: "A rocky outcrop."
 - id: 10586
-  examine: "Perhaps you can get a grip here and climb the wall."
+  examine: "A rocky outcrop."
 - id: 10587
-  examine: "Mind the pigeon."
+  examine: "A rocky outcrop."
 - id: 10588
 - id: 10589
 - id: 10590
@@ -16973,6 +17195,7 @@
 - id: 10605
   examine: "Danger - large deadly creatures within!"
 - id: 10606
+  examine: ""
 - id: 10607
   examine: "A strangely decorated chest, the open lock is painted brown."
 - id: 10608
@@ -17024,6 +17247,7 @@
 - id: 10636
 - id: 10637
 - id: 10638
+  examine: "Shrine to the glory of Saradomin."
 - id: 10639
   examine: "Shrine to the glory of Saradomin."
 - id: 10640
@@ -17031,7 +17255,6 @@
 - id: 10641
   examine: "Used for sharpening blades."
 - id: 10642
-  examine: "You're aiming for the ruins below."
 - id: 10643
 - id: 10644
 - id: 10645
@@ -17042,71 +17265,119 @@
 - id: 10650
 - id: 10651
 - id: 10652
+  examine: "A large tree."
 - id: 10653
+  examine: "A decorated tree."
 - id: 10654
+  examine: "A decorated tree."
 - id: 10655
+  examine: "A large evergreen tree."
 - id: 10656
+  examine: "A decorated tree."
 - id: 10657
+  examine: "A decorated tree."
 - id: 10658
-  examine: "A naked flame seems unwise next to all that swamp gas."
+  examine: "A decorated tree."
 - id: 10659
+  examine: "A decorated tree."
 - id: 10660
-  examine: "The feeble flame does little to alleviate the chilly dampness."
+  examine: "A decorated tree."
 - id: 10661
-  examine: "A bank deposit chest."
+  examine: "A decorated tree."
 - id: 10662
-  examine: "A manky old crate."
+  examine: "A decorated tree."
 - id: 10663
-  examine: "It looks very small and slippery."
+  examine: "A decorated tree."
 - id: 10664
+  examine: "A tall Trollweiss Spruce. An engraving on the trunk reads, 'Ug loves Aga'."
 - id: 10665
+  examine: "Boxes containing stuff."
 - id: 10666
+  examine: "Boxes containing stuff."
 - id: 10667
+  examine: "Only sawdust..."
 - id: 10668
 - id: 10669
+  examine: "Reclaim your lost puppets!"
 - id: 10670
 - id: 10671
   examine: "Only sawdust..."
 - id: 10672
-  examine: "Someone's been making marionettes!"
+  examine: "Reclaim your lost puppets!"
 - id: 10673
+  examine: "Equipment for colouring items."
 - id: 10674
+  examine: "Equipment for colouring items."
 - id: 10675
+  examine: "Equipment for colouring items."
 - id: 10676
+  examine: "A puppet is being constructed here."
 - id: 10677
+  examine: "A puppet is being constructed here."
 - id: 10678
+  examine: "A puppet is being constructed here."
 - id: 10679
+  examine: "A box containing unpainted decorations."
 - id: 10680
+  examine: "A box containing unpainted decorations."
 - id: 10681
+  examine: "A box containing unpainted decorations."
 - id: 10682
+  examine: "A box containing unpainted decorations."
 - id: 10683
+  examine: "A box containing unpainted decorations."
 - id: 10684
+  examine: "A box containing unpainted decorations."
 - id: 10685
+  examine: "A box containing unpainted decorations."
 - id: 10686
+  examine: "Box containing blue puppet heads."
 - id: 10687
+  examine: "Box containing blue puppet torsos."
 - id: 10688
+  examine: "Box containing blue puppet arms."
 - id: 10689
+  examine: "Box containing blue puppet legs."
 - id: 10690
+  examine: "Box containing red puppet heads."
 - id: 10691
+  examine: "Box containing red puppet torsos."
 - id: 10692
+  examine: "Box containing red puppet arms."
 - id: 10693
+  examine: "Box containing red puppet legs."
 - id: 10694
+  examine: "Box containing green puppet heads."
 - id: 10695
+  examine: "Box containing green puppet torsos."
 - id: 10696
+  examine: "Box containing green puppet arms."
 - id: 10697
+  examine: "Box containing green puppet legs."
 - id: 10698
+  examine: "What could be down here?"
 - id: 10699
+  examine: "You can climb up these."
 - id: 10700
 - id: 10701
+  examine: "A blue crate. Probably containing puppets."
 - id: 10702
+  examine: "A green crate. Probably containing puppets."
 - id: 10703
+  examine: "A red crate. Probably containing puppets."
 - id: 10704
+  examine: "A large crate. More puppets?"
 - id: 10705
+  examine: "Some large wooden crates."
 - id: 10706
+  examine: "A large box full of wood chippings.."
 - id: 10707
+  examine: "A wooden ladder."
 - id: 10708
+  examine: "A wooden ladder."
 - id: 10709
 - id: 10710
+  examine: "Pots full of paint."
 - id: 10711
 - id: 10712
 - id: 10713
@@ -17196,57 +17467,59 @@
 - id: 10776
   examine: "Stairs."
 - id: 10777
-  examine: "Jump to the wall and try to swing on the beams."
 - id: 10778
-  examine: "Clamber up onto the roof."
 - id: 10779
-  examine: "Try to land on the pub's balcony."
 - id: 10780
-  examine: "Try to land on the building below."
 - id: 10781
-  examine: "Not far now."
 - id: 10782
-  examine: "A lump of rock."
 - id: 10783
-  examine: "A lump of rock."
+  examine: "This may be worth opening."
 - id: 10784
-  examine: "A lump of rock."
+  examine: "This may be worth opening."
 - id: 10785
-  examine: "A lump of rock."
+  examine: "This may be worth opening."
 - id: 10786
-  examine: "A big slimy lump of rock."
+  examine: "This may be worth opening."
 - id: 10787
-  examine: "A slimy lump of rock."
+  examine: "This may be worth opening."
 - id: 10788
-  examine: "A slippery looking rock."
+  examine: "This may be worth opening."
 - id: 10789
+  examine: "This may be worth opening."
 - id: 10790
-  examine: "A huge lump of rock."
+  examine: "This may be worth opening."
 - id: 10791
-  examine: "A huge lump of rock."
+  examine: "This may be worth opening."
 - id: 10792
-  examine: "Some small stones."
+  examine: "This may be worth opening."
 - id: 10793
-  examine: "Some small stones."
+  examine: "This may be worth opening."
 - id: 10794
+  examine: "This may be worth opening."
 - id: 10795
-  examine: "A rocky ledge."
+  examine: "This may be worth opening."
 - id: 10796
+  examine: "This may be worth opening."
 - id: 10797
+  examine: "This may be worth opening."
 - id: 10798
+  examine: "This may be worth opening."
 - id: 10799
+  examine: "Some simple cubes."
 - id: 10800
+  examine: "A pile of cylindrical shapes."
 - id: 10801
-  examine: "Materials for tailors."
+  examine: "A pile of Icosahedrons."
 - id: 10802
-  examine: "A pile of boxes for storage."
+  examine: "A pile of pentamids."
 - id: 10803
-  examine: "A pile of boxes for storage."
+  examine: "A hole the perfect shape for spheres"
 - id: 10804
-  examine: "Leads into Diango's workshop."
+  examine: "Perhaps the pixies will be back next year."
 - id: 10805
   examine: "Sandy's desk is piled high with paperwork towers."
 - id: 10806
+  examine: "Looks useful for putting things on."
 - id: 10807
   examine: "A large steaming mug of the finest Karamja Coffee."
 - id: 10808
@@ -17256,6 +17529,7 @@
 - id: 10810
 - id: 10811
 - id: 10812
+  examine: "It's very sandy."
 - id: 10813
   examine: "Betty's counter. There is a vial standing on it."
 - id: 10814
@@ -17263,18 +17537,13 @@
 - id: 10815
 - id: 10816
 - id: 10817
-  examine: "Head back down to the ground now."
+  examine: "Pull me!"
 - id: 10818
 - id: 10819
-  examine: "An ominous tree."
 - id: 10820
-  examine: "It's a looooooong way down!"
 - id: 10821
-  examine: "Don't look down!"
 - id: 10822
-  examine: "Less examiney, more jumpy!"
 - id: 10823
-  examine: "It's not that far across..."
 - id: 10824
   examine: "Oh for a marshmallow on a stick!"
 - id: 10825
@@ -17282,21 +17551,23 @@
 - id: 10827
   examine: "An ornate fountain."
 - id: 10828
-  examine: "Parkour; Go!"
+  examine: "Smells like fish."
 - id: 10829
-  examine: "This would be easier if the rope were under more tension!"
+  examine: "Smells like fish."
 - id: 10830
+  examine: "Smells like fish."
 - id: 10831
-  examine: "For jumping large gaps."
+  examine: "Smells like fish."
 - id: 10832
-  examine: "Try not to belly-flop."
+  examine: "Smells like fish."
 - id: 10833
-  examine: "Perhaps you can get a grip here and climb the wall."
+  examine: "Smells like fish."
 - id: 10834
-  examine: "Viaducts are for noobs."
+  examine: "Smells like fish."
 - id: 10835
+  examine: "Smells like fish."
 - id: 10836
-  examine: "Perhaps you can drag yourself across here."
+  examine: "Smells like fish."
 - id: 10837
 - id: 10838
 - id: 10839
@@ -17350,6 +17621,7 @@
 - id: 10870
 - id: 10871
 - id: 10872
+  examine: "A stone block."
 - id: 10873
 - id: 10874
 - id: 10875
@@ -17357,10 +17629,15 @@
 - id: 10876
   examine: "A stone block."
 - id: 10877
+  examine: "A gap."
 - id: 10878
+  examine: "A gap."
 - id: 10879
+  examine: "A gap."
 - id: 10880
+  examine: "A gap."
 - id: 10881
+  examine: "A narrow ledge."
 - id: 10882
   examine: "A gap."
 - id: 10883
@@ -17432,22 +17709,26 @@
 - id: 10942
 - id: 10943
 - id: 10944
-  examine: "Useful for transportation of delicate items."
+  examine: "A rocky outcrop."
 - id: 10945
-  examine: "A wooden crate for storage."
+  examine: "A rocky outcrop."
 - id: 10946
+  examine: "A rocky outcrop."
   depleted: 2551
 - id: 10947
+  examine: "A rocky outcrop."
   depleted: 2560
 - id: 10948
+  examine: "A rocky outcrop."
   depleted: 10944
 - id: 10949
+  examine: "A rocky outcrop."
   depleted: 10945
-  examine: "You could grow a vine here."
 - id: 10950
   examine: "Looks sturdy enough to climb!"
 - id: 10951
 - id: 10952
+  examine: "Something heavy must have made this."
 - id: 10953
   examine: "Something heavy must have made this."
 - id: 10954
@@ -17483,6 +17764,7 @@
 - id: 10969
   examine: "A large statue."
 - id: 10970
+  examine: "It has no limbs."
 - id: 10971
   examine: "It has no limbs."
 - id: 10972
@@ -17516,6 +17798,7 @@
 - id: 10986
   examine: "It has all its limbs still attached."
 - id: 10987
+  examine: "There's a recess on the top shaped like a head."
 - id: 10988
   examine: "There's a recess on the top shaped like a head."
 - id: 10989
@@ -17556,6 +17839,7 @@
 - id: 11007
   examine: "This fountain is frozen solid."
 - id: 11008
+  examine: "A hot place for forging things in."
 - id: 11009
   examine: "It's blocked and is spewing out smoke."
 - id: 11010
@@ -17566,6 +17850,7 @@
 - id: 11014
 - id: 11015
 - id: 11016
+  examine: "Something burned in here long ago."
 - id: 11017
   examine: "Something burned in here long ago."
 - id: 11018
@@ -17625,9 +17910,7 @@
 - id: 11047
 - id: 11048
 - id: 11049
-  examine: "I wonder what's under it?"
 - id: 11050
-  examine: "I wonder what's down there?"
 - id: 11051
   examine: "There's a recess in it in the shape of a Z."
 - id: 11052
@@ -17776,78 +18059,90 @@
 - id: 11159
 - id: 11160
 - id: 11161
-  examine: "This shouldn't be too hard."
 - id: 11162
+  examine: "A big grinding thing."
 - id: 11163
+  examine: "A big grinding thing."
 - id: 11164
-  examine: "You could grow a vine here."
+  examine: "A big grinding thing."
 - id: 11165
+  examine: "A rocky outcrop."
 - id: 11166
-  examine: "It's small, but it gets bigger."
+  examine: "A rocky outcrop."
 - id: 11167
+  examine: "A rocky outcrop."
 - id: 11168
-  examine: "It's getting a little bigger."
+  examine: "A rocky outcrop."
 - id: 11169
+  examine: "A rocky outcrop."
 - id: 11170
-  examine: "It's getting bigger."
+  examine: "A rocky outcrop."
 - id: 11171
+  examine: "A rocky outcrop."
 - id: 11172
-  examine: "It's getting a lot bigger."
+  examine: "A rocky outcrop."
 - id: 11173
+  examine: "A rocky outcrop."
 - id: 11174
-  examine: "Solid rock from the cave floor."
+  examine: "A rocky outcrop."
 - id: 11175
-  examine: "Solid rock from the cave floor."
+  examine: "A rocky outcrop."
 - id: 11176
+  examine: "A rocky outcrop."
 - id: 11177
+  examine: "A rocky outcrop."
 - id: 11178
+  examine: "A rocky outcrop."
 - id: 11179
+  examine: "A rocky outcrop."
   depleted: 11182
 - id: 11180
+  examine: "A rocky outcrop."
   depleted: 11192
 - id: 11181
+  examine: "A rocky outcrop."
   depleted: 11193
 - id: 11182
-  examine: "Looks slippery!"
+  examine: "A rocky outcrop."
 - id: 11183
+  examine: "A rocky outcrop."
   depleted: 37700
-  examine: "Looks slippery!"
 - id: 11184
+  examine: "A rocky outcrop."
   depleted: 37701
-  examine: "Formed over many years of dripping limestone."
 - id: 11185
+  examine: "A rocky outcrop."
   depleted: 37702
-  examine: "Formed over many years of dripping limestone."
 - id: 11186
+  examine: "A rocky outcrop."
   depleted: 37700
-  examine: "Formed over many years of dripping limestone."
 - id: 11187
+  examine: "A rocky outcrop."
   depleted: 37701
-  examine: "A limestone ceiling growth."
 - id: 11188
+  examine: "A rocky outcrop."
   depleted: 37702
-  examine: "Limestone floor growth."
 - id: 11189
+  examine: "A rocky outcrop."
   depleted: 37700
-  examine: "A limestone ceiling growth."
 - id: 11190
+  examine: "A rocky outcrop."
   depleted: 37701
-  examine: "A deposit of rocks."
 - id: 11191
+  examine: "A rocky outcrop."
   depleted: 37702
-  examine: "A deposit of rocks."
 - id: 11192
-  examine: "A deposit of rocks."
+  examine: "A rocky outcrop."
 - id: 11193
-  examine: "A deposit of rocks."
+  examine: "A rocky outcrop."
 - id: 11194
+  examine: "A rocky outcrop."
   depleted: 11365
 - id: 11195
+  examine: "A rocky outcrop."
   depleted: 11366
 - id: 11196
-  examine: "An ornately fashioned door."
 - id: 11197
-  examine: "An ornately fashioned door."
 - id: 11198
   examine: "The ladder to the Runeversi challenge room for experienced players."
 - id: 11199
@@ -17893,22 +18188,29 @@
 - id: 11220
   examine: "Let's hope they don't repair it."
 - id: 11221
+  examine: "Useful for transportation of valuable items."
 - id: 11222
+  examine: "Useful for transportation of valuable items."
 - id: 11223
+  examine: "Useful for transportation of valuable items."
 - id: 11224
+  examine: "Useful for transportation of valuable items."
 - id: 11225
 - id: 11226
 - id: 11227
+  examine: "Useful for transportation of valuable items."
 - id: 11228
   examine: "Useful for transportation of valuable items."
 - id: 11229
   examine: "Useful for transportation of valuable items."
 - id: 11230
+  examine: "Perhaps I should search it."
 - id: 11231
   examine: "I wonder what's inside."
 - id: 11232
   examine: "Perhaps I should search it."
 - id: 11233
+  examine: "A wooden barrel for storage."
 - id: 11234
   examine: "A wooden barrel for storage."
 - id: 11235
@@ -17978,7 +18280,7 @@
 - id: 11282
   examine: "Useful for making ships move."
 - id: 11283
-  examine: "Useful for making ships move."
+  examine: "Useful for making ships move"
 - id: 11284
 - id: 11285
 - id: 11286
@@ -18098,6 +18400,7 @@
 - id: 11354
   examine: "Who knows where it may lead?"
 - id: 11355
+  examine: "A gateway back to RuneScape."
 - id: 11356
   examine: "A gateway back to RuneScape."
 - id: 11357
@@ -18105,92 +18408,88 @@
 - id: 11358
   examine: "I can climb up these stairs."
 - id: 11359
+  examine: "This stall smells great."
 - id: 11360
-  examine: "Don't roll off the roof when you land."
+  examine: "This stall smells great."
 - id: 11361
-  examine: "It's hard not to look down when the camera won't point up."
+  examine: "It's a raw chompybird on a spit."
 - id: 11362
+  examine: "It's a raw Rabbit on a spit."
 - id: 11363
+  examine: "It's an iron spit."
 - id: 11364
+  examine: "A stone pillar that looks like Bob the Cat."
   depleted: 11367
-  examine: "Downhill is easy, right?"
 - id: 11365
-  examine: "This shouldn't be too hard."
+  examine: "A stone pillar that looks like Zamorak."
 - id: 11366
-  examine: "Down we go..."
+  examine: "A stone pillar that looks like Guthix."
 - id: 11367
-  examine: "... and up we go..."
+  examine: "A stone pillar that looks like Saradomin."
 - id: 11368
-  examine: "... and down we go..."
 - id: 11369
-  examine: "... and down we go..."
 - id: 11370
-  examine: "... and up we go..."
 - id: 11371
-  examine: "... and finally all the way down."
 - id: 11372
 - id: 11373
-  examine: "Parkour; Go!"
 - id: 11374
-  examine: "Over!"
 - id: 11375
-  examine: "Over!"
 - id: 11376
-  examine: "Over!"
 - id: 11377
-  examine: "Try not to belly-flop."
+  examine: "A large church door."
 - id: 11378
-  examine: "This would be easier if the rope were under more tension!"
 - id: 11379
 - id: 11380
-  examine: "If that lid's sturdy enough, you could climb on this momentarily."
 - id: 11381
-  examine: "Also known as a trampoline for ninjas."
 - id: 11382
-  examine: "This would be a good time not to lose your grip."
 - id: 11383
-  examine: "It's not too big."
+  examine: "A stone pillar that looks like Saradomin."
 - id: 11384
-  examine: "You might be able to grab it."
+  examine: "A stone pillar that looks like Saradomin."
 - id: 11385
-  examine: "Perhaps you can get a grip here and climb the wall."
+  examine: "A stone pillar that looks like Saradomin."
 - id: 11386
-  examine: "This looks quite scary."
+  examine: "A stone pillar that looks like Guthix."
 - id: 11387
+  examine: "A stone pillar that looks like Guthix."
 - id: 11388
+  examine: "A stone pillar that looks like Guthix."
 - id: 11389
-  examine: "Tread softly, for you tread on my fronds."
+  examine: "A stone pillar that looks like Zamorak."
 - id: 11390
-  examine: "You can't miss the ground!"
+  examine: "A stone pillar that looks like Zamorak."
 - id: 11391
-  examine: "Some of the wood is jutting out here."
+  examine: "A stone pillar that looks like Zamorak."
 - id: 11392
-  examine: "Hopefully the roof is well maintained."
+  examine: "A stone pillar that looks like Bob the Cat."
 - id: 11393
-  examine: "It's hard not to look down when the camera won't point up."
+  examine: "A stone pillar that looks like Bob the Cat."
 - id: 11394
+  examine: "A stone pillar that looks like Bob the Cat."
 - id: 11395
-  examine: "You should be able to shuffle along the sloping roof."
+  examine: "A candle in a holder."
 - id: 11396
-  examine: "Hop onto the Navigator's hut."
+  examine: "A melted candle."
 - id: 11397
-  examine: "This is a long one."
+  examine: "A candle flame."
 - id: 11398
-  examine: "All that has been, all that is and space for all that will be."
+  examine: "Interface surround."
 - id: 11399
-  examine: "Looks like a tight squeeze."
+  examine: "Interface button up."
 - id: 11400
-  examine: "This huge web blocks your path."
+  examine: "Interface button down."
 - id: 11401
-  examine: "A huge web, cruelly slashed in half."
+  examine: "Interface button left."
 - id: 11402
+  examine: "Interface button right."
 - id: 11403
+  examine: "Interface button ignite."
 - id: 11404
-  examine: "Leap safely down onto a nice, soft pile of fish."
+  examine: "Hot!"
 - id: 11405
-  examine: "Up we go!"
+  examine: "Hot!"
 - id: 11406
-  examine: "Over!"
+  examine: "Hot!"
 - id: 11407
 - id: 11408
 - id: 11409
@@ -18214,55 +18513,67 @@
 - id: 11418
   examine: "Hard to notice, but this mud looks disturbed."
 - id: 11419
+  examine: "A rocky outcrop."
 - id: 11420
+  examine: "A rocky outcrop."
 - id: 11421
+  examine: "A rocky outcrop."
 - id: 11422
+  examine: "A rocky outcrop."
 - id: 11423
   examine: "It's a grill."
 - id: 11424
-  examine: "Looks slippery!"
+  examine: "A rocky outcrop."
 - id: 11425
-  examine: "Looks slippery!"
+  examine: "A rocky outcrop."
 - id: 11426
-  examine: "A deposit of rocks."
+  examine: "A rocky outcrop."
 - id: 11427
-  examine: "A deposit of rocks."
+  examine: "A rocky outcrop."
 - id: 11428
-  examine: "A deposit of rocks."
+  examine: "A rocky outcrop."
 - id: 11429
-  examine: "Over!"
+  examine: "A rocky outcrop."
 - id: 11430
-  examine: "Over!"
+  examine: "A rocky outcrop."
 - id: 11431
-  examine: "A deposit of rocks."
+  examine: "A rocky outcrop."
 - id: 11432
-  examine: "A deposit of rocks."
+  examine: "A rocky outcrop."
 - id: 11433
-  examine: "A deposit of rocks."
+  examine: "A rocky outcrop."
 - id: 11434
+  examine: "A rocky outcrop."
   depleted: 11435
-  examine: "A deposit of rocks."
 - id: 11435
+  examine: "A rocky outcrop."
   depleted: 11436
-  examine: "A deposit of rocks."
 - id: 11436
+  examine: "A rocky outcrop."
   depleted: 11925
 - id: 11437
+  examine: "A rocky outcrop."
   depleted: 11438
 - id: 11438
+  examine: "A rocky outcrop."
   depleted: 11439
 - id: 11439
+  examine: "A rocky outcrop."
   depleted: 11926
 - id: 11440
+  examine: "A rocky outcrop."
   depleted: 11441
 - id: 11441
+  examine: "A rocky outcrop."
   depleted: 11442
-  examine: "A collection of rocks over what looks like a depression."
 - id: 11442
+  examine: "A rocky outcrop."
   depleted: 11927
 - id: 11443
+  examine: "A rocky outcrop."
   depleted: 11444
 - id: 11444
+  examine: "A rocky outcrop."
   depleted: 11915
 - id: 11445
 - id: 11446
@@ -18304,11 +18615,9 @@
 - id: 11468
   examine: "Handy that they're already lit."
 - id: 11469
-  examine: "Disturbingly, its eyes look everywhere in the room except at you."
+  examine: "Disturbingly its eyes look everywhere in the room except at you."
 - id: 11470
-  examine: "The door is closed."
 - id: 11471
-  examine: "The door is not closed."
 - id: 11472
   examine: "Little candles flickering."
 - id: 11473
@@ -18422,11 +18731,17 @@
 - id: 11551
   examine: "It's a table for putting objects on."
 - id: 11552
+  examine: "A rocky outcrop."
 - id: 11553
+  examine: "A rocky outcrop."
 - id: 11554
+  examine: "A rocky outcrop."
 - id: 11555
+  examine: "A rocky outcrop."
 - id: 11556
+  examine: "A rocky outcrop."
 - id: 11557
+  examine: "A rocky outcrop."
 - id: 11558
 - id: 11559
 - id: 11560
@@ -18495,166 +18810,143 @@
 - id: 11615
   examine: "A barbarian flag."
 - id: 11616
-  examine: "Keeps the wind out."
 - id: 11617
-  examine: "It would keep the wind out better if it were closed."
 - id: 11618
 - id: 11619
   examine: "Generally used for putting things on."
 - id: 11620
-  examine: "The entrance to the barbarians' longhall."
 - id: 11621
-  examine: "The entrance to the barbarians' longhall."
 - id: 11622
 - id: 11623
 - id: 11624
-  examine: "The entrance to the barbarians' longhall."
 - id: 11625
-  examine: "The entrance to the barbarians' longhall."
 - id: 11626
   examine: "Items are for sale here."
 - id: 11627
   examine: "A small wooden table."
 - id: 11628
 - id: 11629
-  examine: "It's getting substantially bigger."
+  examine: "A rocky outcrop that looks rather crumbly."
 - id: 11630
-  examine: "Over!"
+  examine: "South to Falador :: West to Taverley :: East to Varrock."
 - id: 11631
-  examine: "Walk the plank!"
+  examine: "South to Falador :: West to Taverley :: East to Varrock."
 - id: 11632
 - id: 11633
-  examine: "How's your balance?"
 - id: 11634
-  examine: "Try not to belly-flop."
+  examine: "A rock."
 - id: 11635
-  examine: "Looks like whoever uses this has claws on their hands."
+  examine: "A rock."
 - id: 11636
-  examine: "I wonder what's under it?"
+  examine: "A rock."
 - id: 11637
-  examine: "I wonder what's down there?"
+  examine: "A rock."
 - id: 11638
-  examine: "A hurdle."
+  examine: "A rock."
 - id: 11639
-  examine: "A hurdle."
+  examine: "A rock."
 - id: 11640
-  examine: "A hurdle."
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11641
-  examine: "A climbing wall made from skulls."
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11642
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11643
-  examine: "A very slippery stepping stone."
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11644
-  examine: "A scary zip line for teeth?"
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11645
-  examine: "A scary zip line for teeth?"
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11646
-  examine: "A scary zip line for teeth?"
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11647
-  examine: "A scary zip line for teeth?"
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11648
-  examine: "A scary zip line for teeth?"
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11649
-  examine: "A scary zip line for teeth?"
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11650
-  examine: "A scary zip line for teeth?"
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11651
-  examine: "A goal."
+  examine: "Keeps unwelcome folk out of Falador."
 - id: 11652
-  examine: "A goal."
 - id: 11653
-  examine: "A goal."
 - id: 11654
 - id: 11655
 - id: 11656
 - id: 11657
-  examine: "A pipe I can squeeze through."
+  examine: "A rack for displaying fine maces."
 - id: 11658
+  examine: "Shelves for maces."
 - id: 11659
+  examine: "A barrel of maces."
 - id: 11660
+  examine: "A table bearing a fine selection of maces."
 - id: 11661
-  examine: "This leads to the practice tower."
+  examine: "A handy source of water."
 - id: 11662
-  examine: "This leads back down to the guild."
+  examine: "Fine gems for sale!"
 - id: 11663
-  examine: "I wonder if I can hit a bullseye?"
+  examine: "Precious stones for sale."
 - id: 11664
 - id: 11665
-  examine: "The door to the Ranging Guild."
 - id: 11666
-  examine: "Goes up and down!"
+  examine: "A hot furnace."
 - id: 11667
-  examine: "I wonder what's under it?"
 - id: 11668
-  examine: "I wonder what's down there?"
 - id: 11669
-  examine: "A wooden barrel."
 - id: 11670
 - id: 11671
-  examine: "An empty ale barrel."
 - id: 11672
-  examine: "A barrel of bad ale."
 - id: 11673
-  examine: "A barrel of unfermented liquid."
 - id: 11674
-  examine: "A barrel of bad cider."
+  examine: "Rising Sun Tavern."
 - id: 11675
-  examine: "A barrel of Dwarven Stout."
+  examine: "Rising Sun Tavern, Falador."
 - id: 11676
-  examine: "A barrel of mature Dwarven Stout."
 - id: 11677
-  examine: "A barrel of Asgarnian Ale."
+  examine: "Powers the spinning pole outside."
 - id: 11678
-  examine: "A barrel of mature Asgarnian Ale."
+  examine: "The traditional sign of a barber."
 - id: 11679
-  examine: "A barrel of Greenmans Ale."
 - id: 11680
-  examine: "A barrel of mature Greenmans Ale."
 - id: 11681
-  examine: "A barrel of Wizards Mind Bomb."
 - id: 11682
-  examine: "A barrel of mature Wizards Mind Bomb."
+  examine: "A small wooden table."
 - id: 11683
-  examine: "A barrel of Dragon Bitter."
 - id: 11684
-  examine: "A barrel of mature Dragon Bitter."
 - id: 11685
-  examine: "A barrel of Moonlight Mead."
 - id: 11686
-  examine: "A barrel of mature Moonlight Mead."
 - id: 11687
-  examine: "A barrel of Axeman's Folly."
 - id: 11688
-  examine: "A barrel of mature Axeman's Folly."
 - id: 11689
-  examine: "A barrel of Chef's Delight."
 - id: 11690
-  examine: "A barrel of mature Chef's Delight."
 - id: 11691
-  examine: "A barrel of Slayer's Respite."
 - id: 11692
-  examine: "A barrel of mature Slayer's Respite."
 - id: 11693
-  examine: "A barrel of Cider."
+  examine: "A statue of a famous White Knight."
 - id: 11694
-  examine: "A barrel of mature Cider."
+  examine: "A statue of a famous White Knight."
 - id: 11695
-  examine: "Turns milk into other dairy products."
+  examine: "A statue of a famous White Knight."
 - id: 11696
-  examine: "Turns milk into other dairy products."
+  examine: "A statue of a famous White Knight."
 - id: 11697
-  examine: "This stall smells great."
+  examine: "A statue of a famous White Knight."
 - id: 11698
+  examine: "Filled to the brim with knowledge."
 - id: 11699
+  examine: "The flag of Asgarnia."
 - id: 11700
+  examine: "I thought he'd be bigger than that."
 - id: 11701
-  examine: "A teleportation scroll that seems to be fixed to the ground of Zulrah's shrine."
+  examine: "Big beard, robes. Yeah, that's Saradomin."
 - id: 11702
-  examine: "For observing what's going on further into the swamp."
 - id: 11703
 - id: 11704
 - id: 11705
 - id: 11706
+  examine: "Nicely planted."
 - id: 11707
 - id: 11708
 - id: 11709
@@ -18668,176 +18960,158 @@
 - id: 11717
 - id: 11718
 - id: 11719
-  examine: "A secure door."
 - id: 11720
-  examine: "A secure door."
 - id: 11721
-  examine: "A metal gate bars your way."
 - id: 11722
-  examine: "A metal gate bars your way."
 - id: 11723
-  examine: "A secure door."
 - id: 11724
-  examine: "A secure door."
+  examine: "I can climb up these stairs."
 - id: 11725
-  examine: "A secure door."
+  examine: "I can climb down these stairs."
 - id: 11726
-  examine: "A secure door."
 - id: 11727
-  examine: "A secure door."
+  examine: "I can climb this."
 - id: 11728
-  examine: "A secure door."
+  examine: "I can climb down this."
 - id: 11729
-  examine: "Fine silk woven by experts."
+  examine: "I can climb up these stairs."
 - id: 11730
-  examine: "This stall smells great."
 - id: 11731
-  examine: "Precious stones from around the world."
+  examine: "I can climb down these stairs."
 - id: 11732
-  examine: "All manner of animal clothing."
+  examine: "I can climb up these stairs."
 - id: 11733
-  examine: "Spices to tingle your taste buds."
+  examine: "I can climb down these stairs."
 - id: 11734
-  examine: "Fine silver items are for sale here."
+  examine: "I can climb these stairs."
 - id: 11735
-  examine: "I wonder what's inside it."
+  examine: "They go down."
 - id: 11736
-  examine: "I wonder what's inside it."
+  examine: "I can climb these stairs."
 - id: 11737
-  examine: "I wonder what's inside it."
+  examine: "They go down."
 - id: 11738
-  examine: "I wonder what's inside it."
+  examine: "A nice sturdy-looking table."
 - id: 11739
-  examine: "I wonder what's inside it."
+  examine: "Allows access to above level."
 - id: 11740
-  examine: "I wonder what's inside it."
+  examine: "Allows access to above level."
 - id: 11741
-  examine: "I wonder what's inside it."
+  examine: "Allows access to level below."
 - id: 11742
-  examine: "I wonder what's inside it."
+  examine: "Allows access to level below."
 - id: 11743
+  examine: "A nice sturdy looking table."
 - id: 11744
+  examine: "Small wooden boxes."
 - id: 11745
-  examine: "It's getting pretty darn big."
+  examine: "Wooden crates."
 - id: 11746
+  examine: "A wooden stool."
 - id: 11747
-  examine: "This is about as big as it gets."
+  examine: "A basic bed."
 - id: 11748
-  examine: "Your vine bears much fruit."
+  examine: "Nice banquet table."
 - id: 11749
+  examine: "A sturdy-looking round table."
 - id: 11750
-  examine: "Your vine bears much fruit."
 - id: 11751
 - id: 11752
-  examine: "Your vine bears fruit."
 - id: 11753
+  examine: "Armour of a White Knight. Decorative, but still effective."
 - id: 11754
-  examine: "Your vine bears some fruit."
 - id: 11755
+  examine: "'Concerned about theft? Set a Bank PIN today!'"
 - id: 11756
-  examine: "Your vine bears a little fruit."
+  examine: "'Customers are reminded NEVER to tell ANYONE their password.'"
 - id: 11757
+  examine: "This chest contains an impressive amount of Gold!!"
 - id: 11758
-  examine: "Your vine is nearly out of juice."
+  examine: "The bank teller will serve you from here."
 - id: 11759
+  examine: "Hope springs eternal."
 - id: 11760
-  examine: "It lived a fruitful life."
+  examine: "A comfortable seat."
 - id: 11761
-  examine: "Don't eat any!"
+  examine: "A carving of a figure from the history of RuneScape."
 - id: 11762
-  examine: "Presumably that's what one calls a scarecrow in coastal regions."
+  examine: "A source of foamy neurotoxin."
 - id: 11763
-  examine: "A door."
+  examine: "Where drunkards may be found."
 - id: 11764
+  examine: "So clean you could eat your dinner off it."
 - id: 11765
-  examine: "This door is locked."
+  examine: "I'd really hate to drink anything that had been in here."
 - id: 11766
-  examine: "A gate."
+  examine: "Smells alcoholic."
 - id: 11767
-  examine: "A gate."
+  examine: "Dusty old books."
 - id: 11768
-  examine: "It looks small and slippery."
+  examine: "Storage for all needs."
 - id: 11769
+  examine: "Storage for all needs."
 - id: 11770
-  examine: "A gate."
+  examine: "Storage for all needs."
 - id: 11771
-  examine: "A gate."
+  examine: "Storage for all needs."
 - id: 11772
-  examine: "The door is open."
 - id: 11773
-  examine: "The door is closed."
 - id: 11774
-  examine: "The door is open."
 - id: 11775
-  examine: "The door is closed."
 - id: 11776
-  examine: "The door is open."
 - id: 11777
-  examine: "The door is closed."
 - id: 11778
-  examine: "The door is open."
 - id: 11779
 - id: 11780
-  examine: "The door is closed."
 - id: 11781
-  examine: "The door is boarded up."
 - id: 11782
-  examine: "The door is open."
+  examine: "What ancient rites were performed here?"
 - id: 11783
-  examine: "The door is closed."
+  examine: "What ancient rites were performed here?"
 - id: 11784
+  examine: "What ancient rites were performed here?"
 - id: 11785
+  examine: "What ancient rites were performed here?"
 - id: 11786
 - id: 11787
 - id: 11788
-  examine: "Staff only beyond this point!"
 - id: 11789
-  examine: "I can climb up these stairs."
+  examine: "Weathered rocks."
 - id: 11790
-  examine: "I can climb up these stairs."
+  examine: "Weathered rocks."
 - id: 11791
-  examine: "I can climb these stairs."
+  examine: "Weathered rocks."
 - id: 11792
-  examine: "I can climb these stairs."
 - id: 11793
-  examine: "I can climb down these stairs."
+  examine: "Best used with a bucket."
 - id: 11794
-  examine: "Allows access to level above."
+  examine: "Ready for a quick snip?"
 - id: 11795
-  examine: "Allows access to level below."
+  examine: "Put your head in my hands..."
 - id: 11796
-  examine: "I can climb up these stairs."
+  examine: "Ooh - pretty!"
 - id: 11797
-  examine: "I can climb up these stairs."
 - id: 11798
-  examine: "I can climb up these stairs."
 - id: 11799
-  examine: "They go down."
+  examine: "Makes your hair stay curly."
 - id: 11800
-  examine: "For descending."
 - id: 11801
-  examine: "Allows access to level above."
 - id: 11802
-  examine: "Allows access to level below."
 - id: 11803
-  examine: "I can climb down this."
 - id: 11804
-  examine: "I can climb this."
 - id: 11805
-  examine: "I can climb up these stairs."
 - id: 11806
-  examine: "A way out of this ghastly place."
 - id: 11807
-  examine: "I can climb up these stairs."
 - id: 11808
-  examine: "A fine wine, like a good fantasy world, becomes better with age."
 - id: 11809
-  examine: "Mass-produced for the discerning drinker."
 - id: 11810
 - id: 11811
 - id: 11812
+  examine: "Running water - very nice!"
 - id: 11813
+  examine: "Might be handy for a workman."
 - id: 11814
+  examine: "Might be handy for a workman."
 - id: 11815
 - id: 11816
 - id: 11817
@@ -18855,37 +19129,31 @@
 - id: 11829
 - id: 11830
 - id: 11831
-  examine: "This looks like the way out."
 - id: 11832
-  examine: "A cave deep into the volcano."
 - id: 11833
-  examine: "A cave deeper into the volcano."
 - id: 11834
-  examine: "A cave deeper into the volcano."
 - id: 11835
-  examine: "A cave deep into the volcano."
 - id: 11836
-  examine: "This looks like the way out."
 - id: 11837
 - id: 11838
 - id: 11839
 - id: 11840
+  examine: "A pile of bricks."
 - id: 11841
+  examine: "A pile of bricks."
 - id: 11842
 - id: 11843
-  examine: "The barrier of heat is down."
 - id: 11844
-  examine: "A barrier of heat."
+  examine: "It looks like I might be able to climb over this piece of the wall..."
 - id: 11845
-  examine: "A barrier of heat."
 - id: 11846
-  examine: "A barrier of heat."
 - id: 11847
 - id: 11848
+  examine: "An attractively laid out collection of ranging weapons."
 - id: 11849
+  examine: "Contains washing items."
 - id: 11850
 - id: 11851
-  examine: "Hot enough to cook your breakfast on."
 - id: 11852
 - id: 11853
 - id: 11854
@@ -18906,7 +19174,6 @@
 - id: 11866
   depleted: 9389
 - id: 11867
-  examine: "I wonder what's down there?"
 - id: 11868
   examine: "A powerful ranging device that fires metal balls."
 - id: 11869
@@ -18978,137 +19245,155 @@
 - id: 11914
   examine: "A dead bush."
 - id: 11915
+  examine: "A rocky outcrop."
   depleted: 11928
 - id: 11916
+  examine: "A rocky outcrop."
   depleted: 11917
 - id: 11917
+  examine: "A rocky outcrop."
   depleted: 11918
 - id: 11918
+  examine: "A rocky outcrop."
   depleted: 11929
 - id: 11919
+  examine: "A rocky outcrop."
   depleted: 11920
 - id: 11920
+  examine: "A rocky outcrop."
   depleted: 11921
-  examine: "A deposit of rocks."
 - id: 11921
+  examine: "A rocky outcrop."
   depleted: 12711
-  examine: "A deposit of rocks."
 - id: 11922
+  examine: "A rocky outcrop."
   depleted: 11923
-  examine: "A deposit of rocks."
 - id: 11923
+  examine: "A rocky outcrop."
   depleted: 11924
-  examine: "A deposit of rocks."
 - id: 11924
+  examine: "A rocky outcrop."
   depleted: 12712
-  examine: "A rock with a pickaxe and mining tools."
 - id: 11925
+  examine: "A rocky outcrop."
 - id: 11926
-  examine: "An egg incubated in the lava."
+  examine: "A rocky outcrop."
 - id: 11927
+  examine: "A rocky outcrop."
 - id: 11928
+  examine: "A rocky outcrop."
 - id: 11929
+  examine: "A rocky outcrop."
 - id: 11930
+  examine: "A rocky outcrop."
   depleted: 10580
-  examine: "A very tall column of ice."
 - id: 11931
+  examine: "A rocky outcrop."
   depleted: 11553
-  examine: "A deposit of rocks."
 - id: 11932
+  examine: "A rocky outcrop."
   depleted: 10582
-  examine: "A deposit of rocks."
 - id: 11933
+  examine: "A rocky outcrop."
   depleted: 10580
-  examine: "A deposit of rocks."
 - id: 11934
+  examine: "A rocky outcrop."
   depleted: 11553
-  examine: "A deposit of rocks."
 - id: 11935
+  examine: "A rocky outcrop."
   depleted: 10582
 - id: 11936
+  examine: "A rocky outcrop."
   depleted: 10580
 - id: 11937
+  examine: "A rocky outcrop."
   depleted: 11553
-  examine: "Formed over many years of dripping limestone."
 - id: 11938
+  examine: "A rocky outcrop."
   depleted: 10582
-  examine: "Formed over many years of dripping limestone."
 - id: 11939
+  examine: "A rocky outcrop."
   depleted: 10580
-  examine: "Formed over many years of dripping limestone."
 - id: 11940
-  examine: "Formed over many years of dripping limestone."
+  examine: "A rocky outcrop."
 - id: 11941
+  examine: "A rocky outcrop."
   depleted: 10582
-  examine: "Formed over many years of dripping limestone."
 - id: 11942
+  examine: "A rocky outcrop."
   depleted: 10580
-  examine: "Formed over many years of dripping limestone."
 - id: 11943
+  examine: "A rocky outcrop."
   depleted: 11553
-  examine: "A limestone ceiling growth."
 - id: 11944
+  examine: "A rocky outcrop."
   depleted: 10582
-  examine: "Formed over many years of dripping limestone."
 - id: 11945
-  examine: "A limestone ceiling growth."
+  examine: "A rocky outcrop."
 - id: 11946
+  examine: "A rocky outcrop."
   depleted: 11556
-  examine: "Limestone floor growth."
 - id: 11947
+  examine: "A rocky outcrop."
   depleted: 11557
 - id: 11948
-  depleted: 11555
   examine: "A rocky outcrop."
+  depleted: 11555
 - id: 11949
-  depleted: 11556
   examine: "A rocky outcrop."
-- id: 11950
-  depleted: 11557
-  examine: "A limestone ceiling growth."
-- id: 11951
-  depleted: 11555
-  examine: "It looks like spring in there."
-- id: 11952
   depleted: 11556
-  examine: "It looks like summer in there."
-- id: 11953
+- id: 11950
+  examine: "A rocky outcrop."
   depleted: 11557
-  examine: "It looks like autumn in there."
-- id: 11954
+- id: 11951
+  examine: "A rocky outcrop."
   depleted: 11555
-  examine: "It looks like winter in there."
+- id: 11952
+  examine: "A rocky outcrop."
+  depleted: 11556
+- id: 11953
+  examine: "A rocky outcrop."
+  depleted: 11557
+- id: 11954
+  examine: "A rocky outcrop."
+  depleted: 11555
 - id: 11955
+  examine: "A rocky outcrop."
   depleted: 11556
 - id: 11956
+  examine: "A rocky outcrop."
   depleted: 11557
 - id: 11957
+  examine: "A rocky outcrop."
   depleted: 11555
 - id: 11958
+  examine: "A rocky outcrop."
   depleted: 11556
 - id: 11959
+  examine: "A rocky outcrop."
   depleted: 11557
 - id: 11960
+  examine: "A rocky outcrop."
   depleted: 11555
 - id: 11961
+  examine: "A rocky outcrop."
   depleted: 11556
 - id: 11962
+  examine: "A rocky outcrop."
   depleted: 11557
 - id: 11963
+  examine: "A rocky outcrop."
   depleted: 11555
 - id: 11964
+  examine: "A rocky outcrop."
   depleted: 11556
 - id: 11965
+  examine: "A rocky outcrop."
 - id: 11966
-  examine: "An egg incubated in the lava."
 - id: 11967
-  examine: "An egg incubated in the lava."
 - id: 11968
-  examine: "Who's the man?"
 - id: 11969
-  examine: "A wooden crate."
 - id: 11970
-  examine: "Some wooden crates."
 - id: 11971
 - id: 11972
 - id: 11973
@@ -19117,9 +19402,7 @@
 - id: 11976
 - id: 11977
 - id: 11978
-  examine: "A natural forge using volcanic heat."
 - id: 11979
-  examine: "I spy with my little eye..."
 - id: 11980
 - id: 11981
 - id: 11982
@@ -19128,7 +19411,6 @@
 - id: 11985
 - id: 11986
 - id: 11987
-  examine: "It looks like summer in there."
 - id: 11988
 - id: 11989
 - id: 11990
@@ -19141,11 +19423,15 @@
 - id: 11997
 - id: 11998
 - id: 11999
+  examine: "Better not eat them!"
   depleted: 12007
 - id: 12000
+  examine: "Better not eat them!"
   depleted: 12001
 - id: 12001
+  examine: "Better not eat them!"
 - id: 12002
+  examine: "Better not eat them!"
 - id: 12003
   examine: "Better not eat them!"
 - id: 12004
@@ -19227,10 +19513,9 @@
 - id: 12065
   examine: "It says Nuff is a healer."
 - id: 12066
-  examine: "An assortment of colourful bubbling and smoking potions!"
 - id: 12067
-  examine: "An assortment of colourful bubbling and smoking potions!"
 - id: 12068
+  examine: "An assortment of colourful bubbling and smoking potions!"
 - id: 12069
 - id: 12070
 - id: 12071
@@ -19315,12 +19600,14 @@
 - id: 12125
   examine: "Here lies Guy, he told a lie, so we swung him from the gallows high."
 - id: 12126
+  examine: "Looks suspicious."
 - id: 12127
+  examine: "A wall jutting out into the path."
 - id: 12128
 - id: 12129
 - id: 12130
 - id: 12131
-  examine: "Brick built steps leading out of the crypt."
+  examine: "Spooky."
 - id: 12132
   examine: "Spooky."
 - id: 12133
@@ -19331,8 +19618,11 @@
   examine: "Contains dead people."
 - id: 12136
 - id: 12137
+  examine: "A wild cadava berry bush."
 - id: 12138
+  examine: "A wild red berry bush."
 - id: 12139
+  examine: "A perfectly appointed rosebush."
 - id: 12140
   examine: "The sort of bench you get in churches."
 - id: 12141
@@ -19379,12 +19669,17 @@
 - id: 12163
 - id: 12164
 - id: 12165
+  examine: "canoe"
 - id: 12166
 - id: 12167
 - id: 12168
+  examine: "canoe"
 - id: 12169
+  examine: "canoe"
 - id: 12170
+  examine: "canoe"
 - id: 12171
+  examine: "canoe"
 - id: 12172
 - id: 12173
 - id: 12174
@@ -19450,11 +19745,17 @@
   examine: "I can climb out of this cave from here."
 - id: 12231
 - id: 12232
+  examine: "A place to keep all your clothes & equipment."
 - id: 12233
+  examine: "A trophy of a mighty slayer!"
 - id: 12234
+  examine: "A trophy of a mighty slayer!"
 - id: 12235
+  examine: "A trophy of a mighty slayer!"
 - id: 12236
+  examine: "A trophy of a master fisher."
 - id: 12237
+  examine: "A trophy of a master fisher."
 - id: 12238
 - id: 12239
   examine: "It's a Vanilla Planifolia of the Orchidaceae family."
@@ -19497,22 +19798,22 @@
 - id: 12260
   examine: "Will this take me home?"
 - id: 12261
-  examine: "Glough's experiments must have broken free."
 - id: 12262
-  examine: "Glough's experiments must have broken free."
+  examine: "It probably leads to some sort of cellar."
 - id: 12263
-  examine: "Climb these to travel between floors."
+  examine: "What mysteries lie below?"
 - id: 12264
-  examine: "Climb these to travel between floors."
+  examine: "An oak ladder."
 - id: 12265
   examine: "Old wooden steps."
 - id: 12266
+  examine: "Rickety wooden steps lead down into the lair of evil."
 - id: 12267
   examine: "What evil lurks below?"
 - id: 12268
   examine: "Rickety wooden steps lead down into the lair of evil."
 - id: 12269
-  examine: "Hmmmm... home cooking."
+  examine: "Hmmmm...home cooking."
 - id: 12270
 - id: 12271
 - id: 12272
@@ -19526,8 +19827,8 @@
   depleted: 12283
 - id: 12278
 - id: 12279
-  depleted: 12283
   examine: "Wash your hands!"
+  depleted: 12283
 - id: 12280
   examine: "A nice sturdy looking table."
 - id: 12281
@@ -19604,12 +19905,15 @@
 - id: 12328
   examine: "He's been frozen in time."
 - id: 12329
+  examine: "He's been frozen in time."
 - id: 12330
   examine: "He's been frozen in time."
 - id: 12331
+  examine: "He's been frozen in time."
 - id: 12332
   examine: "He's been frozen in time."
 - id: 12333
+  examine: "He's been frozen in time."
 - id: 12334
   examine: "He's been frozen in time."
 - id: 12335
@@ -19620,23 +19924,23 @@
 - id: 12339
   examine: "He's been frozen in time."
 - id: 12340
+  examine: "He's been frozen in time."
 - id: 12341
   examine: "He's been frozen in time."
 - id: 12342
+  examine: "He's been frozen in time."
 - id: 12343
   examine: "He's been frozen in time."
 - id: 12344
 - id: 12345
   examine: "He's been frozen in time."
 - id: 12346
+  examine: "An ornate-fashioned door."
 - id: 12347
   examine: "He's been frozen in time."
 - id: 12348
-  examine: "An ornate-fashioned door."
 - id: 12349
-  examine: "A large double door."
 - id: 12350
-  examine: "A large double door."
 - id: 12351
   examine: "Some kind of strange time barrier."
 - id: 12352
@@ -19736,6 +20040,7 @@
 - id: 12415
   examine: "Cutlery with an identity crisis."
 - id: 12416
+  examine: "An empty wooden barrel."
 - id: 12417
 - id: 12418
 - id: 12419
@@ -19769,17 +20074,11 @@
 - id: 12443
   examine: "A neatly stacked pair of crates."
 - id: 12444
-  examine: "The door is closed."
 - id: 12445
-  examine: "The door is open."
 - id: 12446
-  examine: "A large double door."
 - id: 12447
-  examine: "A large double door."
 - id: 12448
-  examine: "A large double door."
 - id: 12449
-  examine: "A large double door."
 - id: 12450
   examine: "A rough wooden table."
 - id: 12451
@@ -19960,6 +20259,7 @@
 - id: 12548
   examine: "Some wooden crates."
 - id: 12549
+  examine: "A large old tree, pushed over by Rantz."
 - id: 12550
   examine: "A large old tree."
 - id: 12551
@@ -19988,113 +20288,128 @@
 - id: 12563
   examine: "Useful for ogre dinners."
 - id: 12564
-  depleted: 3431
   examine: "A pile of rock."
+  depleted: 3431
 - id: 12565
   examine: "A pile of rock."
 - id: 12566
-  depleted: 33402
   examine: "A pile of rock."
+  depleted: 33402
 - id: 12567
   examine: "A pile of rock."
 - id: 12568
-  examine: "A tooth shaped rock formation protruding from the floor."
+  examine: "A very slippery stepping stone."
 - id: 12569
+  examine: "A very slippery stepping stone."
 - id: 12570
+  examine: "A terribly tall tropical tree."
 - id: 12571
+  examine: "A terribly tall tropical tree."
 - id: 12572
+  examine: "A terribly tall tropical tree."
 - id: 12573
-  examine: "A tooth shaped rock formation protruding from the ceiling."
+  examine: "I can traverse these."
 - id: 12574
 - id: 12575
-  examine: "A tooth shaped rock formation protruding from the floor."
+  examine: "I can traverse these."
 - id: 12576
-  examine: "A tooth shaped rock formation protruding from the floor."
+  examine: "A climbing wall made from skulls."
 - id: 12577
-  examine: "A tooth shaped rock formation protruding from the ceiling."
 - id: 12578
-  examine: "A tooth shaped rock formation protruding from the floor."
+  examine: "For swinging on."
 - id: 12579
-  examine: "A huge lump of rock."
+  examine: "A terribly tall tropical tree."
 - id: 12580
-  examine: "Intimidating!"
+  examine: "A terribly tall tropical tree."
 - id: 12581
+  examine: "A vine-choked hole."
 - id: 12582
-  examine: "A deposit of rocks."
 - id: 12583
-  examine: "A deposit of rocks."
 - id: 12584
-  examine: "A deposit of rocks."
 - id: 12585
-  examine: "A deposit of rocks."
 - id: 12586
 - id: 12587
 - id: 12588
-  examine: "A little rock."
 - id: 12589
-  examine: "A small chunk of rock."
+  examine: "A Rock."
 - id: 12590
-  examine: "They're not floating, even though it may look like they are!"
+  examine: "A Rock."
 - id: 12591
-  examine: "A deposit of rocks."
 - id: 12592
-  examine: "A deposit of rocks."
 - id: 12593
-  examine: "A deposit of rocks."
 - id: 12594
-  examine: "A deposit of rocks."
+  examine: "A Snake."
 - id: 12595
+  examine: "A Snake."
 - id: 12596
+  examine: "A Snake."
 - id: 12597
+  examine: "A hole."
 - id: 12598
+  examine: "A Snake."
 - id: 12599
+  examine: "A Snake."
 - id: 12600
+  examine: "A Snake."
 - id: 12601
+  examine: "There's a hole in the roof!"
 - id: 12602
+  examine: "A hole in the ground."
 - id: 12603
+  examine: "This bush seems to glow in the dim light of the cave."
 - id: 12604
-  examine: "Handy for woodcutting."
+  examine: "This banana tree has a strange reddish hue on the leaves."
 - id: 12605
+  examine: "This thin shaft of light is all the Tchiki Monkey Nut bush needs to grow."
 - id: 12606
+  examine: "A Banana Tree."
 - id: 12607
+  examine: "A Banana Tree."
 - id: 12608
+  examine: "A Banana Tree."
 - id: 12609
-  examine: "There must be a source of fresh water somewhere nearby."
+  examine: "A Banana Tree."
 - id: 12610
-  examine: "Rough but adequate."
 - id: 12611
-  examine: "Smells of fried fish."
 - id: 12612
-  examine: "A basic wooden table, suitable for casual meals."
 - id: 12613
 - id: 12614
 - id: 12615
+  examine: "A Bush with monkey nuts growing on it."
 - id: 12616
+  examine: "I can see the surface."
 - id: 12617
-  examine: "It looks like winter in there."
+  examine: "A way out."
 - id: 12618
+  examine: "A terribly tall tropical tree."
 - id: 12619
 - id: 12620
 - id: 12621
 - id: 12622
+  examine: "A vine."
 - id: 12623
 - id: 12624
 - id: 12625
 - id: 12626
 - id: 12627
+  examine: "A terribly tall tropical tree."
 - id: 12628
 - id: 12629
 - id: 12630
 - id: 12631
 - id: 12632
 - id: 12633
+  examine: "It's a rock with a dead snake on."
 - id: 12634
+  examine: "It's a long, hot rock."
 - id: 12635
+  examine: "It's a rock with a dead snake on."
 - id: 12636
+  examine: "It's a rock with a dead, burnt snake on."
 - id: 12637
+  examine: "It's a rock with a cooked snake on. Smells good..."
 - id: 12638
 - id: 12639
-  examine: "It looks like autumn in there."
 - id: 12640
 - id: 12641
 - id: 12642
@@ -20111,16 +20426,14 @@
 - id: 12653
 - id: 12654
 - id: 12655
-  examine: "A furnace; small but effective."
 - id: 12656
-  examine: "A small hole through which I can crawl."
 - id: 12657
-  examine: "A simple door."
+  examine: "I can get out this way."
 - id: 12658
-  examine: "A simple door, now open."
 - id: 12659
 - id: 12660
 - id: 12661
+  examine: "Entrance to the monkey agility arena."
 - id: 12662
 - id: 12663
 - id: 12664
@@ -20143,9 +20456,9 @@
 - id: 12681
 - id: 12682
 - id: 12683
-  examine: "Like a viaduct over troubled waters."
+  examine: "Bridge Corner"
 - id: 12684
-  examine: "These wouldn't be necessary if everyone could sail."
+  examine: "Bridge Corner"
 - id: 12685
 - id: 12686
 - id: 12687
@@ -20173,31 +20486,51 @@
 - id: 12709
 - id: 12710
 - id: 12711
+  examine: "A recently filled in grave."
 - id: 12712
+  examine: "A recently filled in grave."
 - id: 12713
+  examine: "A recently filled in grave."
 - id: 12714
+  examine: "A recently filled in grave."
 - id: 12715
+  examine: "A recently filled in grave."
 - id: 12716
+  examine: "This will show me who is supposed to go here."
 - id: 12717
+  examine: "This will show me who is supposed to go here."
 - id: 12718
+  examine: "This will show me who is supposed to go here."
 - id: 12719
-  examine: "It looks like spring in there."
+  examine: "This will show me who is supposed to go here."
 - id: 12720
+  examine: "This will show me who is supposed to go here."
 - id: 12721
+  examine: "A grave with a coffin in."
 - id: 12722
+  examine: "A grave with a coffin in."
 - id: 12723
-  examine: "The gate of the Piscatoris Fishing Colony."
+  examine: "A grave with a coffin in."
 - id: 12724
+  examine: "A grave with a coffin in."
 - id: 12725
-  examine: "The gate of the Piscatoris Fishing Colony."
+  examine: "A grave with a coffin in."
 - id: 12726
+  examine: "An empty grave."
 - id: 12727
+  examine: "An empty grave."
 - id: 12728
+  examine: "An empty grave."
 - id: 12729
+  examine: "An empty grave."
 - id: 12730
+  examine: "An empty grave."
 - id: 12731
+  examine: "Not the best place to live."
 - id: 12732
+  examine: "This tree has long been dead."
 - id: 12733
+  examine: "This tree has been cut down."
 - id: 12734
   examine: "Rickety table with signs of recent gambling among the remains of past meals."
 - id: 12735
@@ -20217,13 +20550,13 @@
   examine: "Broken parts of an old wall."
 - id: 12743
 - id: 12744
-  examine: "I wonder what's under it?"
 - id: 12745
-  examine: "I wonder what's down there?"
 - id: 12746
   examine: "A pile of rubble."
 - id: 12747
-  examine: "Just a bit pile of rubble, probably from the fallen down building which surrounds you."
+  examine: ">-
+    Just a bit pile of rubble, probably from the fallen down building which
+    surrounds you."
 - id: 12748
   examine: "I can climb this."
 - id: 12749
@@ -20231,20 +20564,25 @@
 - id: 12750
   examine: "You seem to make out some writing."
 - id: 12751
+  examine: "I can climb this."
 - id: 12752
+  examine: "A rotten looking door."
 - id: 12753
+  examine: "A rotten looking door."
 - id: 12754
+  examine: "Where does this go?"
 - id: 12755
 - id: 12756
 - id: 12757
 - id: 12758
 - id: 12759
+  examine: "Where does this go?"
 - id: 12760
+  examine: "Where does this go?"
 - id: 12761
   examine: "A rotten looking door."
 - id: 12762
 - id: 12763
-  examine: "Where does this go?"
 - id: 12764
   examine: "I can climb this."
 - id: 12765
@@ -20263,7 +20601,6 @@
   examine: "A small cave entrance."
 - id: 12772
 - id: 12773
-  examine: "This cave has been boarded up."
 - id: 12774
   examine: "A rock under the surface of the sea."
 - id: 12775
@@ -20293,13 +20630,21 @@
 - id: 12787
   examine: "This wall really needs repairing."
 - id: 12788
+  examine: "An empty wooden crate."
 - id: 12789
+  examine: "An empty wooden crate."
 - id: 12790
+  examine: "An empty wooden crate."
 - id: 12791
+  examine: "An empty wooden crate."
 - id: 12792
+  examine: "There are some tinderboxes on these shelves."
 - id: 12793
+  examine: "There are some axes on these shelves."
 - id: 12794
+  examine: "There are some snails on these shelves."
 - id: 12795
+  examine: "Come bask in the fire's warm glowing warming glow."
 - id: 12796
   examine: "Come bask in the fire's warm glowing warming glow."
 - id: 12797
@@ -20314,6 +20659,7 @@
 - id: 12802
   examine: "The resting place of an ancient warrior of Morytania."
 - id: 12803
+  examine: "An old and broken furnace, there is a huge hole in the steel hood."
 - id: 12804
   examine: "It looks a tad bloody..."
 - id: 12805
@@ -20330,9 +20676,13 @@
 - id: 12812
   examine: "Hardened earth, with bits of rock in it, not easy to move."
 - id: 12813
-  examine: "Hardened earth, with bits of rock in it, not easy to move, slightly broken up."
+  examine: ">-
+    Hardened earth, with bits of rock in it, not easy to move, slightly broken
+    up."
 - id: 12814
-  examine: "Hardened earth, with bits of rock in it, not easy to move, partially broken up."
+  examine: ">-
+    Hardened earth, with bits of rock in it, not easy to move, partially broken
+    up."
 - id: 12815
   examine: "Hard rubble reduced to small pieces, it's quite dusty and not easy to move."
 - id: 12816
@@ -20382,9 +20732,9 @@
 - id: 12855
   examine: "It's a bit broken."
 - id: 12856
-  examine: "A door barely hanging onto its hinges."
+  examine: "A door barely hanging onto it's hinges."
 - id: 12857
-  examine: "Actually, I could do with a drink... never mind, I wasn't thirsty anyway."
+  examine: "Actually, I could do with a drink...never mind...I wasn't thirsty anyway."
 - id: 12858
 - id: 12859
 - id: 12860
@@ -20422,7 +20772,7 @@
 - id: 12882
   examine: "A rotten and decrepid book case."
 - id: 12883
-  examine: "There's nothing here."
+  examine: "Theres nothing here."
 - id: 12884
   examine: "Generally used for putting things on."
 - id: 12885
@@ -20442,8 +20792,9 @@
 - id: 12892
   examine: "A small wooden table."
 - id: 12893
+  examine: "There's nothing on these shelves."
 - id: 12894
-  examine: "The tree has been cut down."
+  examine: "Cut down to feed the furnace."
 - id: 12895
   examine: "It doesn't look healthy..."
 - id: 12896
@@ -20497,11 +20848,13 @@
 - id: 12939
 - id: 12940
 - id: 12941
-  examine: "A beautiful fountain."
+  examine: "A distinctive layer in the rock strata."
 - id: 12942
+  examine: "A distinctive layer in the rock strata."
 - id: 12943
-  examine: "It bears really good fruit."
+  examine: "A distinctive layer in the rock strata."
 - id: 12944
+  examine: "It's not a schooner, it's a sailboat."
 - id: 12945
 - id: 12946
 - id: 12947
@@ -20583,9 +20936,7 @@
 - id: 12999
 - id: 13000
 - id: 13001
-  examine: "The door is closed."
 - id: 13002
-  examine: "The door is open."
 - id: 13003
   examine: "I wonder what's inside."
 - id: 13004
@@ -20688,13 +21039,9 @@
 - id: 13092
 - id: 13093
 - id: 13094
-  examine: "A large double door."
 - id: 13095
-  examine: "A large double door."
 - id: 13096
-  examine: "A large double door."
 - id: 13097
-  examine: "A large double door."
 - id: 13098
 - id: 13099
 - id: 13100
@@ -20706,26 +21053,21 @@
 - id: 13103
   examine: "A way in to the house."
 - id: 13104
-  examine: "A statue of Hazelmere the Ethereal."
 - id: 13105
-  examine: "A broken statue of Glouphrie the Untrusted."
 - id: 13106
-  examine: "A remains of the statue of Glouphrie the Untrusted."
 - id: 13107
-  examine: "I'm sure the tree is glad its wood was put to good use."
+  examine: "I'm sure the animal is glad its fur was put to good use."
 - id: 13108
-  examine: "I'm sure the tree is glad its wood was put to good use."
+  examine: "I'm sure the animal is glad its fur was put to good use."
 - id: 13109
-  examine: "I'm sure the tree is glad its wood was put to good use."
+  examine: "I'm sure the animal is glad its fur was put to good use."
 - id: 13110
-  examine: "I'm sure the tree is glad its wood was put to good use."
+  examine: "I'm sure the animal is glad its fur was put to good use."
 - id: 13111
 - id: 13112
 - id: 13113
 - id: 13114
-  examine: "It's a pretty crystal ornament."
 - id: 13115
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 13116
 - id: 13117
 - id: 13118
@@ -20735,7 +21077,6 @@
 - id: 13120
   examine: "A posh door."
 - id: 13121
-  examine: "A posh door."
 - id: 13122
 - id: 13123
 - id: 13124
@@ -21231,6 +21572,7 @@
 - id: 13370
   examine: "No spider could get that big! It's unrealistic!"
 - id: 13371
+  examine: "Good doggie..."
 - id: 13372
   examine: "Young but still dangerous."
 - id: 13373
@@ -21244,11 +21586,11 @@
 - id: 13377
   examine: "I don't like the look of those spines..."
 - id: 13378
-  examine: "A creature worthy of fear."
+  examine: "A demon."
 - id: 13379
-  examine: "Activate the mushroom and see what happens!"
+  examine: "Rub the mushroom's head and see what pops out!"
 - id: 13380
-  examine: "Activate the mushroom and see what happens!"
+  examine: "Rub the mushroom's head and see what pops out!"
 - id: 13381
   examine: "A place to hang your boxing gloves."
 - id: 13382
@@ -21298,96 +21640,156 @@
 - id: 13404
   examine: "A letter-guessing game with a subtext of death."
 - id: 13405
-  examine: "It bears nearly-ripe fruit."
+  examine: "Use this to leave the house."
 - id: 13406
-  examine: "It bears over-ripe fruit."
+  examine: "Rocky!"
 - id: 13407
-  examine: "It bears withered fruit."
+  examine: "A home for tiny fish and frogs."
 - id: 13408
+  examine: "What a naughty little imp!"
 - id: 13409
+  examine: "What horrors lurk below?"
 - id: 13410
 - id: 13411
+  examine: "One of the most common trees in RuneScape."
 - id: 13412
+  examine: "One of the most common trees in RuneScape."
 - id: 13413
+  examine: "A beautiful oak tree."
 - id: 13414
+  examine: "A lovely addition to the garden."
 - id: 13415
+  examine: "A lovely addition to the garden."
 - id: 13416
+  examine: "A lovely addition to the garden."
 - id: 13417
+  examine: "The tree shimmers with a magical force."
 - id: 13418
+  examine: "A lovely addition to the garden."
 - id: 13419
+  examine: "A lovely addition to the garden."
 - id: 13420
+  examine: "A lovely addition to the garden."
 - id: 13421
+  examine: "A lovely addition to the garden."
 - id: 13422
+  examine: "A lovely addition to the garden."
 - id: 13423
+  examine: "A lovely addition to the garden."
 - id: 13424
+  examine: "A fully grown Willow tree."
 - id: 13425
+  examine: "A plant."
 - id: 13426
+  examine: "A plant."
 - id: 13427
+  examine: "A plant."
 - id: 13428
+  examine: "A plant."
 - id: 13429
+  examine: "A plant."
 - id: 13430
-  examine: "Shayzien official proclamation."
+  examine: "A plant."
 - id: 13431
+  examine: "A plant."
 - id: 13432
-  examine: "Shayzien official proclamation."
+  examine: "A plant."
 - id: 13433
-  examine: "Shayzien official proclamation."
+  examine: "A plant."
 - id: 13434
-  examine: "A snapped shayzien banner."
+  examine: "A plant."
 - id: 13435
-  examine: "A wooden cage filled with rocks."
+  examine: "A plant."
 - id: 13436
-  examine: "A block of wood impaled with metal spikes."
+  examine: "A plant."
 - id: 13437
-  examine: "A block of wood impaled with metal spikes."
+  examine: "A little orange flower."
 - id: 13438
-  examine: "A block of wood impaled with metal spikes."
+  examine: "Lonely as a cloud."
 - id: 13439
-  examine: "A table used to block incoming arrows."
+  examine: "The bluebells are coming!"
 - id: 13440
-  examine: "A table used to block incoming arrows."
+  examine: "A little orange flower."
 - id: 13441
+  examine: "Lonely as a cloud."
 - id: 13442
+  examine: "The bluebells are coming!"
 - id: 13443
+  examine: "A great big sunny flower."
 - id: 13444
+  examine: "Lovely flowers."
 - id: 13445
+  examine: "They smell lovely."
 - id: 13446
+  examine: "Great big sunny flowers."
 - id: 13447
+  examine: "Lovely flowers."
 - id: 13448
+  examine: "They smell lovely."
 - id: 13449
+  examine: "They mark a square."
 - id: 13450
+  examine: "Would probably not stop a charging rhinoceros."
 - id: 13451
+  examine: "Very rural."
 - id: 13452
+  examine: "A little bleak."
 - id: 13453
+  examine: "Marks the boundary of the garden."
 - id: 13454
+  examine: "Just like in Varrock palace!"
 - id: 13455
+  examine: "Very posh!"
 - id: 13456
+  examine: "Like a living wall."
 - id: 13457
+  examine: "Like a living wall."
 - id: 13458
+  examine: "Like a living wall."
 - id: 13459
+  examine: "Like a living wall."
 - id: 13460
+  examine: "Like a living wall."
 - id: 13461
+  examine: "Like a living wall."
 - id: 13462
+  examine: "Like a living wall."
 - id: 13463
+  examine: "Like a living wall."
 - id: 13464
+  examine: "Like a living wall."
 - id: 13465
-  examine: "The iconic sigil of Kourend."
+  examine: "Like a living wall."
 - id: 13466
+  examine: "Like a living wall."
 - id: 13467
+  examine: "Like a living wall."
 - id: 13468
+  examine: "Like a living wall."
 - id: 13469
+  examine: "Like a living wall."
 - id: 13470
+  examine: "Like a living wall."
 - id: 13471
+  examine: "Like a living wall."
 - id: 13472
+  examine: "Like a living wall."
 - id: 13473
+  examine: "Like a living wall."
 - id: 13474
+  examine: "Like a living wall."
 - id: 13475
+  examine: "Like a living wall."
 - id: 13476
-  examine: "I can see fish swimming in the water."
+  examine: "Like a living wall."
 - id: 13477
+  examine: "Run for it! It's a gazebo!"
 - id: 13478
+  examine: "Like a tiny private waterfall."
 - id: 13479
+  examine: "A sculpture of flowing water."
 - id: 13480
+  examine: "Two little fishes forever spew water into the pond."
 - id: 13481
   examine: "A trophy of a mighty slayer!"
 - id: 13482
@@ -21435,10 +21837,11 @@
 - id: 13503
   examine: "I can climb up or go down these stairs."
 - id: 13504
-  examine: "Conveniently placed for the agile."
+  examine: "I can climb down these stairs."
 - id: 13505
   examine: "I can climb up or go down these stairs."
 - id: 13506
+  examine: "I can climb down these stairs."
 - id: 13507
   examine: "Elemental runes made by a skilled runecrafter."
 - id: 13508
@@ -21472,7 +21875,7 @@
 - id: 13522
   examine: "This shield protected a hero from the flames of the dragon Elvarg."
 - id: 13523
-  examine: "An Amulet of Glory, symbol of a member of the Heroes' Guild."
+  examine: "An Amulet of Glory, symbol of a member of the Heroes Guild."
 - id: 13524
   examine: "The pleated white cape of a member of the Legends Guild."
 - id: 13525
@@ -21560,11 +21963,11 @@
 - id: 13566
   examine: "An oak larder to keep food cool."
 - id: 13567
-  examine: "A nicely carved teak larder to keep food cool."
+  examine: "A nicely carved oak larder to keep food cool."
 - id: 13568
   examine: "It's got beer in it."
 - id: 13569
-  examine: "It's got cider in it."
+  examine: "It's got beer in it."
 - id: 13570
   examine: "An oak barrel of Asgarnian ale."
 - id: 13571
@@ -21588,108 +21991,112 @@
 - id: 13580
   examine: "A place for your pet to sleep."
 - id: 13581
+  examine: "It's not the best chair but you think it would take your weight."
 - id: 13582
+  examine: "The ideal thing to sit on."
 - id: 13583
-  examine: "Something has damaged the wall here."
+  examine: "A comfortable seat."
 - id: 13584
-  examine: "Something has damaged the wall here."
+  examine: "A comfortable seat."
 - id: 13585
-  examine: "Something has damaged the wall here."
+  examine: "A comfortable seat."
 - id: 13586
-  examine: "The wall here has been hastily patched."
+  examine: "A comfortable seat."
 - id: 13587
-  examine: "The wall here has been hastily patched."
+  examine: "A comfortable seat."
 - id: 13588
-  examine: "The wall here has been hastily patched."
+  examine: "It's an ugly rug, but better than a bare floor."
 - id: 13589
-  examine: "Big rusty cogs."
+  examine: "It's an ugly rug, but better than a bare floor."
 - id: 13590
-  examine: "Rusty machinery."
+  examine: "It's an ugly rug, but better than a bare floor."
 - id: 13591
-  examine: "Some large fishing weights."
+  examine: "The handkerchief of giants!"
 - id: 13592
-  examine: "The pressing section of a metal pressing machine."
+  examine: "The handkerchief of giants!"
 - id: 13593
-  examine: "The pressing section of a metal pressing machine."
+  examine: "The handkerchief of giants!"
 - id: 13594
-  examine: "The firebox of a metal pressing machine."
+  examine: "An opulent rug woven with gold leaf."
 - id: 13595
-  examine: "There are some logs in the firebox of the press."
+  examine: "An opulent rug woven with gold leaf."
 - id: 13596
-  examine: "The firebox is heating the press."
+  examine: "An opulent rug woven with gold leaf."
 - id: 13597
-  examine: "All-purpose storage."
+  examine: "A good source of books!"
 - id: 13598
-  examine: "Crates that are coated in a thin layer of fishy grease."
+  examine: "A good source of books!"
 - id: 13599
-  examine: "Crates that smell strongly of salty fish."
+  examine: "A good source of books!"
 - id: 13600
-  examine: "A wooden barrel containing lots of fish."
+  examine: "A good source of scrolls!"
 - id: 13601
-  examine: "An empty barrel, suitable for storing fish."
+  examine: "A good source of scrolls!"
 - id: 13602
-  examine: "Someone certainly believes in having lots of barrels!"
+  examine: "A good source of scrolls!"
 - id: 13603
-  examine: "Unusually enough, this barrel smells more strongly of rum than of fish."
 - id: 13604
-  examine: "If they store fish in this dirty old barrow, I hope they clean them later!"
 - id: 13605
-  examine: "A barrow full of fish."
 - id: 13606
-  examine: "'Can I borrow a shallow barrow?' Now say that faster! FASTER!"
+  examine: "???"
 - id: 13607
-  examine: "Apparently there's a lot of paperwork involved in running a Fishing Colony."
+  examine: "???"
 - id: 13608
-  examine: "A large net for pulling in fish."
+  examine: "Your house logo in mahogany."
 - id: 13609
-  examine: "There is seaweed all over this fishing net."
+  examine: "You can light a fire here."
 - id: 13610
+  examine: "A fire burns cosily in the grate."
 - id: 13611
+  examine: "You can light a fire here."
 - id: 13612
+  examine: "A fire burns cosily in the grate."
 - id: 13613
+  examine: "You can light a fire here."
 - id: 13614
+  examine: "A fire burns cosily in the grate."
 - id: 13615
-  examine: "A gateway to Varrock."
+  examine: "A gateway to Varrock"
 - id: 13616
-  examine: "A gateway to Lumbridge."
+  examine: "A gateway to Lumbridge"
 - id: 13617
-  examine: "A gateway to Falador."
+  examine: "A gateway to Falador"
 - id: 13618
-  examine: "A gateway to Camelot."
+  examine: "A gateway to Camelot"
 - id: 13619
-  examine: "A gateway to Ardougne."
+  examine: "A gateway to Ardougne"
 - id: 13620
-  examine: "A gateway to the Yanille watchtower."
+  examine: "A gateway to the Yanille watchtower"
 - id: 13621
-  examine: "Don't eat any!"
+  examine: "A gateway to Trollheim"
 - id: 13622
-  examine: "A gateway to Varrock."
+  examine: "A gateway to Varrock"
 - id: 13623
-  examine: "A gateway to Lumbridge."
+  examine: "A gateway to Lumbridge"
 - id: 13624
-  examine: "A gateway to Falador."
+  examine: "A gateway to Falador"
 - id: 13625
-  examine: "A gateway to Camelot."
+  examine: "A gateway to Camelot"
 - id: 13626
-  examine: "A gateway to Ardougne."
+  examine: "A gateway to Ardougne"
 - id: 13627
-  examine: "A gateway to the Yanille watchtower."
+  examine: "A gateway to the Yanille watchtower"
 - id: 13628
-  examine: "Don't eat any!"
+  examine: "A gateway to Trollheim"
 - id: 13629
-  examine: "A gateway to Varrock."
+  examine: "A gateway to Varrock"
 - id: 13630
-  examine: "A gateway to Lumbridge."
+  examine: "A gateway to Lumbridge"
 - id: 13631
-  examine: "A gateway to Falador."
+  examine: "A gateway to Falador"
 - id: 13632
-  examine: "A gateway to Camelot."
+  examine: "A gateway to Camelot"
 - id: 13633
-  examine: "A gateway to Ardougne."
+  examine: "A gateway to Ardougne"
 - id: 13634
-  examine: "A gateway to the Yanille watchtower."
+  examine: "A gateway to the Yanille watchtower"
 - id: 13635
-  examine: "Don't eat any!"
+  examine: "A gateway to Trollheim"
 - id: 13636
   examine: "An un-directed teak portal frame."
 - id: 13637
@@ -21769,11 +22176,11 @@
 - id: 13674
   examine: "Pull this to activate your machinery of doom!"
 - id: 13675
-  examine: "Go through this oak trapdoor to see what is below your throne room."
+  examine: "Go through this oak trapdoor to see the pit below your throne room."
 - id: 13676
-  examine: "Go through this teak trapdoor to see what is below your throne room."
+  examine: "Go through this teak trapdoor to see the pit below your throne room."
 - id: 13677
-  examine: "Go through this mahogany trapdoor to see what is below your throne room."
+  examine: "Go through this mahogany trapdoor to see the pit below your throne room."
 - id: 13678
   examine: "Go through this oak trapdoor to see the pit below your throne room."
 - id: 13679
@@ -21807,7 +22214,7 @@
 - id: 13693
   examine: "A splendid stained-glass decoration."
 - id: 13694
-  examine: "A nice teak dining bench."
+  examine: "A nice teak ding bench."
 - id: 13695
   examine: "A mahogany bench."
 - id: 13696
@@ -21817,53 +22224,68 @@
 - id: 13698
   examine: "An important looking chair."
 - id: 13699
+  examine: "Hammer, chisel, saw and shears."
 - id: 13700
+  examine: "Bucket, spade, tinderbox and knife."
 - id: 13701
+  examine: "Needle, apron and glassblowing pipe."
 - id: 13702
+  examine: "A selection of jewellery moulds."
 - id: 13703
-  examine: "A tree found in tropical areas."
+  examine: "Farming tools."
 - id: 13704
+  examine: "You can make furniture here."
 - id: 13705
+  examine: "You can make furniture here."
 - id: 13706
+  examine: "You can make furniture here."
 - id: 13707
+  examine: "You can make furniture here."
 - id: 13708
+  examine: "You can make furniture here."
 - id: 13709
+  examine: "You can do delicate crafting here."
 - id: 13710
+  examine: "You can do delicate crafting here."
 - id: 13711
+  examine: "You can do delicate crafting here."
 - id: 13712
+  examine: "You can do delicate crafting here."
 - id: 13713
+  examine: "You can repair broken staffs and arrows here."
 - id: 13714
+  examine: "You can sharpen rusty swords here."
 - id: 13715
+  examine: "You can repair armour here."
 - id: 13716
+  examine: "You can add a plume to your helmet here."
 - id: 13717
+  examine: "You can paint your logo onto your heraldic shield here."
 - id: 13718
+  examine: "You can make a banner with your logo on here."
 - id: 13719
+  examine: "A wooden stool."
 - id: 13720
+  examine: "An oak stool."
 - id: 13721
-  examine: "There's nothing there."
+  examine: "There's nothing there"
 - id: 13722
-  examine: "There's nothing there."
+  examine: "There's nothing there"
 - id: 13723
-  examine: "There's nothing there."
+  examine: "There's nothing there"
 - id: 13724
-  examine: "There's nothing there."
+  examine: "There's nothing there"
 - id: 13725
 - id: 13726
   examine: "A private jester."
 - id: 13727
   examine: "A private jester."
 - id: 13728
-  examine: "You can build a chapel window here."
 - id: 13729
-  examine: "You can build a chapel window here."
 - id: 13730
-  examine: "You can build a chapel window here."
 - id: 13731
-  examine: "You can build a chapel window here."
 - id: 13732
-  examine: "You can build a chapel window here."
 - id: 13733
-  examine: "You can build a chapel window here."
 - id: 13734
   examine: "A shield with the symbol of Arrav."
 - id: 13735
@@ -21933,7 +22355,7 @@
 - id: 13767
   examine: "A shield with the symbol of Asgarnia."
 - id: 13768
-  examine: "A shield with the symbol of the Dorgeshuun."
+  examine: "A shield with the symbol of the Dorgeshuun/"
 - id: 13769
   examine: "A shield with a picture of a dragon."
 - id: 13770
@@ -22057,13 +22479,13 @@
 - id: 13829
   examine: "The symbol of Zamorak."
 - id: 13830
-  examine: "Lets you see through walls."
+  examine: "This should have resolved!"
 - id: 13831
   examine: "A path leading out of this swampy dead end."
 - id: 13832
   examine: "A path leading out of this swampy dead end."
 - id: 13833
-  examine: "A path leading out of Mort Myre. You'll be running away if you go down here."
+  examine: "A path leading out of Mort Myre, you'll be running away if you go down here."
 - id: 13834
   examine: "I could mend this if I had some wood..."
 - id: 13835
@@ -22125,9 +22547,11 @@
 - id: 13870
   examine: "A path leading out of this swampy dead end."
 - id: 13871
-  examine: "A path leading out of this swampy dead end. You'll be running away if you go down here."
+  examine: ">-
+    A path leading out of this swampy dead end, you'll be running away if you go
+    down here."
 - id: 13872
-  examine: "An old backpack. It seems to be falling apart."
+  examine: "An old backpack, it seems to be falling apart."
 - id: 13873
   examine: "There's something written here..."
 - id: 13874
@@ -22178,11 +22602,16 @@
 - id: 13905
 - id: 13906
 - id: 13907
+  examine: "Where does it lead?"
 - id: 13908
+  examine: "Where does it lead?"
 - id: 13909
+  examine: "Where does it lead?"
 - id: 13910
+  examine: "Where does it lead?"
 - id: 13911
 - id: 13912
+  examine: "Where does it lead?"
 - id: 13913
   examine: "Where does it lead?"
 - id: 13914
@@ -22218,7 +22647,7 @@
 - id: 13932
   examine: "I think it's the way out."
 - id: 13933
-  examine: "I think it's the way forward."
+  examine: "I think it's the forward."
 - id: 13934
 - id: 13935
 - id: 13936
@@ -22279,6 +22708,7 @@
 - id: 13967
   examine: "Should I go down there?"
 - id: 13968
+  examine: "Should I go down there?"
 - id: 13969
   examine: "Should I go down there?"
 - id: 13970
@@ -22316,6 +22746,7 @@
 - id: 13991
 - id: 13992
 - id: 13993
+  examine: "Oooo, sharp, pointy things!"
 - id: 13994
   examine: "Oooo, sharp, pointy things!"
 - id: 13995
@@ -22472,7 +22903,6 @@
 - id: 14104
 - id: 14105
 - id: 14106
-  examine: "There are some convenient rocks below."
 - id: 14107
 - id: 14108
 - id: 14109
@@ -22536,21 +22966,27 @@
 - id: 14166
 - id: 14167
 - id: 14168
+  examine: "This perch looks overloaded and underpaid!"
 - id: 14169
-  examine: "The wood burning here must be full of salt."
+  examine: "These chocolate eggs should keep the little people happy!"
 - id: 14170
+  examine: "These chocolate eggs should keep the little folk happy!"
 - id: 14171
-  examine: "I could probably get this going again..."
+  examine: "These chocolate eggs should keep the little children happy!"
 - id: 14172
+  examine: "These chocolate eggs should keep the little kids happy!"
 - id: 14173
-  examine: "Doesn't look like it'll be sailing again."
+  examine: "It's flashing hypnotically and emitting a stream of rabbit noises."
 - id: 14174
-  examine: "Looks a bit damp."
+  examine: "It's flashing hypnotically and emitting a stream of rabbit noises."
 - id: 14175
+  examine: "This chute looks like it's laying eggs!"
 - id: 14176
 - id: 14177
 - id: 14178
+  examine: "A way down."
 - id: 14179
+  examine: "There's a hole in the ceiling of the cave."
 - id: 14180
 - id: 14181
 - id: 14182
@@ -22565,31 +23001,36 @@
 - id: 14191
 - id: 14192
 - id: 14193
-  examine: "King Rada I."
 - id: 14194
-  examine: "King Rada I."
 - id: 14195
-  examine: "King Rada I."
 - id: 14196
-  examine: "An old-looking chest."
+  examine: "There are no eggs here!"
 - id: 14197
-  examine: "An old-looking chest."
+  examine: "An egg is sliding down."
 - id: 14198
+  examine: "An egg is sliding down."
 - id: 14199
+  examine: "An egg is sliding down."
 - id: 14200
+  examine: "An egg is sliding down."
 - id: 14201
+  examine: "An egg is sliding down."
 - id: 14202
+  examine: "An egg is sliding down."
 - id: 14203
-  examine: "An unsculpted stone block."
+  examine: "So small only a rabbit could squeeze down."
 - id: 14204
-  examine: "An unsculpted stone block."
+  examine: "Looks like something is buried here."
 - id: 14205
-  examine: "An unsculpted stone block."
+  examine: "Looks like something is buried here."
 - id: 14206
+  examine: "Looks like something is buried here."
 - id: 14207
+  examine: "Looks like something is buried here."
 - id: 14208
+  examine: "Looks like something is buried here."
 - id: 14209
-  examine: "Reigning Champions of the Pure Clan Cup!"
+  examine: "Looks like something is buried here."
 - id: 14210
 - id: 14211
 - id: 14212
@@ -22740,11 +23181,11 @@
 - id: 14307
   examine: "Handy for boarding the ship."
 - id: 14308
-  depleted: 1342
   examine: "One of the most common trees in RuneScape."
+  depleted: 1342
 - id: 14309
-  depleted: 7400
   examine: "A commonly found tree."
+  depleted: 7400
 - id: 14310
 - id: 14311
 - id: 14312
@@ -22859,43 +23300,25 @@
 - id: 14393
 - id: 14394
 - id: 14395
-  examine: "Oblong boxes. You hope there isn't anything other than salt inside."
 - id: 14396
 - id: 14397
 - id: 14398
-  examine: "There is a powerful presence about these ruins..."
 - id: 14399
-  examine: "There is a powerful presence about these ruins..."
 - id: 14400
-  examine: "There is a powerful presence about these ruins..."
 - id: 14401
-  examine: "There is a powerful presence about these ruins..."
 - id: 14402
-  examine: "There is a powerful presence about these ruins..."
 - id: 14403
-  examine: "There is a powerful presence about these ruins..."
 - id: 14404
-  examine: "There is a powerful presence about these ruins..."
 - id: 14405
-  examine: "There is a powerful presence about these ruins..."
 - id: 14406
-  examine: "There is a powerful presence about these ruins..."
 - id: 14407
-  examine: "There is a powerful presence about these ruins..."
 - id: 14408
-  examine: "There is a powerful presence about these ruins..."
 - id: 14409
-  examine: "There is a powerful presence about these ruins..."
 - id: 14410
-  examine: "There is a powerful presence about these ruins..."
 - id: 14411
-  examine: "There is a powerful presence about these ruins..."
 - id: 14412
-  examine: "There is a powerful presence about these ruins..."
 - id: 14413
-  examine: "There is a powerful presence about these ruins..."
 - id: 14414
-  examine: "There is a powerful presence about these ruins..."
 - id: 14415
   examine: "The ideal place to study."
 - id: 14416
@@ -23009,7 +23432,7 @@
 - id: 14503
   examine: "Stop examining signs! You're in the Wilderness now!"
 - id: 14504
-  examine: "Danger, Wilderness up ahead. Last chance to turn back..."
+  examine: "Danger, Wilderness up ahead. Last chance to turn back.."
 - id: 14505
   examine: "Danger, Wilderness up ahead. Watch out for the Beast!"
 - id: 14506
@@ -23436,7 +23859,7 @@
 - id: 14742
   examine: "I wonder what's in them?"
 - id: 14743
-  examine: "A mucky sack."
+  examine: "There's some rank food in here."
 - id: 14744
 - id: 14745
   examine: "I can climb up this."
@@ -23447,21 +23870,15 @@
 - id: 14748
   examine: "Too broken to climb up."
 - id: 14749
-  examine: "A tatty old door."
 - id: 14750
-  examine: "A tatty old door."
 - id: 14751
-  examine: "Ominous."
 - id: 14752
-  examine: "Ominous."
 - id: 14753
-  examine: "Ominous."
 - id: 14754
-  examine: "Ominous."
 - id: 14755
   examine: "The colours of the Dark Knights."
 - id: 14756
-  examine: "A tatty banner."
+  examine: "Apparently they're proud to be roguish."
 - id: 14757
   examine: "Welcoming you to the Wilderness Agility Course."
 - id: 14758
@@ -23584,77 +24001,84 @@
 - id: 14831
   examine: "I wonder what this does..."
 - id: 14832
-  examine: "There is a powerful presence about these ruins..."
+  examine: "A rocky outcrop."
 - id: 14833
-  examine: "There is a powerful presence about these ruins..."
+  examine: "A rocky outcrop."
 - id: 14834
-  examine: "There is a powerful presence about these ruins..."
+  examine: "A rocky outcrop."
 - id: 14835
-  examine: "There is a powerful presence about these ruins..."
+  examine: "A rocky outcrop."
 - id: 14836
-  examine: "There is a powerful presence about these ruins..."
+  examine: "A rocky outcrop."
 - id: 14837
+  examine: "A rocky outcrop."
 - id: 14838
+  examine: "A rocky outcrop."
 - id: 14839
+  examine: "A rocky outcrop."
 - id: 14840
+  examine: "A rocky outcrop."
 - id: 14841
-  examine: "A portal from this mystical place."
+  examine: "A rocky outcrop."
 - id: 14842
-  examine: "A portal from this mystical place."
+  examine: "A rocky outcrop."
 - id: 14843
-  examine: "A portal from this mystical place."
+  examine: "A rocky outcrop."
 - id: 14844
-  examine: "A portal from this mystical place."
+  examine: "A rocky outcrop."
 - id: 14845
-  examine: "A portal from this mystical place."
+  examine: "A rocky outcrop."
 - id: 14846
-  examine: "A portal from this mystical place."
+  examine: "A rocky outcrop."
 - id: 14847
-  examine: "A portal from this mystical place."
+  examine: "A rocky outcrop."
 - id: 14848
-  examine: "A portal from this mystical place."
+  examine: "A rocky outcrop."
 - id: 14849
-  examine: "A poorly made chair."
+  examine: "A rocky outcrop."
 - id: 14850
+  examine: "A rocky outcrop."
   depleted: 14832
-  examine: "A poorly made chair."
 - id: 14851
+  examine: "A rocky outcrop."
   depleted: 14833
-  examine: "A tatty table."
 - id: 14852
+  examine: "A rocky outcrop."
   depleted: 14834
-  examine: "A large table."
 - id: 14853
+  examine: "A rocky outcrop."
   depleted: 14832
-  examine: "A poorly made chair."
 - id: 14854
+  examine: "A rocky outcrop."
   depleted: 14833
-  examine: "Too scruffy to be of much use."
 - id: 14855
+  examine: "A rocky outcrop."
   depleted: 14834
-  examine: "A single bed."
 - id: 14856
+  examine: "A rocky outcrop."
   depleted: 14832
-  examine: "Neatly made up."
 - id: 14857
+  examine: "A rocky outcrop."
   depleted: 14833
-  examine: "A trunk for the guards to keep their things in."
 - id: 14858
+  examine: "A rocky outcrop."
   depleted: 14834
-  examine: "A wooden locker for the guards to store their things in."
 - id: 14859
+  examine: "A rocky outcrop."
   depleted: 14832
-  examine: "A wallhanging of the Saradomin star."
 - id: 14860
+  examine: "A rocky outcrop."
   depleted: 14833
-  examine: "A cloth-covered altar with a symbol of Saradomin."
 - id: 14861
-  examine: "The sort of bench you get in churches."
+  examine: "A rocky outcrop."
 - id: 14862
+  examine: "A rocky outcrop."
   depleted: 14832
 - id: 14863
+  examine: "A rocky outcrop."
   depleted: 14833
 - id: 14864
+  examine: "A rocky outcrop."
   depleted: 14834
 - id: 14865
   examine: "A wooden barrel for storage."
@@ -23680,189 +24104,191 @@
 - id: 14878
 - id: 14879
 - id: 14880
-  examine: "I wonder what's down there?"
 - id: 14881
 - id: 14882
 - id: 14883
-  examine: "Lit to remember the souls of the departed."
+  examine: "A rocky outcrop."
 - id: 14884
-  examine: "A Tree trunk."
+  examine: "A rocky outcrop."
 - id: 14885
-  examine: "An elegant tree."
+  examine: "A rocky outcrop."
 - id: 14886
-  examine: "An open bank chest."
+  examine: "A rocky outcrop."
 - id: 14887
-  examine: "Used for fashioning clay items."
+  examine: "A rocky outcrop."
 - id: 14888
-  examine: "Bake your clay items in here."
+  examine: "A rocky outcrop."
 - id: 14889
-  examine: "Used for spinning thread."
+  examine: "A rocky outcrop."
 - id: 14890
-  examine: "A tray of sand."
+  examine: "A rocky outcrop."
 - id: 14891
   examine: "A drab-looking bed."
 - id: 14892
-  examine: "A portal from this mystical place."
+  examine: "A rocky outcrop."
 - id: 14893
-  examine: "A portal from this mystical place."
+  examine: "A rocky outcrop."
 - id: 14894
-  examine: "A portal from this mystical place."
+  examine: "A rocky outcrop."
 - id: 14895
+  examine: "A rocky outcrop."
 - id: 14896
-  examine: "A plant cultivated for fibres."
+  examine: "A rocky outcrop."
 - id: 14897
-  examine: "A mysterious power emanates from this shrine."
+  examine: "A rocky outcrop."
 - id: 14898
-  examine: "A mysterious power emanates from this shrine."
+  examine: "A rocky outcrop."
 - id: 14899
-  examine: "A mysterious power emanates from this shrine."
+  examine: "A rocky outcrop."
 - id: 14900
-  examine: "A mysterious power emanates from this shrine."
+  examine: "A rocky outcrop."
 - id: 14901
-  examine: "A mysterious power emanates from this shrine."
+  examine: "A rocky outcrop."
 - id: 14902
+  examine: "A rocky outcrop."
   depleted: 14892
-  examine: "A mysterious power emanates from this shrine."
 - id: 14903
+  examine: "A rocky outcrop."
   depleted: 14893
-  examine: "A mysterious power emanates from this shrine."
 - id: 14904
+  examine: "A rocky outcrop."
   depleted: 14892
-  examine: "A mysterious power emanates from this shrine."
 - id: 14905
+  examine: "A rocky outcrop."
   depleted: 14893
-  examine: "A mysterious power emanates from this shrine."
 - id: 14906
+  examine: "A rocky outcrop."
   depleted: 14892
-  examine: "A mysterious power emanates from this shrine."
 - id: 14907
+  examine: "A rocky outcrop."
   depleted: 14893
-  examine: "A mysterious power emanates from this shrine."
 - id: 14908
 - id: 14909
 - id: 14910
-  examine: "The door to the Crafting Guild."
+  examine: "Handy for mining."
 - id: 14911
-  examine: "A mysterious power emanates from this shrine."
+  examine: "A rocky outcrop."
 - id: 14912
+  examine: "Handy for woodcutting."
 - id: 14913
+  examine: "A rocky outcrop."
   depleted: 14892
 - id: 14914
+  examine: "A rocky outcrop."
   depleted: 14916
-  examine: "A large pile of sand."
 - id: 14915
-  examine: "A medium pile of sand."
+  examine: "A rocky outcrop."
 - id: 14916
-  examine: "A powerful ranging device, unfortunately not working."
+  examine: "A rocky outcrop."
 - id: 14917
-  examine: "Hop on, hop off."
+  examine: "There must be a source of fresh water somewhere nearby."
 - id: 14918
-  examine: "Looks molten hot."
+  examine: "Rough but adequate."
 - id: 14919
-  examine: "A part of an old temple."
+  examine: "Smells of fried fish."
 - id: 14920
-  examine: "A part of an old temple."
+  examine: "A basic wooden table, suitable for casual meals."
 - id: 14921
-  examine: "A part of an old temple."
+  examine: "A furnace; small but effective."
 - id: 14922
-  examine: "A part of an old temple."
+  examine: "A small hole through which I can crawl."
 - id: 14923
-  examine: "A part of an old temple."
+  examine: "A simple door."
 - id: 14924
-  examine: "A part of an old temple."
+  examine: "A simple door, now open."
 - id: 14925
 - id: 14926
 - id: 14927
-  examine: "Unusual energy is gathered here."
 - id: 14928
-  examine: "Unusual energy is gathered here."
 - id: 14929
-  examine: "Unusual energy is gathered here."
 - id: 14930
-  examine: "Unusual energy is gathered here."
 - id: 14931
-  examine: "Unusual energy is gathered here."
 - id: 14932
-  examine: "Unusual energy is gathered here."
 - id: 14933
-  examine: "Unusual energy is gathered here."
 - id: 14934
-  examine: "An old crumbled pillar."
 - id: 14935
-  examine: "An old crumbled pillar."
 - id: 14936
-  examine: "An old crumbled pillar."
+  examine: "Something has damaged the wall here."
 - id: 14937
-  examine: "An old crumbled pillar."
 - id: 14938
-  examine: "An old crumbled pillar."
+  examine: "I can see fish swimming in the water."
 - id: 14939
-  examine: "An old crumbled pillar."
 - id: 14940
-  examine: "An old crumbled pillar."
 - id: 14941
-  examine: "An old crumbled pillar."
 - id: 14942
-  examine: "Broken parts of an old temple."
 - id: 14943
-  examine: "Broken parts of an old temple."
 - id: 14944
-  examine: "Broken parts of an old temple."
 - id: 14945
+  examine: "Something has damaged the wall here."
 - id: 14946
+  examine: "Something has damaged the wall here."
 - id: 14947
+  examine: "Something has damaged the wall here."
 - id: 14948
-  examine: "A small pile of sand."
+  examine: "The wall here has been hastily patched."
 - id: 14949
+  examine: "The wall here has been hastily patched."
 - id: 14950
+  examine: "The wall here has been hastily patched."
 - id: 14951
+  examine: "Big rusty cogs."
 - id: 14952
+  examine: "Rusty machinery."
 - id: 14953
+  examine: "Some large fishing weights."
 - id: 14954
 - id: 14955
 - id: 14956
+  examine: "The pressing section of a metal pressing machine."
 - id: 14957
+  examine: "The pressing section of a metal pressing machine."
 - id: 14958
+  examine: "The firebox of a metal pressing machine."
 - id: 14959
+  examine: "There are some logs in the firebox of the press."
 - id: 14960
+  examine: "The firebox is heating the press."
 - id: 14961
+  examine: "All-purpose storage."
 - id: 14962
+  examine: "Crates that are coated in a thin layer of fishy grease."
 - id: 14963
+  examine: "Crates that smell strongly of salty fish."
 - id: 14964
+  examine: "A wooden barrel containing lots of fish."
 - id: 14965
+  examine: "An empty barrel, suitable for storing fish."
 - id: 14966
+  examine: "Someone certainly believes in having lots of barrels!"
 - id: 14967
+  examine: "Unusually enough, this barrel smells more strongly of rum than of fish."
 - id: 14968
+  examine: "If they store fish in this dirty old barrow, I hope they clean them later!"
 - id: 14969
+  examine: "A barrow full of fish."
 - id: 14970
+  examine: "Can I borrow a shallow barrow?' Now say that faster! FASTER!"
 - id: 14971
+  examine: "Apparently there's a lot of paperwork involved in running a Fishing Colony."
 - id: 14972
+  examine: "A large net for pulling in fish."
 - id: 14973
+  examine: "There is seaweed all over this fishing net."
 - id: 14974
-  examine: "It's a bamboo door with a large iron padlock."
 - id: 14975
 - id: 14976
 - id: 14977
-  examine: "It looks very sturdy."
 - id: 14978
 - id: 14979
-  examine: "It looks very sturdy."
 - id: 14980
-  examine: "It looks very sturdy."
 - id: 14981
-  examine: "It looks very sturdy."
 - id: 14982
-  examine: "It looks very sturdy."
 - id: 14983
-  examine: "It looks very sturdy."
 - id: 14984
 - id: 14985
-  examine: "A shrine of the gods!"
 - id: 14986
-  examine: "I wonder what's inside..."
 - id: 14987
 - id: 14988
-  examine: "It looks empty."
 - id: 14989
 - id: 14990
 - id: 14991
@@ -23870,12 +24296,9 @@
 - id: 14993
 - id: 14994
 - id: 14995
-  examine: "A wooden ladder."
 - id: 14996
-  examine: "A wooden ladder."
 - id: 14997
 - id: 14998
-  examine: "A natural spring."
 - id: 14999
 - id: 15000
 - id: 15001
@@ -23908,11 +24331,8 @@
 - id: 15028
 - id: 15029
 - id: 15030
-  examine: "A wooden crate."
 - id: 15031
-  examine: "A wooden crate."
 - id: 15032
-  examine: "Some wooden crates."
 - id: 15033
 - id: 15034
 - id: 15035
@@ -23920,192 +24340,113 @@
 - id: 15037
 - id: 15038
 - id: 15039
-  examine: "A wooden stool."
 - id: 15040
-  examine: "Items are for sale here."
 - id: 15041
-  examine: "So clean you could eat your dinner off it."
 - id: 15042
 - id: 15043
 - id: 15044
-  examine: "A small wooden table."
 - id: 15045
-  examine: "A source of foamy neurotoxin."
 - id: 15046
-  examine: "Storage for all needs."
 - id: 15047
-  examine: "Storage for all needs."
 - id: 15048
-  examine: "Storage for all needs."
 - id: 15049
-  examine: "Storage for all needs."
 - id: 15050
-  examine: "An altar to Saradomin."
 - id: 15051
-  examine: "An altar to Saradomin."
 - id: 15052
-  examine: "Ooooh! Spooky!"
 - id: 15053
-  examine: "The skull is back in there."
 - id: 15054
 - id: 15055
 - id: 15056
-  examine: "Keeps the wind out."
 - id: 15057
-  examine: "I wonder why this hasn't been buried?"
 - id: 15058
 - id: 15059
 - id: 15060
 - id: 15061
 - id: 15062
   depleted: 9037
-  examine: "A beautiful old teak tree."
 - id: 15063
-  examine: "This patch is overgrown with weeds."
 - id: 15064
-  examine: "This patch has weeds growing in it."
 - id: 15065
-  examine: "This patch has a few weeds in it."
 - id: 15066
-  examine: "This patch is clear of weeds."
 - id: 15067
 - id: 15068
-  examine: "This patch is completely dry."
 - id: 15069
-  examine: "This patch is almost dry."
 - id: 15070
-  examine: "This patch has just been watered."
 - id: 15071
 - id: 15072
-  examine: "Nothing can grow in this patch."
 - id: 15073
-  examine: "This patch has been fertilised."
 - id: 15074
 - id: 15075
-  examine: "A plant cultivated for fibres."
 - id: 15076
-  examine: "A plant cultivated for fibres."
 - id: 15077
-  examine: "A plant cultivated for fibres."
 - id: 15078
-  examine: "A plant cultivated for fibres."
 - id: 15079
 - id: 15080
-  examine: "A herb is growing in this patch."
 - id: 15081
-  examine: "A herb is growing in this patch."
 - id: 15082
-  examine: "A herb is growing in this patch."
 - id: 15083
-  examine: "A herb is growing in this patch."
 - id: 15084
 - id: 15085
 - id: 15086
 - id: 15087
 - id: 15088
-  examine: "Sit back and relax..."
 - id: 15089
 - id: 15090
 - id: 15091
-  examine: "Generally used for sitting."
 - id: 15092
-  examine: "Generally used for putting things on."
 - id: 15093
-  examine: "Too dirty to sit on."
 - id: 15094
-  examine: "A thoroughly used bed."
 - id: 15095
-  examine: "A thoroughly used bed."
 - id: 15096
-  examine: "A thoroughly used bed."
 - id: 15097
-  examine: "Looks pretty comfy."
 - id: 15098
-  examine: "An empty shelf..."
 - id: 15099
-  examine: "An empty shelf..."
 - id: 15100
-  examine: "There are some pots and pans here."
 - id: 15101
-  examine: "There are some tankards here."
 - id: 15102
-  examine: "There are a few books on this shelf."
 - id: 15103
-  examine: "Actually, I could do with a drink..."
 - id: 15104
-  examine: "For leaning against..."
 - id: 15105
-  examine: "A wooden barrel full of beer."
 - id: 15106
-  examine: "Some wooden crates."
 - id: 15107
-  examine: "A wooden crate."
 - id: 15108
-  examine: "A wooden barrel full of beer."
 - id: 15109
-  examine: "Some wooden crates."
 - id: 15110
-  examine: "Storage for all needs."
 - id: 15111
-  examine: "Storage for all needs."
 - id: 15112
-  examine: "Storage for all needs."
 - id: 15113
-  examine: "Storage for all needs."
 - id: 15114
-  examine: "Items are for sale here."
 - id: 15115
-  examine: "I can climb this."
 - id: 15116
-  examine: "What's down there?"
 - id: 15117
-  examine: "Mainly Reader's Digest."
 - id: 15118
-  examine: "Mainly Reader's Digest."
 - id: 15119
-  examine: "There's nothing here."
 - id: 15120
-  examine: "A bizarre fungus."
 - id: 15121
-  examine: "A bizarre fungus."
 - id: 15122
 - id: 15123
 - id: 15124
 - id: 15125
 - id: 15126
 - id: 15127
-  examine: "A rock with a pickaxe and mining tools."
 - id: 15128
-  examine: "A rock with a spade next to it."
 - id: 15129
 - id: 15130
 - id: 15131
 - id: 15132
 - id: 15133
 - id: 15134
-  examine: "These dyed fabrics are drying off."
 - id: 15135
-  examine: "These dyed fabrics are drying off."
 - id: 15136
-  examine: "These dyed fabrics are drying off."
 - id: 15137
-  examine: "Items for making clothes are kept on here."
 - id: 15138
-  examine: "Pots full of dye."
 - id: 15139
-  examine: "Some fabric ready for clothing."
 - id: 15140
-  examine: "I'm guessing it's for making women's clothes."
 - id: 15141
-  examine: "I'm guessing it's for making women's clothes."
 - id: 15142
-  examine: "Looks like it's for making men's clothes."
 - id: 15143
-  examine: "I think this one's for making men's clothes."
 - id: 15144
-  examine: "Essentials for a seamstress."
 - id: 15145
-  examine: "Tailor made for needlework supplies"
 - id: 15146
 - id: 15147
 - id: 15148
@@ -24117,10 +24458,8 @@
 - id: 15154
 - id: 15155
 - id: 15156
-  examine: "Warming."
 - id: 15157
 - id: 15158
-  examine: "A crude torch stuck in the ground."
 - id: 15159
 - id: 15160
 - id: 15161
@@ -24128,11 +24467,8 @@
 - id: 15163
 - id: 15164
 - id: 15165
-  examine: "A stand for hats."
 - id: 15166
-  examine: "Metal plating to protect the dwarf."
 - id: 15167
-  examine: "Metal plating to protect the dwarf."
 - id: 15168
 - id: 15169
 - id: 15170
@@ -24148,120 +24484,69 @@
 - id: 15180
 - id: 15181
 - id: 15182
-  examine: "Snake eggs."
 - id: 15183
-  examine: "These have recently hatched..."
 - id: 15184
-  examine: "These have recently hatched..."
 - id: 15185
-  examine: "These have recently hatched..."
 - id: 15186
-  examine: "A few rocks short of a wall - very crevice-like."
 - id: 15187
-  examine: "A few rocks short of a wall - very crevice-like."
 - id: 15188
-  examine: "It'll be a tight fit..."
 - id: 15189
-  examine: "It'll be a tight fit..."
 - id: 15190
-  examine: "I can see the surface."
 - id: 15191
-  examine: "I can see the surface."
 - id: 15192
 - id: 15193
 - id: 15194
-  examine: "A few rocks short of a wall - very crevice-like."
 - id: 15195
-  examine: "A few rocks short of a wall - very crevice-like."
 - id: 15196
-  examine: "A few rocks short of a wall - very crevice-like."
 - id: 15197
-  examine: "A few rocks short of a wall - very crevice-like."
 - id: 15198
-  examine: "It's a rock."
 - id: 15199
-  examine: "It's a rock."
 - id: 15200
 - id: 15201
-  examine: "It leads back to the caverns beneath the islands."
 - id: 15202
-  examine: "It leads back to the caverns beneath the islands."
 - id: 15203
 - id: 15204
-  examine: "The door is closed."
 - id: 15205
-  examine: "The door is open."
 - id: 15206
-  examine: "A recently extinguished fire."
 - id: 15207
-  examine: "A recently extinguished fire."
 - id: 15208
-  examine: "A recently extinguished fire."
 - id: 15209
-  examine: "A recently extinguished fire."
 - id: 15210
-  examine: "A recently extinguished fire."
 - id: 15211
 - id: 15212
 - id: 15213
-  examine: "They look very wet and slippery."
 - id: 15214
-  examine: "Steam is coming out of this hole."
 - id: 15215
-  examine: "There's nothing coming out at the moment..."
 - id: 15216
-  examine: "Use this to swing over crevices."
 - id: 15217
-  examine: "An odd-looking rock formation."
 - id: 15218
-  examine: "An odd-looking rock formation."
 - id: 15219
-  examine: "An odd-looking rock formation."
 - id: 15220
 - id: 15221
 - id: 15222
-  examine: "This platform is broken."
 - id: 15223
-  examine: "This platform needs rope."
 - id: 15224
-  examine: "This platform has been repaired."
 - id: 15225
-  examine: "This platform has been repaired."
 - id: 15226
-  examine: "This platform is broken."
 - id: 15227
-  examine: "There used to be some kind of power source here."
 - id: 15228
-  examine: "A coal-powered engine for the lift."
 - id: 15229
-  examine: "A coal-powered engine for the lift."
 - id: 15230
-  examine: "This scaffold needs repairing."
 - id: 15231
-  examine: "This still needs work before it can be used."
 - id: 15232
-  examine: "This scaffold has been fully repaired."
 - id: 15233
-  examine: "This scaffold needs repairing."
 - id: 15234
-  examine: "This scaffold has been fully repaired."
 - id: 15235
-  examine: "This still needs work before it can be used."
 - id: 15236
-  examine: "This still needs work before it can be used."
 - id: 15237
-  examine: "It's now fully-functional."
 - id: 15238
 - id: 15239
 - id: 15240
 - id: 15241
 - id: 15242
 - id: 15243
-  examine: "A crate of AMCE Beams-In-A-Box."
 - id: 15244
-  examine: "A crate of AMCE Pulley-Beams-In-A-Box."
 - id: 15245
-  examine: "A crate of AMCE Ropes-In-A-Box."
 - id: 15246
   depleted: 15249
 - id: 15247
@@ -24270,403 +24555,208 @@
   depleted: 15251
 - id: 15249
 - id: 15250
-  examine: "A limestone floor growth."
 - id: 15251
-  examine: "A tooth shaped rock formation protruding from the floor."
 - id: 15252
 - id: 15253
 - id: 15254
 - id: 15255
 - id: 15256
-  examine: "You can build a treasure chest here."
 - id: 15257
-  examine: "You can buy a monster guard to go here."
 - id: 15258
 - id: 15259
-  examine: "You can build a wall decoration here."
 - id: 15260
-  examine: "You can build a bed here."
 - id: 15261
-  examine: "You can build a wardrobe here."
 - id: 15262
-  examine: "You can build a mirror or dresser here."
 - id: 15263
-  examine: "You can build curtains here."
 - id: 15264
-  examine: "You can build a rug here."
 - id: 15265
-  examine: "You can build a rug here."
 - id: 15266
-  examine: "You can build a rug here."
 - id: 15267
-  examine: "You can build a fireplace here."
 - id: 15268
-  examine: "You can build a corner piece here."
 - id: 15269
-  examine: "You can build a symbol or icon here."
 - id: 15270
-  examine: "You can build an altar here."
 - id: 15271
-  examine: "You can build a pair of lamps or incense burners here."
 - id: 15272
-  examine: "You can build a rug here."
 - id: 15273
-  examine: "You can build a rug here."
 - id: 15274
-  examine: "You can build a rug here."
 - id: 15275
-  examine: "You can build a statue here"
 - id: 15276
-  examine: "You can build a musical thing here."
 - id: 15277
-  examine: "You can build a combat ring here."
 - id: 15278
-  examine: "You can build a combat ring here."
 - id: 15279
-  examine: "You can build a combat ring here."
 - id: 15280
-  examine: "You can build a combat ring here."
 - id: 15281
-  examine: "You can build a combat ring here."
 - id: 15282
-  examine: "You can build a combat ring here."
 - id: 15283
-  examine: "This ought to be invisible!"
 - id: 15284
-  examine: "This ought to be invisible!"
 - id: 15285
-  examine: "This ought to be invisible!"
 - id: 15286
-  examine: "You can build a combat ring here."
 - id: 15287
-  examine: "You can build a combat ring here."
 - id: 15288
-  examine: "You can build a combat ring here."
 - id: 15289
-  examine: "You can build a combat ring here."
 - id: 15290
-  examine: "You can build a combat ring here."
 - id: 15291
-  examine: "You can build a combat ring here."
 - id: 15292
-  examine: "You can build a combat ring here."
 - id: 15293
-  examine: "You can build a combat ring here."
 - id: 15294
-  examine: "You can build a combat ring here."
 - id: 15295
-  examine: "You can build a combat ring here."
 - id: 15296
-  examine: "You can build a weapon rack here."
 - id: 15297
-  examine: "You can build a wall decoration here."
 - id: 15298
-  examine: "You can build a table here."
 - id: 15299
-  examine: "You can build a bench or a row of chairs here."
 - id: 15300
-  examine: "You can build a bench or a row of chairs here."
 - id: 15301
-  examine: "You can build a fireplace here."
 - id: 15302
-  examine: "You can build curtains here."
 - id: 15303
-  examine: "You can build a wall decoration here."
 - id: 15304
-  examine: "You can build a bell-pull here."
 - id: 15305
-  examine: "You can use this to add or remove rooms."
 - id: 15306
-  examine: "You can use this to add or remove rooms."
 - id: 15307
-  examine: "You can use this to add or remove rooms."
 - id: 15308
-  examine: "You can use this to add or remove rooms."
 - id: 15309
-  examine: "You can use this to add or remove rooms."
 - id: 15310
-  examine: "You can use this to add or remove rooms."
 - id: 15311
-  examine: "You can use this to add or remove rooms."
 - id: 15312
-  examine: "You can use this to add or remove rooms."
 - id: 15313
-  examine: "You can use this to add or remove rooms."
 - id: 15314
-  examine: "You can use this to add or remove rooms."
 - id: 15315
-  examine: "You can use this to add or remove rooms."
 - id: 15316
-  examine: "You can use this to add or remove rooms."
 - id: 15317
-  examine: "You can make this into a room."
 - id: 15318
-  examine: "You can make this into a room."
 - id: 15319
-  examine: "You can make this into a room."
 - id: 15320
-  examine: "You can make this into a room."
 - id: 15321
-  examine: "You can make this into a room."
 - id: 15322
-  examine: "You can make this into a room."
 - id: 15323
-  examine: "You can buy a monster guard to go here."
 - id: 15324
-  examine: "You can build a trap here."
 - id: 15325
-  examine: "You can build a trap here."
 - id: 15326
-  examine: "You can build a door here."
 - id: 15327
-  examine: "You can build a door here."
 - id: 15328
-  examine: "You can build a door here."
 - id: 15329
-  examine: "You can build a door here."
 - id: 15330
-  examine: "You can build lighting here."
 - id: 15331
-  examine: "You can build something scary here."
 - id: 15332
-  examine: "You can build a rug here."
 - id: 15333
-  examine: "You can build a rug here."
 - id: 15334
-  examine: "You can build a rug here."
 - id: 15335
-  examine: "You can build a rug here."
 - id: 15336
-  examine: "You can buy a monster guard to go here."
 - id: 15337
-  examine: "You can buy a monster guard to go here."
 - id: 15338
-  examine: "You can build a door here."
 - id: 15339
-  examine: "You can build a door here."
 - id: 15340
-  examine: "You can build lighting here."
 - id: 15341
-  examine: "You can build something scary here."
 - id: 15342
-  examine: "You can build a magical party game here."
 - id: 15343
-  examine: "You can build a prize chest here."
 - id: 15344
-  examine: "You can build an Attack Stone here."
 - id: 15345
-  examine: "You can build an elemental balance here."
 - id: 15346
-  examine: "You can build a ranging game here."
 - id: 15347
-  examine: "You can build various things here."
 - id: 15348
-  examine: "You can build various things here."
 - id: 15349
-  examine: "You can build various things here."
 - id: 15350
-  examine: "You can build various things here."
 - id: 15351
-  examine: "You can build various things here."
 - id: 15352
-  examine: "You can build a prison here."
 - id: 15353
-  examine: "You can build a prison here here."
 - id: 15354
-  examine: "You can buy a monster guard to go here."
 - id: 15355
-  examine: "You can build lighting here."
 - id: 15356
-  examine: "You can build a ladder here."
 - id: 15357
-  examine: "You can build a door here."
 - id: 15358
-  examine: "You can build a door here."
 - id: 15359
-  examine: "You can build a door here."
 - id: 15360
-  examine: "You can build a door here."
 - id: 15361
-  examine: "You can build something here."
 - id: 15362
-  examine: "You can grow plants here."
 - id: 15363
-  examine: "You can grow plants here."
 - id: 15364
-  examine: "You can grow plants here."
 - id: 15365
-  examine: "You can grow plants here."
 - id: 15366
-  examine: "You can grow plants here."
 - id: 15367
-  examine: "You can grow plants here."
 - id: 15368
-  examine: "You can build something here."
 - id: 15369
-  examine: "You can build a fence here."
 - id: 15370
-  examine: "You can grow plants here."
 - id: 15371
-  examine: "You can grow plants here."
 - id: 15372
-  examine: "You can grow plants here."
 - id: 15373
-  examine: "You can grow plants here."
 - id: 15374
-  examine: "You can grow plants here."
 - id: 15375
-  examine: "You can grow plants here."
 - id: 15376
-  examine: "You can grow plants here."
 - id: 15377
-  examine: "You can build a rug here."
 - id: 15378
-  examine: "You can build a rug here."
 - id: 15379
-  examine: "You can build a rug here."
 - id: 15380
-  examine: "You can build stairs here."
 - id: 15381
-  examine: "You can build stairs here."
 - id: 15382
-  examine: "You can mount a monster head here."
 - id: 15383
-  examine: "You can mount a fish here."
 - id: 15384
-  examine: "You can mount a suit of armour here."
 - id: 15385
-  examine: "You can mount a suit of Castlewars armour here."
 - id: 15386
-  examine: "You can build a runecrafting display case here."
 - id: 15387
-  examine: "You can build a rug or staircase here."
 - id: 15388
-  examine: "You can build a rug or staircase here."
 - id: 15389
-  examine: "You can build a rug or staircase here."
 - id: 15390
-  examine: "You can build stairs here."
 - id: 15391
-  examine: "You can build stairs here."
 - id: 15392
-  examine: "You can frame a portrait here."
 - id: 15393
-  examine: "You can frame a landscape painting here."
 - id: 15394
-  examine: "You can mount a guild membership item here."
 - id: 15395
-  examine: "You can mount a quest sword here."
 - id: 15396
-  examine: "You can mount a map here."
 - id: 15397
-  examine: "You can build a bookcase here."
 - id: 15398
-  examine: "You can build a stove here."
 - id: 15399
-  examine: "You can build a set of shelves here."
 - id: 15400
-  examine: "You can build a set of shelves here."
 - id: 15401
-  examine: "You can build a barrel of beer here."
 - id: 15402
-  examine: "You can build a cat basket here."
 - id: 15403
-  examine: "You can build a larder here."
 - id: 15404
-  examine: "You can build a sink here."
 - id: 15405
-  examine: "You can build a table here."
 - id: 15406
-  examine: "You can create a portal here."
 - id: 15407
-  examine: "You can create a portal here."
 - id: 15408
-  examine: "You can create a portal here."
 - id: 15409
-  examine: "You can build a centrepiece to the room here."
 - id: 15410
-  examine: "Some mystical rock..."
 - id: 15411
 - id: 15412
-  examine: "A very slippery stepping stone."
 - id: 15413
-  examine: "A very slippery stepping stone."
 - id: 15414
-  examine: "A terribly tall tropical tree."
 - id: 15415
-  examine: "A terribly tall tropical tree."
 - id: 15416
-  examine: "A terribly tall tropical tree."
 - id: 15417
-  examine: "I can traverse these."
 - id: 15418
 - id: 15419
-  examine: "I can traverse these."
 - id: 15420
-  examine: "You can build a spellbook stand here."
 - id: 15421
-  examine: "You can build a globe or orrery here."
 - id: 15422
-  examine: "You can build a crystal ball here."
 - id: 15423
-  examine: "You can frame a wall chart here."
 - id: 15424
-  examine: "You can build a telescope here."
 - id: 15425
-  examine: "You can build a bookcase here."
 - id: 15426
-  examine: "You can build a throne here."
 - id: 15427
-  examine: "You can build various fiendish devices here."
 - id: 15428
-  examine: "You can build various fiendish devices here."
 - id: 15429
-  examine: "You can build various fiendish devices here."
 - id: 15430
-  examine: "You can build various fiendish devices here."
 - id: 15431
-  examine: "You can build various fiendish devices here."
 - id: 15432
-  examine: "You can build various fiendish devices here."
 - id: 15433
-  examine: "You can build a wall decoration here."
 - id: 15434
-  examine: "You can build a wall decoration here."
 - id: 15435
-  examine: "You can build a lever here."
 - id: 15436
-  examine: "You can build a row of seats here."
 - id: 15437
-  examine: "You can build a row of seats here."
 - id: 15438
-  examine: "You can build a trapdoor down here."
 - id: 15439
-  examine: "You can build a workbench here."
 - id: 15440
-  examine: "An eye-wrenching nexus of utter negation!"
 - id: 15441
-  examine: "You can build a clockmaking table here."
 - id: 15442
-  examine: "An eye-wrenching nexus of utter negation!"
 - id: 15443
-  examine: "You can build a tool rack here."
 - id: 15444
-  examine: "You can build a tool rack here."
 - id: 15445
-  examine: "You can build a tool rack here."
 - id: 15446
-  examine: "You can build a tool rack here."
 - id: 15447
-  examine: "You can build a tool rack here."
 - id: 15448
-  examine: "You can build a repair bench here."
 - id: 15449
-  examine: "An eye-wrenching nexus of utter negation!"
 - id: 15450
-  examine: "You can build a heraldic painting bench here."
 - id: 15451
 - id: 15452
-  examine: "This shows where a door would be."
 - id: 15453
 - id: 15454
 - id: 15455
@@ -24676,59 +24766,36 @@
 - id: 15459
 - id: 15460
 - id: 15461
-  examine: "A good source of books!"
 - id: 15462
-  examine: "A comfortable seat."
 - id: 15463
-  examine: "A stand for hats!"
 - id: 15464
-  examine: "A picture of a particularly splendid house."
 - id: 15465
-  examine: "Maybe you could own a house like this."
 - id: 15466
-  examine: "An automated stone hammer."
 - id: 15467
-  examine: "Some cleaning supplies and a bucket."
 - id: 15468
-  examine: "An automated cutting machine."
 - id: 15469
-  examine: "A tank used to clean and preserve dead beasts."
 - id: 15470
 - id: 15471
-  examine: "A fish bowl placed on a table, but the fish arn't moving."
 - id: 15472
-  examine: "A pair of servants' white gloves and a feather duster."
 - id: 15473
-  examine: "With all the servants around this table is very clean."
 - id: 15474
 - id: 15475
 - id: 15476
 - id: 15477
-  examine: "Home sweet home?"
 - id: 15478
-  examine: "Home sweet home?"
 - id: 15479
-  examine: "Home sweet home?"
 - id: 15480
-  examine: "Home sweet home?"
 - id: 15481
-  examine: "Home sweet home?"
 - id: 15482
 - id: 15483
-  examine: "A climbing wall made from skulls."
 - id: 15484
 - id: 15485
 - id: 15486
 - id: 15487
-  examine: "For swinging on."
 - id: 15488
-  examine: "A terribly tall tropical tree."
 - id: 15489
-  examine: "A terribly tall tropical tree."
 - id: 15490
-  examine: "Very majestic."
 - id: 15491
-  examine: "A vine-choked hole."
 - id: 15492
 - id: 15493
 - id: 15494
@@ -24747,41 +24814,24 @@
 - id: 15505
   depleted: 11557
 - id: 15506
-  examine: "Baby bread."
 - id: 15507
-  examine: "Baby bread."
 - id: 15508
-  examine: "Baby bread."
 - id: 15509
 - id: 15510
-  examine: "A wooden gate."
 - id: 15511
-  examine: "A wooden gate."
 - id: 15512
-  examine: "A wooden gate."
 - id: 15513
-  examine: "A wooden gate."
 - id: 15514
-  examine: "A wooden gate."
 - id: 15515
-  examine: "A wooden gate."
 - id: 15516
-  examine: "A wooden gate."
 - id: 15517
-  examine: "A wooden gate."
 - id: 15518
-  examine: "The mouse equivalent of a door."
 - id: 15519
-  examine: "The mouse equivalent of a door."
 - id: 15520
 - id: 15521
-  examine: "Time for a recital?"
 - id: 15522
-  examine: "Beware! Magic earth!"
 - id: 15523
-  examine: "A locked trapdoor."
 - id: 15524
-  examine: "A barrel."
 - id: 15525
 - id: 15526
 - id: 15527
@@ -24794,34 +24844,21 @@
 - id: 15534
 - id: 15535
 - id: 15536
-  examine: "A Rock."
 - id: 15537
-  examine: "A Rock."
 - id: 15538
 - id: 15539
 - id: 15540
 - id: 15541
-  examine: "A Snake."
 - id: 15542
-  examine: "A Snake."
 - id: 15543
-  examine: "A Snake."
 - id: 15544
-  examine: "A hole."
 - id: 15545
-  examine: "A Snake."
 - id: 15546
-  examine: "A Snake."
 - id: 15547
-  examine: "A pile of armour."
 - id: 15548
-  examine: "Oh dear, what's it doing?"
 - id: 15549
-  examine: "Now that's a severe diet!"
 - id: 15550
-  examine: "Oh dear, what's it doing?"
 - id: 15551
-  examine: "A meal would do him good."
 - id: 15552
 - id: 15553
 - id: 15554
@@ -24830,51 +24867,30 @@
 - id: 15557
 - id: 15558
 - id: 15559
-  examine: "Oh dear, what's it doing?"
 - id: 15560
-  examine: "Stores items."
 - id: 15561
-  examine: "Probably looked better mounted on the dragon's neck."
 - id: 15562
-  examine: "Probably looked better mounted on the dragon's neck."
 - id: 15563
-  examine: "Probably looked better mounted on the dragon's neck."
 - id: 15564
-  examine: "Probably looked better mounted on the dragon's neck."
 - id: 15565
-  examine: "Probably looked better mounted on the dragon's neck."
 - id: 15566
-  examine: "Noxious gas hazard! Naked flames may cause an explosion!"
 - id: 15567
-  examine: "A wooden stool."
 - id: 15568
-  examine: "A small wooden table."
 - id: 15569
-  examine: "A bookcase."
 - id: 15570
-  examine: "A Snake."
 - id: 15571
-  examine: "There's a hole in the roof!"
 - id: 15572
-  examine: "A hole in the ground."
 - id: 15573
-  examine: "This bush seems to glow in the dim light of the cave."
 - id: 15574
-  examine: "This banana tree has a strange reddish hue on the leaves."
 - id: 15575
-  examine: "This thin shaft of light is all the Tchiki Monkey Nut bush needs to grow."
 - id: 15576
   depleted: 15582
-  examine: "A Banana Tree."
 - id: 15577
   depleted: 15583
-  examine: "A Banana Tree."
 - id: 15578
   depleted: 15584
-  examine: "A Banana Tree."
 - id: 15579
   depleted: 15582
-  examine: "A Banana Tree."
 - id: 15580
   depleted: 15583
 - id: 15581
@@ -24894,24 +24910,15 @@
 - id: 15594
 - id: 15595
 - id: 15596
-  examine: "The body of a Dwarf savaged by Goblins."
 - id: 15597
 - id: 15598
-  examine: "Oblong boxes. You hope there isn't anything other than salt inside."
 - id: 15599
-  examine: "A crate. You wonder what could be inside."
 - id: 15600
-  examine: "Wooden crates, contents unknown."
 - id: 15601
-  examine: "Intended to keep the goblins away from the mines."
 - id: 15602
-  examine: "Intended to keep the goblins away from the mines."
 - id: 15603
-  examine: "Intended to keep the goblins away from the mines."
 - id: 15604
-  examine: "A secure gate."
 - id: 15605
-  examine: "A secure gate."
 - id: 15606
 - id: 15607
 - id: 15608
@@ -24922,11 +24929,8 @@
 - id: 15613
 - id: 15614
 - id: 15615
-  examine: "A small pile of snow."
 - id: 15616
-  examine: "A small pile of snow."
 - id: 15617
-  examine: "A small pile of snow."
 - id: 15618
 - id: 15619
 - id: 15620
@@ -24935,7 +24939,6 @@
 - id: 15623
 - id: 15624
 - id: 15625
-  examine: "That's really bright!"
 - id: 15626
 - id: 15627
 - id: 15628
@@ -24949,7 +24952,6 @@
 - id: 15636
 - id: 15637
 - id: 15638
-  examine: "Must be a part of Glough's sickening experiments."
 - id: 15639
 - id: 15640
 - id: 15641
@@ -24957,159 +24959,94 @@
 - id: 15643
 - id: 15644
 - id: 15645
-  examine: "I can climb these stairs."
 - id: 15646
-  examine: "I can climb these stairs."
 - id: 15647
-  examine: "I can climb these stairs."
 - id: 15648
-  examine: "They go down."
 - id: 15649
-  examine: "I can climb these stairs."
 - id: 15650
-  examine: "They go down."
 - id: 15651
-  examine: "They go down."
 - id: 15652
-  examine: "I can climb down these stairs."
 - id: 15653
-  examine: "I can climb up this."
 - id: 15654
-  examine: "I can climb down this."
 - id: 15655
-  examine: "I can climb down this."
 - id: 15656
-  examine: "I can climb down this."
 - id: 15657
-  examine: "I can climb this."
 - id: 15658
-  examine: "It looks like it's made from lead - heavy, man."
 - id: 15659
-  examine: "It looks like it's made from lead - heavy, man."
 - id: 15660
-  examine: "It looks like it's made from lead - heavy, man."
 - id: 15661
-  examine: "It looks like it's made from lead - heavy, man."
 - id: 15662
-  examine: "It's a small-ish beer keg."
 - id: 15663
-  examine: "It's a small-ish beer keg."
 - id: 15664
-  examine: "It's a pile of 18lb shot."
 - id: 15665
-  examine: "It's a pile of 22lb shot."
 - id: 15666
 - id: 15667
 - id: 15668
-  examine: "It's a small-ish beer keg."
 - id: 15669
 - id: 15670
 - id: 15671
 - id: 15672
 - id: 15673
 - id: 15674
-  examine: "An ale barrel."
 - id: 15675
-  examine: "A wooden barrel containing lots of fish."
 - id: 15676
-  examine: "An ale barrel."
 - id: 15677
-  examine: "Banking transactions are recorded here."
 - id: 15678
-  examine: "Wash your hands!"
 - id: 15679
-  examine: "A wooden stool."
 - id: 15680
-  examine: "It's a small table."
 - id: 15681
 - id: 15682
 - id: 15683
-  examine: "A well slept in bed."
 - id: 15684
-  examine: "Generally used for putting things on."
 - id: 15685
-  examine: "Storage for cookery items."
 - id: 15686
-  examine: "Storage for cookery items."
 - id: 15687
 - id: 15688
 - id: 15689
 - id: 15690
-  examine: "A painting of the King looking royal."
 - id: 15691
-  examine: "A mysterious figure stands alone in this haunting image."
 - id: 15692
-  examine: "A wooden crate."
 - id: 15693
-  examine: "Wooden crates."
 - id: 15694
 - id: 15695
-  examine: "A crate full of machine parts."
 - id: 15696
-  examine: "An empty crate."
 - id: 15697
-  examine: "A crate full of machine parts."
 - id: 15698
-  examine: "An empty machine parts crate."
 - id: 15699
-  examine: "A cart for carrying boxes."
 - id: 15700
-  examine: "A cart for carrying boxes."
 - id: 15701
 - id: 15702
 - id: 15703
 - id: 15704
-  examine: "A discarded crate with a lid."
 - id: 15705
-  examine: "A discarded crate with a lid."
 - id: 15706
-  examine: "A discarded crate."
 - id: 15707
-  examine: "The crate is closed."
 - id: 15708
 - id: 15709
-  examine: "Alas, poor Zanik."
 - id: 15710
 - id: 15711
-  examine: "She's not moving."
 - id: 15712
 - id: 15713
-  examine: "If Sigmund activated this he could flood the Dorgeshuun city!"
 - id: 15714
-  examine: "This drilling machine is in trouble!"
 - id: 15715
-  examine: "It's broken beyond repair. The Dorgeshuun city is safe!"
 - id: 15716
 - id: 15717
 - id: 15718
 - id: 15719
-  examine: "A rough wooden table."
 - id: 15720
-  examine: "Who would have thought the Karamja Box Company supports the HAM cult?"
 - id: 15721
-  examine: "Who would have thought the Karamja Box Company supports the HAM cult?"
 - id: 15722
-  examine: "I don't think it contains ham."
 - id: 15723
-  examine: "I don't think it contains ham."
 - id: 15724
-  examine: "I don't think it contains ham."
 - id: 15725
-  examine: "I don't think it contains ham."
 - id: 15726
-  examine: "I don't think it contains ham."
 - id: 15727
-  examine: "It must be from the river above."
 - id: 15728
-  examine: "It must be from the river above."
 - id: 15729
 - id: 15730
 - id: 15731
-  examine: "A cracked wall."
 - id: 15732
-  examine: "A wall"
 - id: 15733
-  examine: "A wall"
 - id: 15734
 - id: 15735
 - id: 15736
@@ -25123,59 +25060,34 @@
 - id: 15744
 - id: 15745
 - id: 15746
-  examine: "It's the ladder I came in here by."
 - id: 15747
-  examine: "It's the ladder I came in here by."
 - id: 15748
-  examine: "A long dark tunnel."
 - id: 15749
-  examine: "A blocked tunnel."
 - id: 15750
-  examine: "A long dark tunnel."
 - id: 15751
-  examine: "A blocked tunnel."
 - id: 15752
-  examine: "It probably leads to some sort of cellar."
 - id: 15753
-  examine: "What mysteries lie below?"
 - id: 15754
-  examine: "Doesn't look very interesting."
 - id: 15755
-  examine: "You would never have seen this trapdoor if it wasn't for Zanik."
 - id: 15756
-  examine: "Where does this go?"
 - id: 15757
-  examine: "A large double door."
 - id: 15758
-  examine: "A large double door."
 - id: 15759
-  examine: "The door is closed."
 - id: 15760
-  examine: "A large empty sack."
 - id: 15761
-  examine: "It's full of flour ground by the mill."
 - id: 15762
-  examine: "It's full of flour ground by the mill."
 - id: 15763
 - id: 15764
 - id: 15765
 - id: 15766
 - id: 15767
-  examine: "A bed."
 - id: 15768
-  examine: "A wooden crate."
 - id: 15769
-  examine: "A wooden crate."
 - id: 15770
-  examine: "A passageway leading somewhere."
 - id: 15771
-  examine: "A passageway leading somewhere."
 - id: 15772
-  examine: "A passageway leading somewhere."
 - id: 15773
-  examine: "A passageway leading somewhere."
 - id: 15774
-  examine: "A passageway leading somewhere."
 - id: 15775
 - id: 15776
 - id: 15777
@@ -25218,9 +25130,7 @@
 - id: 15814
 - id: 15815
 - id: 15816
-  examine: "A floating crate."
 - id: 15817
-  examine: "A floating barrel."
 - id: 15818
 - id: 15819
 - id: 15820
@@ -25229,294 +25139,155 @@
 - id: 15823
 - id: 15824
 - id: 15825
-  examine: "Keeps mine carts from rolling away."
 - id: 15826
 - id: 15827
 - id: 15828
 - id: 15829
 - id: 15830
-  examine: "It looks cramped and dark."
 - id: 15831
-  examine: "It looks cramped and dark."
 - id: 15832
-  examine: "It prevents the wall unceremoniously squashing people."
 - id: 15833
-  examine: "A door leading somewhere."
 - id: 15834
-  examine: "This door is blocked by a huge slab of stone."
 - id: 15835
 - id: 15836
 - id: 15837
-  examine: "Allows the magic of shoddy brewing to occur."
 - id: 15838
-  examine: "Piping hot."
 - id: 15839
-  examine: "Piping hot."
 - id: 15840
-  examine: "If these were not damaged, then you could brew rum."
 - id: 15841
-  examine: "If these were not damaged, then you could brew rum."
 - id: 15842
-  examine: "If these were not damaged, then you could brew rum."
 - id: 15843
-  examine: "If these were not damaged, then you could brew rum."
 - id: 15844
-  examine: "If these were not damaged, then you could brew rum."
 - id: 15845
-  examine: "Used for the storage of rum made in the distillery."
 - id: 15846
-  examine: "You can use these to make a colour dye."
 - id: 15847
-  examine: "The ingredients for the rum go in here."
 - id: 15848
-  examine: "It's a hopper filled with fire!"
 - id: 15849
-  examine: "It's a hopper filled with fire!"
 - id: 15850
-  examine: "That won't work until it has been repaired."
 - id: 15851
-  examine: "That won't work until it has been repaired."
 - id: 15852
-  examine: "That won't work until it has been repaired."
 - id: 15853
-  examine: "That won't work until it has been repaired."
 - id: 15854
-  examine: "That won't work until it has been repaired."
 - id: 15855
-  examine: "It's a bridge."
 - id: 15856
-  examine: "Flames above, troubled water below!"
 - id: 15857
-  examine: "Flames above, troubled water below!"
 - id: 15858
-  examine: "This isn't safe to walk on."
 - id: 15859
-  examine: "This isn't safe to walk on."
 - id: 15860
-  examine: "This isn't safe to walk on."
 - id: 15861
-  examine: "This isn't safe to walk on."
 - id: 15862
-  examine: "This isn't safe to walk on."
 - id: 15863
-  examine: "Allows the magic of shoddy brewing to occur."
 - id: 15864
-  examine: "Piping hot."
 - id: 15865
-  examine: "Piping hot."
 - id: 15866
-  examine: "If these were not damaged, then you could brew rum."
 - id: 15867
-  examine: "If these were not damaged, then you could brew rum."
 - id: 15868
-  examine: "If these were not damaged, then you could brew rum."
 - id: 15869
-  examine: "If these were not damaged, then you could brew rum."
 - id: 15870
-  examine: "If these were not damaged, then you could brew rum."
 - id: 15871
-  examine: "Used for the storage of rum made in the distillery."
 - id: 15872
-  examine: "You can use these to make a colour dye."
 - id: 15873
-  examine: "The ingredients for the rum go in here."
 - id: 15874
-  examine: "It's a hopper filled with fire!"
 - id: 15875
-  examine: "It's a hopper filled with fire!"
 - id: 15876
-  examine: "That won't work until it has been repaired."
 - id: 15877
-  examine: "That won't work until it has been repaired."
 - id: 15878
-  examine: "That won't work until it has been repaired."
 - id: 15879
-  examine: "That won't work until it has been repaired."
 - id: 15880
-  examine: "That won't work until it has been repaired."
 - id: 15881
-  examine: "It's a bridge."
 - id: 15882
-  examine: "Flames above, troubled water below!"
 - id: 15883
-  examine: "Flames above, troubled water below!"
 - id: 15884
-  examine: "This isn't safe to walk on."
 - id: 15885
-  examine: "This isn't safe to walk on."
 - id: 15886
-  examine: "This isn't safe to walk on."
 - id: 15887
-  examine: "This isn't safe to walk on."
 - id: 15888
-  examine: "This isn't safe to walk on."
 - id: 15889
 - id: 15890
-  examine: "It's a bamboo ladder."
 - id: 15891
-  examine: "It's a bamboo ladder."
 - id: 15892
-  examine: "It's a bamboo ladder."
 - id: 15893
-  examine: "It's a bamboo ladder."
 - id: 15894
-  examine: "It's a bamboo ladder."
 - id: 15895
-  examine: "It's a bamboo ladder."
 - id: 15896
-  examine: "It's a copper ladder."
 - id: 15897
-  examine: "It's a copper ladder."
 - id: 15898
-  examine: "It's a copper ladder."
 - id: 15899
-  examine: "It's a copper ladder."
 - id: 15900
-  examine: "It's a copper ladder."
 - id: 15901
-  examine: "It's a copper ladder."
 - id: 15902
-  examine: "Bamboo railings."
 - id: 15903
-  examine: "A complicated piece of distilling equipment."
 - id: 15904
-  examine: "A complicated piece of distilling equipment."
 - id: 15905
-  examine: "A complicated piece of distilling equipment."
 - id: 15906
-  examine: "A complicated piece of distilling equipment."
 - id: 15907
-  examine: "A complicated piece of distilling equipment."
 - id: 15908
-  examine: "A complicated piece of distilling equipment."
 - id: 15909
-  examine: "A complicated piece of distilling equipment."
 - id: 15910
-  examine: "A complicated piece of distilling equipment."
 - id: 15911
-  examine: "A complicated piece of distilling equipment."
 - id: 15912
-  examine: "A complicated piece of distilling equipment."
 - id: 15913
-  examine: "A complicated piece of distilling equipment."
 - id: 15914
-  examine: "A complicated piece of distilling equipment."
 - id: 15915
 - id: 15916
-  examine: "Connects the hoppers to the stills."
 - id: 15917
-  examine: "Connects the hoppers to the stills."
 - id: 15918
-  examine: "Connects the hoppers to the stills."
 - id: 15919
-  examine: "Connects the hoppers to the stills."
 - id: 15920
-  examine: "Connects the hoppers to the stills."
 - id: 15921
-  examine: "Connects the hoppers to the stills."
 - id: 15922
-  examine: "Where the rum is packaged into bottles."
 - id: 15923
-  examine: "Looks like it's ready to blow.."
 - id: 15924
-  examine: "A crude conveyor belt."
 - id: 15925
-  examine: "A crude conveyor belt."
 - id: 15926
-  examine: "A crude conveyor belt."
 - id: 15927
-  examine: "A crude conveyor belt."
 - id: 15928
-  examine: "You can scald your enemies with this device."
 - id: 15929
-  examine: "You can scald your enemies with this device."
 - id: 15930
-  examine: "You can scald your enemies with this device."
 - id: 15931
-  examine: "You can store wood for the boilers here."
 - id: 15932
-  examine: "You can make new parts here."
 - id: 15933
-  examine: "Empty, so sad..."
 - id: 15934
-  examine: "Filled with equipment."
 - id: 15935
-  examine: "A hole, full of water. Astonishing!"
 - id: 15936
-  examine: "You can fill your buckets from here."
 - id: 15937
-  examine: "That's unlikely to be usable with all the fire on it."
 - id: 15938
-  examine: "It's damaged, you can't get water from here."
 - id: 15939
-  examine: "You can use these to make a colour dye."
 - id: 15940
-  examine: "You can use these to make a colour dye."
 - id: 15941
-  examine: "Pause and smell the burning."
 - id: 15942
-  examine: "Pause and smell the burning."
 - id: 15943
-  examine: "Store things and stuff here."
 - id: 15944
-  examine: "A conveniently located hole."
 - id: 15945
-  examine: "Store things and stuff here."
 - id: 15946
-  examine: "Where the sweetgrubs live."
 - id: 15947
-  examine: "All the sweetgrubs are gone."
 - id: 15948
   depleted: 15950
-  examine: "A native jungle tree."
 - id: 15949
-  examine: "Its leaves are made of burning."
 - id: 15950
-  examine: "Precisely one tenth of a tree."
 - id: 15951
   depleted: 15953
-  examine: "A native jungle tree."
 - id: 15952
-  examine: "I'd best pick another if I dont want my axe to burn up."
 - id: 15953
-  examine: "'Paul Bunion was here.'"
 - id: 15954
   depleted: 15956
-  examine: "A native jungle tree."
 - id: 15955
-  examine: "If I poke it, I will get burned."
 - id: 15956
-  examine: "What's left after the loggers have been."
 - id: 15957
-  examine: "A terribly tall tropical tree."
 - id: 15958
-  examine: "A terribly tall tropical tree."
 - id: 15959
-  examine: "A terribly tall tropical tree."
 - id: 15960
-  examine: "Leaves of a bamboo tree."
 - id: 15961
-  examine: "Where the bitternut grows."
 - id: 15962
-  examine: "Where the bitternut grows."
 - id: 15963
-  examine: "Where the bitternut grows."
 - id: 15964
-  examine: "Where the bitternut grows."
 - id: 15965
-  examine: "Where the bitternut grows."
 - id: 15966
-  examine: "Where the bitternut grows."
 - id: 15967
-  examine: "Where the bitternut grows."
 - id: 15968
-  examine: "Where the bitternut grows."
 - id: 15969
-  examine: "Where the bitternut grows."
 - id: 15970
-  examine: "A gnarled jungle tree, good for its bark."
 - id: 15971
-  examine: "What's left of a tree."
 - id: 15972
 - id: 15973
 - id: 15974
@@ -25524,104 +25295,60 @@
 - id: 15976
 - id: 15977
 - id: 15978
-  examine: "It has large broad leaves."
 - id: 15979
 - id: 15980
 - id: 15981
-  examine: "The ideal thing to sit on."
 - id: 15982
-  examine: "A waiting room table."
 - id: 15983
-  examine: "Hmm... I do feel like a cuppa."
 - id: 15984
-  examine: "Leads outside."
 - id: 15985
-  examine: "I'm sure my belongings will be safe here..."
 - id: 15986
-  examine: "This shows that this hopper is for Bitternuts."
 - id: 15987
-  examine: "This shows that this hopper is for Sweetgrubs."
 - id: 15988
-  examine: "This shows that this hopper is for Scrapey Tree Bark."
 - id: 15989
-  examine: "This shows that this hopper is for Red Water."
 - id: 15990
-  examine: "This shows that this hopper is for Blue Water."
 - id: 15991
-  examine: "This shows that this hopper is for Water."
 - id: 15992
-  examine: "This shows the number of the boiler."
 - id: 15993
-  examine: "This shows the number of the boiler."
 - id: 15994
-  examine: "This shows the number of the boiler."
 - id: 15995
-  examine: "Ooh, looks like Jimmy has some interesting stuff."
 - id: 15996
-  examine: "I'll be able to leave through this if I need to."
 - id: 15997
-  examine: "The flag of the Guilded Smile, Fancy Dan's ship."
 - id: 15998
-  examine: "The flag of the Cutthroat, San Fan's ship."
 - id: 15999
 - id: 16000
 - id: 16001
-  examine: "Useful for transportation of valuable items."
 - id: 16002
-  examine: "Useful for transportation of valuable items."
 - id: 16003
-  examine: "Useful for storage."
 - id: 16004
 - id: 16005
-  examine: "A very slippery piece of wood."
 - id: 16006
-  examine: "A very slippery piece of wood."
 - id: 16007
-  examine: "A very slippery piece of wood."
 - id: 16008
 - id: 16009
 - id: 16010
 - id: 16011
 - id: 16012
-  examine: "A stone that can be stepped on."
 - id: 16013
-  examine: "A very slippery stepping stone."
 - id: 16014
-  examine: "Conveniently located rocks."
 - id: 16015
-  examine: "Store things and stuff here."
 - id: 16016
-  examine: "A conveniently located crate."
 - id: 16017
-  examine: "Store things and stuff here."
 - id: 16018
-  examine: "A conveniently located bush."
 - id: 16019
-  examine: "Store things and stuff here."
 - id: 16020
-  examine: "A conveniently located hole."
 - id: 16021
-  examine: "Store things and stuff here."
 - id: 16022
-  examine: "Conveniently located rocks."
 - id: 16023
-  examine: "Store things and stuff here."
 - id: 16024
-  examine: "A conveniently located crate."
 - id: 16025
 - id: 16026
 - id: 16027
-  examine: "Bars caging off an area."
 - id: 16028
-  examine: "Bars caging off an area."
 - id: 16029
-  examine: "Bars caging off an area."
 - id: 16030
-  examine: "Bars caging off an area."
 - id: 16031
-  examine: "Stairs leading down."
 - id: 16032
-  examine: "Stairs leading down."
 - id: 16033
 - id: 16034
 - id: 16035
@@ -25649,37 +25376,27 @@
 - id: 16057
 - id: 16058
 - id: 16059
-  examine: "A Bush with monkey nuts growing on it."
 - id: 16060
-  examine: "I can see the surface."
 - id: 16061
-  examine: "A way out."
 - id: 16062
-  examine: "A terribly tall tropical tree."
 - id: 16063
 - id: 16064
 - id: 16065
 - id: 16066
-  examine: "A vine."
 - id: 16067
 - id: 16068
 - id: 16069
 - id: 16070
 - id: 16071
-  examine: "A terribly tall tropical tree."
 - id: 16072
 - id: 16073
 - id: 16074
 - id: 16075
 - id: 16076
 - id: 16077
-  examine: "It's a long, hot rock."
 - id: 16078
-  examine: "It's a rock with a dead snake on."
 - id: 16079
-  examine: "It's a rock with a dead, burnt snake on."
 - id: 16080
-  examine: "It's a rock with a cooked snake on. Smells good..."
 - id: 16081
 - id: 16082
 - id: 16083
@@ -25700,40 +25417,25 @@
 - id: 16098
 - id: 16099
 - id: 16100
-  examine: "I can get out this way."
 - id: 16101
 - id: 16102
 - id: 16103
 - id: 16104
-  examine: "Entrance to the monkey agility arena."
 - id: 16105
-  examine: "A ghostly barrier."
 - id: 16106
 - id: 16107
 - id: 16108
-  examine: "These stairs were carved out of the rock of the cavern."
 - id: 16109
-  examine: "These stairs were carved out of the rock of the cavern."
 - id: 16110
-  examine: "I can climb this."
 - id: 16111
-  examine: "I can climb up here."
 - id: 16112
-  examine: "I can go below decks with this ladder."
 - id: 16113
-  examine: "I wonder what's under it."
 - id: 16114
-  examine: "I wonder what's down there."
 - id: 16115
-  examine: "I can't see a rock!"
 - id: 16116
-  examine: "I wonder what's inside."
 - id: 16117
-  examine: "I wonder what's inside."
 - id: 16118
-  examine: "I wonder what's inside."
 - id: 16119
-  examine: "Perhaps I should search it."
 - id: 16120
 - id: 16121
 - id: 16122
@@ -25744,20 +25446,13 @@
 - id: 16127
 - id: 16128
 - id: 16129
-  examine: "A passageway leading somewhere."
 - id: 16130
-  examine: "A passageway leading somewhere."
 - id: 16131
-  examine: "A passageway leading up."
 - id: 16132
-  examine: "A passageway leading up."
 - id: 16133
-  examine: "A passageway leading down."
 - id: 16134
-  examine: "A passageway leading down."
 - id: 16135
 - id: 16136
-  examine: "A little rock."
 - id: 16137
 - id: 16138
 - id: 16139
@@ -25790,11 +25485,8 @@
 - id: 16166
 - id: 16167
 - id: 16168
-  examine: "There's a tunnel down there with a minecart to ride."
 - id: 16169
-  examine: "A table bearing a curious device."
 - id: 16170
-  examine: "A table bearing Mizgog's beads."
 - id: 16171
 - id: 16172
 - id: 16173
@@ -25802,11 +25494,8 @@
 - id: 16175
 - id: 16176
 - id: 16177
-  examine: "A home for frogs."
 - id: 16178
-  examine: "Otherwise known as a lilypad."
 - id: 16179
-  examine: "A home for frogs."
 - id: 16180
 - id: 16181
 - id: 16182
@@ -25815,14 +25504,10 @@
 - id: 16185
 - id: 16186
 - id: 16187
-  examine: "Thick cloud."
 - id: 16188
 - id: 16189
-  examine: "Thick cloud."
 - id: 16190
-  examine: "Looks a little dangerous!"
 - id: 16191
-  examine: "Looks a little dangerous!"
 - id: 16192
 - id: 16193
 - id: 16194
@@ -25830,9 +25515,7 @@
 - id: 16196
 - id: 16197
 - id: 16198
-  examine: "Whatever it is, it's not living."
 - id: 16199
-  examine: "Whatever it is, it's not living."
 - id: 16200
 - id: 16201
 - id: 16202
@@ -25847,24 +25530,17 @@
 - id: 16211
 - id: 16212
 - id: 16213
-  examine: "What an absolute mess!"
 - id: 16214
 - id: 16215
-  examine: "What an absolute mess!"
 - id: 16216
 - id: 16217
-  examine: "Broken glass everywhere!"
 - id: 16218
 - id: 16219
-  examine: "They've all been smashed!"
 - id: 16220
 - id: 16221
-  examine: "A shelf of broken potion vials."
 - id: 16222
 - id: 16223
-  examine: "Smashed potion vials and bits of glass."
 - id: 16224
-  examine: "Fairy Nuff passed Healing 101!"
 - id: 16225
 - id: 16226
 - id: 16227
@@ -25875,74 +25551,43 @@
 - id: 16232
 - id: 16233
 - id: 16234
-  examine: "She looks fairy, fairy injured."
 - id: 16235
-  examine: "She seems almost lifeless."
 - id: 16236
-  examine: "She's 'armless."
 - id: 16237
-  examine: "She looks a bit pale."
 - id: 16238
-  examine: "An empty stretcher."
 - id: 16239
-  examine: "A medical box."
 - id: 16240
-  examine: "Whoever made this had no idea how small fairies really are."
 - id: 16241
-  examine: "A discarded crutch for fairy giants."
 - id: 16242
-  examine: "You guessed it, this crutch is discarded too."
 - id: 16243
 - id: 16244
-  examine: "An emergency medical table."
 - id: 16245
-  examine: "A large tactical map table."
 - id: 16246
-  examine: "A stool. Fantastic for sitting on."
 - id: 16247
-  examine: "A tactical wall map."
 - id: 16248
-  examine: "A crate of fairy wands. They are too small for you to wield."
 - id: 16249
-  examine: "A crate for storing and transporting bows."
 - id: 16250
-  examine: "For storage."
 - id: 16251
-  examine: "Some wooden crates."
 - id: 16252
-  examine: "A wooden crate."
 - id: 16253
-  examine: "A wooden barrel for storage."
 - id: 16254
-  examine: "A tactical map board."
 - id: 16255
 - id: 16256
 - id: 16257
 - id: 16258
 - id: 16259
 - id: 16260
-  examine: "A stalagmite rising from the floor."
 - id: 16261
-  examine: "I must remember stalagmites come from the floor and stalagtites from the roof."
 - id: 16262
-  examine: "A large stalagmite."
 - id: 16263
-  examine: "Interconnected stalagmites."
 - id: 16264
-  examine: "An ancient pine tree."
 - id: 16265
   depleted: 9035
-  examine: "An ancient pine tree."
 - id: 16266
-  examine: "Stumpy or maybe just short."
 - id: 16267
-  examine: "A leafy fern."
 - id: 16268
-  examine: "A small bushy plant."
 - id: 16269
-  examine: "A leafy shrub."
 - id: 16270
-  examine: "A small leafy shrub."
 - id: 16271
 - id: 16272
 - id: 16273
@@ -25956,9 +25601,7 @@
 - id: 16281
 - id: 16282
 - id: 16283
-  examine: "Rock, but obviously not roll."
 - id: 16284
-  examine: "I guess it's not a rolling stone."
 - id: 16285
 - id: 16286
 - id: 16287
@@ -25977,21 +25620,13 @@
 - id: 16300
 - id: 16301
 - id: 16302
-  examine: "A huge, natural shower."
 - id: 16303
-  examine: "A small rock."
 - id: 16304
-  examine: "For ill people."
 - id: 16305
-  examine: "She seems almost lifeless."
 - id: 16306
-  examine: "She seems almost lifeless."
 - id: 16307
-  examine: "What does that say?"
 - id: 16308
-  examine: "A small cave entrance."
 - id: 16309
-  examine: "A small cave entrance."
 - id: 16310
 - id: 16311
 - id: 16312
@@ -26057,17 +25692,11 @@
 - id: 16372
 - id: 16373
 - id: 16374
-  examine: "Broken shelves of colourful potion gourds!"
 - id: 16375
-  examine: "Broken shelves of colourful potion gourds!"
 - id: 16376
-  examine: "A broken shelf of colourful potion gourds!"
 - id: 16377
-  examine: "A broken shelf of colourful potion gourds!"
 - id: 16378
-  examine: "Fairy Nuff passed healing 101!"
 - id: 16379
-  examine: "Fairy Nuff passed healing 101!"
 - id: 16380
 - id: 16381
 - id: 16382
@@ -26139,7 +25768,6 @@
 - id: 16448
 - id: 16449
 - id: 16450
-  examine: "It's the ladder up."
 - id: 16451
 - id: 16452
 - id: 16453
@@ -26154,29 +25782,17 @@
 - id: 16462
 - id: 16463
 - id: 16464
-  examine: "A rocky outcrop."
 - id: 16465
-  examine: "Just another crack in the wall."
 - id: 16466
-  examine: "It looks small and slippery."
 - id: 16467
-  examine: "Must be a part of Glough's sickening experiments."
 - id: 16468
-  examine: "It's quite tight."
 - id: 16469
-  examine: "Very hot."
 - id: 16470
-  examine: "A whetstone for sharpening."
 - id: 16471
-  examine: "Bellows. Great for blowing!"
 - id: 16472
-  examine: "It's a Lathe... What did you expect?"
 - id: 16473
-  examine: "Scraps of wood. How messy."
 - id: 16474
-  examine: "It's a shame this coal hasn't been under a lot of pressure. People would pick it up pretty quickly if that was the case..."
 - id: 16475
-  examine: "It's a shame this coal hasn't been under a lot of pressure. People would pick it up pretty quickly if that was the case..."
 - id: 16476
 - id: 16477
 - id: 16478
@@ -26193,21 +25809,15 @@
 - id: 16489
 - id: 16490
 - id: 16491
-  examine: "Sounds like there's liquid inside."
 - id: 16492
-  examine: "I won't be leaving that way then."
 - id: 16493
-  examine: "I won't be leaving that way then."
 - id: 16494
-  examine: "Flag, pole... Yep, it's a flagpole."
 - id: 16495
 - id: 16496
 - id: 16497
 - id: 16498
 - id: 16499
-  examine: "This must be climbed over."
 - id: 16500
-  examine: "A pipe I can squeeze through."
 - id: 16501
 - id: 16502
 - id: 16503
@@ -26216,125 +25826,71 @@
 - id: 16506
 - id: 16507
 - id: 16508
-  examine: "A mat for exercises."
 - id: 16509
-  examine: "A pipe I can squeeze through."
 - id: 16510
-  examine: "Funny looking holes that don't look too inviting."
 - id: 16511
-  examine: "A pipe I can squeeze through."
 - id: 16512
 - id: 16513
-  examine: "A very slippery stepping stone."
 - id: 16514
-  examine: "A rocky outcrop."
 - id: 16515
-  examine: "A rocky outcrop."
 - id: 16516
 - id: 16517
-  examine: "Ornate railing."
 - id: 16518
-  examine: "Wooden fencing."
 - id: 16519
-  examine: "A well constructed castle wall."
 - id: 16520
-  examine: "A rather strategically placed hole, which appears to be in the ground."
 - id: 16521
-  examine: "A rocky outcrop."
 - id: 16522
-  examine: "A rocky outcrop."
 - id: 16523
-  examine: "A rocky outcrop."
 - id: 16524
-  examine: "A rocky outcrop."
 - id: 16525
-  examine: "A well weathered wall."
 - id: 16526
-  examine: "A well weathered wall."
 - id: 16527
-  examine: "A tunnel leading under the wall."
 - id: 16528
-  examine: "A tunnel leading under the wall."
 - id: 16529
-  examine: "An underwall tunnel."
 - id: 16530
-  examine: "An underwall tunnel."
 - id: 16531
-  examine: "This wall has holes in it; looks damaged, but also suspicious."
 - id: 16532
-  examine: "A wall jutting out into the path."
 - id: 16533
-  examine: "I can jump from this stepping stone."
 - id: 16534
-  examine: "A rocky outcrop."
 - id: 16535
-  examine: "A rocky outcrop."
 - id: 16536
 - id: 16537
-  examine: "A chain rope - looks pretty painful if you slip."
 - id: 16538
-  examine: "A chain rope - looks pretty painful if you slip."
 - id: 16539
-  examine: "A few rocks short of a wall - very crevice like."
 - id: 16540
-  examine: "The foam from the river makes this log very slippy."
 - id: 16541
-  examine: "The foam from the river makes this log very slippy."
 - id: 16542
-  examine: "The foam from the river makes this log very slippy."
 - id: 16543
-  examine: "Just another crack in the wall."
 - id: 16544
-  examine: "Funny looking holes that don't look too inviting."
 - id: 16545
-  examine: "They seem to fit in with the rocky surroundings, so as not to stick out."
 - id: 16546
-  examine: "A slippery well worn log."
 - id: 16547
-  examine: "A slippery well worn log."
 - id: 16548
-  examine: "A slippery well worn log."
 - id: 16549
-  examine: "A rocky outcrop."
 - id: 16550
-  examine: "A rocky outcrop."
 - id: 16551
 - id: 16552
-  examine: "Used to be ornate, now it's a little bit vandalised."
 - id: 16553
 - id: 16554
 - id: 16555
 - id: 16556
-  examine: "It's the ladder down."
 - id: 16557
-  examine: "It's the ladder in both directions."
 - id: 16558
-  examine: "You wouldn't want to watch a goblin getting changed!"
 - id: 16559
-  examine: "A large wooden box."
 - id: 16560
-  examine: "A large wooden box."
 - id: 16561
-  examine: "A large wooden box."
 - id: 16562
-  examine: "A small table."
 - id: 16563
 - id: 16564
-  examine: "A wooden crate."
 - id: 16565
-  examine: "A wooden crate."
 - id: 16566
-  examine: "A wooden barrel."
 - id: 16567
 - id: 16568
-  examine: "A goblin standard."
 - id: 16569
-  examine: "A goblin standard."
 - id: 16570
 - id: 16571
 - id: 16572
 - id: 16573
-  examine: "These obviously mean keep out!"
 - id: 16574
 - id: 16575
 - id: 16576
@@ -26347,44 +25903,27 @@
 - id: 16583
 - id: 16584
 - id: 16585
-  examine: "Like a pile of memes."
 - id: 16586
-  examine: "Like a pile of memes."
 - id: 16587
-  examine: "Like a pile of memes."
 - id: 16588
-  examine: "Like a pile of memes."
 - id: 16589
-  examine: "Like a pile of memes."
 - id: 16590
-  examine: "Like a pile of memes."
 - id: 16591
-  examine: "Like a pile of memes."
 - id: 16592
-  examine: "Like a pile of memes."
 - id: 16593
-  examine: "Like a pile of memes."
 - id: 16594
-  examine: "Like a pile of memes."
 - id: 16595
 - id: 16596
 - id: 16597
 - id: 16598
-  examine: "Mmmm dreamy."
 - id: 16599
-  examine: "All that has been, all that is and space for all that will be."
 - id: 16600
-  examine: "I can jump that! Can't I?"
 - id: 16601
-  examine: "Do re mi!"
 - id: 16602
-  examine: "Do re mi!"
 - id: 16603
 - id: 16604
   depleted: 16605
-  examine: "Now that's weird!"
 - id: 16605
-  examine: "Now that's weird!"
 - id: 16606
 - id: 16607
 - id: 16608
@@ -26399,193 +25938,108 @@
 - id: 16617
 - id: 16618
 - id: 16619
-  examine: "0"
 - id: 16620
-  examine: "The winning position!"
 - id: 16621
-  examine: "The number of thumbs on my handsies."
 - id: 16622
-  examine: "The magic number."
 - id: 16623
-  examine: "The lucky leaf clover."
 - id: 16624
-  examine: "Gimmie!"
 - id: 16625
-  examine: "The highest number on a dice."
 - id: 16626
-  examine: "The deadly sins."
 - id: 16627
-  examine: "The number of pinkies on my handsies."
 - id: 16628
-  examine: "Five joined with four."
 - id: 16629
 - id: 16630
 - id: 16631
 - id: 16632
-  examine: "It might take me somewhere."
 - id: 16633
-  examine: "It might take me somewhere."
 - id: 16634
-  examine: "It might take me somewhere."
 - id: 16635
-  examine: "It might take me somewhere."
 - id: 16636
-  examine: "It might take me somewhere."
 - id: 16637
-  examine: "It might take me somewhere."
 - id: 16638
-  examine: "Dreamy."
 - id: 16639
-  examine: "A very strange looking tree."
 - id: 16640
-  examine: "High above here is a tattered flag, blowing in the wind."
 - id: 16641
-  examine: "An appliance for cooking with."
 - id: 16642
-  examine: "The bank teller will serve you from here."
 - id: 16643
-  examine: "This booth is closed."
 - id: 16644
-  examine: "The resting place of Necrovarus' mortal body."
 - id: 16645
-  examine: "The resting place of Necrovarus' mortal body."
 - id: 16646
-  examine: "I can climb these stairs."
 - id: 16647
-  examine: "They go down."
 - id: 16648
-  examine: "A ghastly fountain filled with slime and bones, the source of Necrovarus' power."
 - id: 16649
-  examine: "It's a small Ectofuntus."
 - id: 16650
-  examine: "A big grinding thing."
 - id: 16651
-  examine: "The tatty gangplank of a tatty ship."
 - id: 16652
-  examine: "The tatty gangplank of a tatty ship."
 - id: 16653
-  examine: "Seen better days."
 - id: 16654
-  examine: "A big grinding thing."
 - id: 16655
-  examine: "A big grinding thing."
 - id: 16656
-  examine: "A big grinding thing."
 - id: 16657
-  examine: "A hot furnace."
 - id: 16658
 - id: 16659
 - id: 16660
 - id: 16661
-  examine: "Dare I go up?"
 - id: 16662
-  examine: "These stairs look spooky!"
 - id: 16663
-  examine: "These stairs look spooky!"
 - id: 16664
-  examine: "I can use these stairs to climb down."
 - id: 16665
-  examine: "I can climb these stairs."
 - id: 16666
-  examine: "A rickety old staircase."
 - id: 16667
-  examine: "I can climb down these stairs."
 - id: 16668
-  examine: "I can climb up these stairs."
 - id: 16669
-  examine: "I can climb down these stairs."
 - id: 16670
-  examine: "I can climb up these stairs."
 - id: 16671
-  examine: "I can climb up these stairs."
 - id: 16672
-  examine: "I can climb up or go down these stairs."
 - id: 16673
-  examine: "I can climb down these stairs."
 - id: 16674
-  examine: "I can climb down these stairs."
 - id: 16675
-  examine: "I can climb up these stairs."
 - id: 16676
-  examine: "I can climb up or go down these stairs."
 - id: 16677
-  examine: "I can climb down these stairs."
 - id: 16678
-  examine: "I can climb down these stairs."
 - id: 16679
-  examine: "I can climb down this."
 - id: 16680
-  examine: "I can climb down this."
 - id: 16681
-  examine: "I can climb down this."
 - id: 16682
-  examine: "I can climb down this."
 - id: 16683
-  examine: "I can climb this."
 - id: 16684
-  examine: "I can climb this."
 - id: 16685
-  examine: "I can climb down this."
 - id: 16686
-  examine: "A portal from this mystical place."
 - id: 16687
-  examine: "A very high quality source of Rune stones."
 - id: 16688
-  examine: "A little empty barrel."
 - id: 16689
-  examine: "This is where the tan is kept."
 - id: 16690
 - id: 16691
-  examine: "For the putting of magic hats on."
 - id: 16692
-  examine: "For the putting of magic hats on."
 - id: 16693
-  examine: "Not my style, I'm sad to say."
 - id: 16694
 - id: 16695
-  examine: "Objects are stored in here."
 - id: 16696
-  examine: "Objects are stored in here."
 - id: 16697
-  examine: "A chest."
 - id: 16698
 - id: 16699
 - id: 16700
-  examine: "The bank teller will serve you from here."
 - id: 16701
-  examine: "Lights up your life."
 - id: 16702
-  examine: "For cooking things."
 - id: 16703
-  examine: "For cooking things."
 - id: 16704
-  examine: "Wash your dirty dirty hands."
 - id: 16705
-  examine: "Wash your hands!"
 - id: 16706
-  examine: "Sit on it."
 - id: 16707
-  examine: "Mostly books about magic and colours."
 - id: 16708
-  examine: "Mmmmmmm, looking fine."
 - id: 16709
 - id: 16710
 - id: 16711
 - id: 16712
 - id: 16713
 - id: 16714
-  examine: "Hanging there as if for sale."
 - id: 16715
-  examine: "Hanging there as if for sale."
 - id: 16716
 - id: 16717
 - id: 16718
 - id: 16719
-  examine: "Built for sleeping upon."
 - id: 16720
-  examine: "Built for sleeping upon."
 - id: 16721
-  examine: "Built for sleeping upon."
 - id: 16722
 - id: 16723
 - id: 16724
@@ -26594,39 +26048,22 @@
 - id: 16727
 - id: 16728
 - id: 16729
-  examine: "For being pretty and making your day brighter."
 - id: 16730
-  examine: "For being pretty and making your day brighter."
 - id: 16731
-  examine: "For being pretty and making your day brighter."
 - id: 16732
-  examine: "Allows access to level below."
 - id: 16733
-  examine: "Allows access to level below."
 - id: 16734
-  examine: "Allows access to level above."
 - id: 16735
-  examine: "Allows access to above level."
 - id: 16736
-  examine: "Allows access to level below."
 - id: 16737
-  examine: "Tables are for glasses."
 - id: 16738
-  examine: "Tables are for glasses."
 - id: 16739
-  examine: "Tables with dyed hides."
 - id: 16740
-  examine: "Tables with cloths on it."
 - id: 16741
-  examine: "Tables are for glasses."
 - id: 16742
-  examine: "Tables are for glasses."
 - id: 16743
-  examine: "It's not uncommon for people to sit on these."
 - id: 16744
-  examine: "It's not uncommon for people to sit on these."
 - id: 16745
-  examine: "You put your backside here."
 - id: 16746
 - id: 16747
 - id: 16748
@@ -26656,16 +26093,11 @@
 - id: 16772
 - id: 16773
 - id: 16774
-  examine: "Lets you walk through walls."
 - id: 16775
 - id: 16776
-  examine: "Lets you walk through walls."
 - id: 16777
-  examine: "Lets you walk through walls."
 - id: 16778
-  examine: "Lets you walk through walls."
 - id: 16779
-  examine: "Lets you walk through walls."
 - id: 16780
 - id: 16781
 - id: 16782
@@ -26695,21 +26127,13 @@
 - id: 16806
 - id: 16807
 - id: 16808
-  examine: "Burn logs - woo hoo!"
 - id: 16809
-  examine: "Burn logs - woo hoo!"
 - id: 16810
-  examine: "Burn logs - woo hoo!"
 - id: 16811
-  examine: "Burn logs - woo hoo!"
 - id: 16812
-  examine: "For cooking things."
 - id: 16813
-  examine: "Cloths are tortured in here."
 - id: 16814
-  examine: "You put your backside here."
 - id: 16815
-  examine: "Tables are for glasses."
 - id: 16816
 - id: 16817
 - id: 16818
@@ -26722,152 +26146,85 @@
 - id: 16825
 - id: 16826
 - id: 16827
-  examine: "You can put stuff on it. If you want to."
 - id: 16828
-  examine: "You can put stuff on it. If you want to."
 - id: 16829
-  examine: "It might take me somewhere."
 - id: 16830
 - id: 16831
-  examine: "It might take me somewhere."
 - id: 16832
 - id: 16833
-  examine: "It might take me somewhere."
 - id: 16834
 - id: 16835
-  examine: "It might take me somewhere."
 - id: 16836
 - id: 16837
-  examine: "It might take me somewhere."
 - id: 16838
 - id: 16839
-  examine: "It might take me somewhere."
 - id: 16840
 - id: 16841
-  examine: "It might take me somewhere."
 - id: 16842
 - id: 16843
-  examine: "The number 1."
 - id: 16844
-  examine: "The number 2."
 - id: 16845
-  examine: "The number 3."
 - id: 16846
-  examine: "The number 4."
 - id: 16847
-  examine: "The number 5."
 - id: 16848
-  examine: "The number 6."
 - id: 16849
-  examine: "Square with numbers."
 - id: 16850
-  examine: "Square with numbers."
 - id: 16851
-  examine: "Square with numbers."
 - id: 16852
-  examine: "Square with numbers."
 - id: 16853
-  examine: "Square with numbers."
 - id: 16854
-  examine: "Square with numbers."
 - id: 16855
-  examine: "Square with numbers."
 - id: 16856
-  examine: "Dreamy."
 - id: 16857
-  examine: "Dreamy."
 - id: 16858
-  examine: "Land and jump from here."
 - id: 16859
-  examine: "Just hanging around."
 - id: 16860
-  examine: "A little barrel of tar."
 - id: 16861
-  examine: "Perfect for a pirate snooze."
 - id: 16862
-  examine: "A crate."
 - id: 16863
-  examine: "A crate."
 - id: 16864
-  examine: "A crate."
 - id: 16865
-  examine: "A crate."
 - id: 16866
-  examine: "Pile of sacks."
 - id: 16867
-  examine: "Pile of sacks."
 - id: 16868
-  examine: "Pile of sacks."
 - id: 16869
-  examine: "Pile of sacks."
 - id: 16870
-  examine: "Pile of sacks."
 - id: 16871
-  examine: "Pile of sacks."
 - id: 16872
-  examine: "Bits of fish."
 - id: 16873
-  examine: "Bits of fish."
 - id: 16874
-  examine: "A simple stool."
 - id: 16875
-  examine: "A stool."
 - id: 16876
-  examine: "A barrel full of fish."
 - id: 16877
-  examine: "A closed barrel."
 - id: 16878
-  examine: "This sack holds grain."
 - id: 16879
-  examine: "These are for shooting from cannons."
 - id: 16880
-  examine: "These are for shooting from cannons."
 - id: 16881
-  examine: "This is where the pirates keep their barrels."
 - id: 16882
-  examine: "This is where the pirates keep their barrels."
 - id: 16883
-  examine: "This is where the pirates keep their barrels."
 - id: 16884
-  examine: "An apple a day..."
 - id: 16885
-  examine: "An apple a day..."
 - id: 16886
-  examine: "An empty barrel."
 - id: 16887
-  examine: "This is where the pirates put their stuff."
 - id: 16888
-  examine: "This is where the pirates put their stuff."
 - id: 16889
-  examine: "An open wooden chest."
 - id: 16890
-  examine: "This is where the pirates put their stuff."
 - id: 16891
-  examine: "This is where the pirates put their stuff."
 - id: 16892
 - id: 16893
-  examine: "An appliance for cooking with."
 - id: 16894
-  examine: "Because one isn't enough."
 - id: 16895
-  examine: "Because you never know when you'll need some."
 - id: 16896
 - id: 16897
 - id: 16898
 - id: 16899
-  examine: "It's a table with candles on."
 - id: 16900
-  examine: "Generally used for sitting."
 - id: 16901
-  examine: "Light!"
 - id: 16902
-  examine: "A door."
 - id: 16903
-  examine: "A door."
 - id: 16904
 - id: 16905
 - id: 16906
-  examine: "Used for steering."
 - id: 16907
 - id: 16908
 - id: 16909
@@ -26900,80 +26257,49 @@
 - id: 16936
 - id: 16937
 - id: 16938
-  examine: "An effective ship repellent."
 - id: 16939
-  examine: "Not in use."
 - id: 16940
 - id: 16941
-  examine: "I wonder what would happen if I took it out?"
 - id: 16942
 - id: 16943
 - id: 16944
 - id: 16945
-  examine: "Go up."
 - id: 16946
-  examine: "Go up."
 - id: 16947
-  examine: "Go down."
 - id: 16948
-  examine: "Go down."
 - id: 16949
 - id: 16950
 - id: 16951
-  examine: "I wonder what would happen if I took it out?"
 - id: 16952
-  examine: "I wonder what would happen if I took it out?"
 - id: 16953
-  examine: "An effective ship repellent."
 - id: 16954
-  examine: "A Crate."
 - id: 16955
-  examine: "Where am I?"
 - id: 16956
-  examine: "This is where the pirates put their stuff."
 - id: 16957
-  examine: "It's used for loading and unloading fishing boats."
 - id: 16958
-  examine: "I hope it doesn't sink."
 - id: 16959
-  examine: "A way up."
 - id: 16960
-  examine: "A way up."
 - id: 16961
-  examine: "A way down."
 - id: 16962
-  examine: "A way down."
 - id: 16963
 - id: 16964
 - id: 16965
 - id: 16966
 - id: 16967
 - id: 16968
-  examine: "An empty shelf..."
 - id: 16969
-  examine: "An empty shelf..."
 - id: 16970
-  examine: "There are some pots and pans here."
 - id: 16971
-  examine: "There are some tankards here."
 - id: 16972
-  examine: "A shelf with a bucket on it."
 - id: 16973
-  examine: "There are a few books on this shelf."
 - id: 16974
-  examine: "It's a small table."
 - id: 16975
-  examine: "Someone needs to learn how to draw."
 - id: 16976
 - id: 16977
 - id: 16978
-  examine: "A map of some distant land."
 - id: 16979
-  examine: "Is it a map or a chart?"
 - id: 16980
-  examine: "X marks the spot!"
 - id: 16981
-  examine: "Old pirate law."
 - id: 16982
 - id: 16983
 - id: 16984
@@ -26992,19 +26318,14 @@
 - id: 16997
 - id: 16998
   depleted: 14892
-  examine: "A rocky outcrop."
 - id: 16999
   depleted: 14893
-  examine: "A rocky outcrop."
 - id: 17000
   depleted: 17009
-  examine: "Used to be ornate, now it's a little bit vandalised."
 - id: 17001
   depleted: 14892
-  examine: "This wall has holes in it; looks damaged, but also suspicious."
 - id: 17002
   depleted: 14893
-  examine: "A wall jutting out into the path."
 - id: 17003
   depleted: 17009
 - id: 17004
@@ -27016,7 +26337,6 @@
 - id: 17007
 - id: 17008
 - id: 17009
-  examine: "Even this door looks half starved - and appears to be eyeing you up as lunch."
 - id: 17010
 - id: 17011
 - id: 17012
@@ -27034,101 +26354,61 @@
 - id: 17024
 - id: 17025
 - id: 17026
-  examine: "I can climb this."
 - id: 17027
-  examine: "I can climb this."
 - id: 17028
-  examine: "I can't climb this."
 - id: 17029
 - id: 17030
 - id: 17031
-  examine: "A whole lot of crossbow items."
 - id: 17032
 - id: 17033
-  examine: "Big crate. Probably has crossbow bits inside."
 - id: 17034
 - id: 17035
 - id: 17036
-  examine: "A strong tree with grapple marks on it."
 - id: 17037
-  examine: "A strong tree with grapple marks on it."
 - id: 17038
-  examine: "A strong tree with grapple marks on it."
 - id: 17039
-  examine: "A strong tree with grapple marks on it."
 - id: 17040
-  examine: "A strong tree with grapple marks on it."
 - id: 17041
-  examine: "A strong tree with grapple marks on it."
 - id: 17042
-  examine: "These look secure enough to grapple."
 - id: 17043
-  examine: "That looks like it could hold my weight."
 - id: 17044
 - id: 17045
 - id: 17046
-  examine: "A strong tree with grapple marks on it."
 - id: 17047
-  examine: "Town wall."
 - id: 17048
-  examine: "Town wall."
 - id: 17049
-  examine: "City wall."
 - id: 17050
-  examine: "City wall."
 - id: 17051
-  examine: "City wall."
 - id: 17052
-  examine: "City wall."
 - id: 17053
 - id: 17054
 - id: 17055
 - id: 17056
-  examine: "Looks like a way to cross."
 - id: 17057
-  examine: "Looks like a way to cross."
 - id: 17058
-  examine: "Looks like a way to cross."
 - id: 17059
-  examine: "Looks like a way to cross."
 - id: 17060
-  examine: "Looks like a way to cross."
 - id: 17061
-  examine: "Looks like a way to cross."
 - id: 17062
-  examine: "Looks like a way to cross."
 - id: 17063
-  examine: "Looks like a way to cross."
 - id: 17064
-  examine: "These look secure."
 - id: 17065
-  examine: "That looks like it could hold my weight."
 - id: 17066
 - id: 17067
 - id: 17068
-  examine: "A smashed up raft."
 - id: 17069
-  examine: "A smashed up raft."
 - id: 17070
-  examine: "A smashed up raft."
 - id: 17071
-  examine: "A smashed up raft."
 - id: 17072
 - id: 17073
 - id: 17074
-  examine: "A strong tree with grapple marks on it."
 - id: 17075
-  examine: "A strong tree with grapple marks on it."
 - id: 17076
-  examine: "A strong tree with grapple marks on it."
 - id: 17077
-  examine: "A strong tree with grapple marks on it."
 - id: 17078
 - id: 17079
 - id: 17080
-  examine: "A strong tree with grapple marks on it."
 - id: 17081
-  examine: "A strong tree with grapple marks on it."
 - id: 17082
 - id: 17083
 - id: 17084
@@ -27137,26 +26417,17 @@
 - id: 17087
 - id: 17088
 - id: 17089
-  examine: "A sturdy wooden door."
 - id: 17090
-  examine: "A sturdy wooden door."
 - id: 17091
-  examine: "A large double door."
 - id: 17092
-  examine: "A large double door."
 - id: 17093
-  examine: "A large double door."
 - id: 17094
-  examine: "A large double door."
 - id: 17095
 - id: 17096
 - id: 17097
 - id: 17098
-  examine: "Stairs leading down."
 - id: 17099
-  examine: "Stairs leading down."
 - id: 17100
-  examine: "Even this door looks half starved - and appears to be eyeing you up as lunch."
 - id: 17101
 - id: 17102
 - id: 17103
@@ -27171,94 +26442,54 @@
 - id: 17112
 - id: 17113
 - id: 17114
-  examine: "Keeps the wind out."
 - id: 17115
-  examine: "It would keep the wind out better if it were closed."
 - id: 17116
-  examine: "A subterranean pool of ectoplasm."
 - id: 17117
-  examine: "A subterranean pool of ectoplasm."
 - id: 17118
-  examine: "A subterranean pool of ectoplasm."
 - id: 17119
-  examine: "A subterranean pool of ectoplasm."
 - id: 17120
-  examine: "I can climb this."
 - id: 17121
-  examine: "I can climb this."
 - id: 17122
-  examine: "I can climb down this."
 - id: 17123
 - id: 17124
 - id: 17125
-  examine: "It's a cute chair."
 - id: 17126
-  examine: "The napkins are made from real silk."
 - id: 17127
-  examine: "The napkins are made from real silk."
 - id: 17128
-  examine: "The napkins are made from real silk."
 - id: 17129
-  examine: "A plain gnome table."
 - id: 17130
-  examine: "Aluft Gianne jnr's desk."
 - id: 17131
-  examine: "For cooking things at gnome height."
 - id: 17132
-  examine: "Single kitchen unit."
 - id: 17133
-  examine: "For files storage."
 - id: 17134
-  examine: "For storage."
 - id: 17135
-  examine: "For extra storage."
 - id: 17136
-  examine: "For storage."
 - id: 17137
-  examine: "For extra storage."
 - id: 17138
 - id: 17139
 - id: 17140
-  examine: "A statue of Oaknock the Engineer."
 - id: 17141
-  examine: "A statue of King Healthorg the Great."
 - id: 17142
 - id: 17143
-  examine: "I can climb up these stairs."
 - id: 17144
-  examine: "Some wooden boxes."
 - id: 17145
-  examine: "Dirty and tatty."
 - id: 17146
-  examine: "The ideal thing to sit on."
 - id: 17147
 - id: 17148
-  examine: "I can climb up this."
 - id: 17149
-  examine: "I can climb down this."
 - id: 17150
-  examine: "Storage for sundry items."
 - id: 17151
-  examine: "Parcels wrapped in brown paper."
 - id: 17152
-  examine: "Storage for drugs and bandages."
 - id: 17153
-  examine: "Who knows what the dark wizards store in here?"
 - id: 17154
 - id: 17155
-  examine: "I can climb down these stairs."
 - id: 17156
 - id: 17157
 - id: 17158
-  examine: "Good for sitting on."
 - id: 17159
-  examine: "I can climb up this."
 - id: 17160
-  examine: "I can climb down this."
 - id: 17161
-  examine: "I wonder what they're making?"
 - id: 17162
-  examine: "It seems to be a bit broken."
 - id: 17163
 - id: 17164
 - id: 17165
@@ -27293,32 +26524,19 @@
 - id: 17194
 - id: 17195
 - id: 17196
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 17197
-  examine: "Our gnome heroes. Hooray!"
 - id: 17198
-  examine: "Our gnome heroes. Hooray!"
 - id: 17199
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 17200
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 17201
-  examine: "Our gnome heroes. Hooray!"
 - id: 17202
-  examine: "Our gnome heroes. Hooray!"
 - id: 17203
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 17204
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 17205
-  examine: "Our gnome heroes. Hooray!"
 - id: 17206
-  examine: "Our gnome heroes. Hooray!"
 - id: 17207
-  examine: "The goblin standard."
 - id: 17208
 - id: 17209
-  examine: "A small door in a hillock."
 - id: 17210
 - id: 17211
 - id: 17212
@@ -27332,9 +26550,7 @@
 - id: 17220
 - id: 17221
 - id: 17222
-  examine: "The way out!"
 - id: 17223
-  examine: "The way out!"
 - id: 17224
 - id: 17225
 - id: 17226
@@ -27344,40 +26560,23 @@
 - id: 17230
 - id: 17231
 - id: 17232
-  examine: "Brimstail's chest of drawers. There are books on top."
 - id: 17233
-  examine: "Brimstail's chest of drawers."
 - id: 17234
-  examine: "A gnome-sized chair."
 - id: 17235
-  examine: "A gnomish table with Brimstail's things on it."
 - id: 17236
-  examine: "Perfect for snoozing in the sun."
 - id: 17237
-  examine: "A wooden torch."
 - id: 17238
-  examine: "The plant moves by itself. Is it a sentient creature disguised as a plant? Naah..."
 - id: 17239
-  examine: "A crystal bowl of elven design."
 - id: 17240
-  examine: "Whatever it is, it's broken."
 - id: 17241
-  examine: "A weird combination of gnomish and elven design."
 - id: 17242
-  examine: "They don't go round any more."
 - id: 17243
-  examine: "They go round and round."
 - id: 17244
 - id: 17245
-  examine: "Looks like some sort of control panel."
 - id: 17246
-  examine: "It looks broken."
 - id: 17247
-  examine: "It looks locked."
 - id: 17248
-  examine: "I wonder what this does."
 - id: 17249
-  examine: "It's broken."
 - id: 17250
 - id: 17251
 - id: 17252
@@ -27385,134 +26584,75 @@
 - id: 17254
 - id: 17255
 - id: 17256
-  examine: "Should I go down there?"
 - id: 17257
-  examine: "Should I go down there?"
 - id: 17258
-  examine: "Should I go down there?"
 - id: 17259
-  examine: "Should I go down there?"
 - id: 17260
-  examine: "Should I go down there?"
 - id: 17261
-  examine: "Should I go down there?"
 - id: 17262
-  examine: "Should I go down there?"
 - id: 17263
-  examine: "Should I go down there?"
 - id: 17264
-  examine: "Should I go down there?"
 - id: 17265
-  examine: "Should I go down there?"
 - id: 17266
-  examine: "Should I go down there?"
 - id: 17267
-  examine: "A bridge has magically appeared."
 - id: 17268
-  examine: "There's nothing to see here..."
 - id: 17269
 - id: 17270
 - id: 17271
-  examine: "Useful for transportation of valuable items."
 - id: 17272
-  examine: "It looks like it might have some useful information."
 - id: 17273
-  examine: "An old silver spirit tree."
 - id: 17274
-  examine: "An old silver spirit tree."
 - id: 17275
-  examine: "The scorched remains of a silver spirit tree."
 - id: 17276
-  examine: "The remains of the silver spirit tree."
 - id: 17277
-  examine: "The remains of the silver spirit tree."
 - id: 17278
-  examine: "The remains of the silver spirit tree."
 - id: 17279
-  examine: "The skies are darkening..."
 - id: 17280
 - id: 17281
 - id: 17282
 - id: 17283
 - id: 17284
-  examine: "Blocks up a hole in the wall."
 - id: 17285
 - id: 17286
-  examine: "A conveniently rolled sail."
 - id: 17287
-  examine: "A conveniently rolled sail."
 - id: 17288
-  examine: "A conveniently rolled sail."
 - id: 17289
-  examine: "A conveniently rolled sail."
 - id: 17290
-  examine: "A conveniently rolled sail."
 - id: 17291
-  examine: "A conveniently rolled sail."
 - id: 17292
-  examine: "A conveniently rolled sail."
 - id: 17293
-  examine: "A conveniently rolled sail."
 - id: 17294
-  examine: "A conveniently rolled sail."
 - id: 17295
-  examine: "A conveniently rolled sail."
 - id: 17296
-  examine: "A sealed barrel with a warning sign on it."
 - id: 17297
-  examine: "A barrel with a warning sign on it."
 - id: 17298
 - id: 17299
-  examine: "A table."
 - id: 17300
-  examine: "A cupboard."
 - id: 17301
-  examine: "A cupboard."
 - id: 17302
-  examine: "A cupboard."
 - id: 17303
-  examine: "A cupboard."
 - id: 17304
-  examine: "A wooden crate."
 - id: 17305
-  examine: "A wooden crate."
 - id: 17306
-  examine: "A wooden stool."
 - id: 17307
-  examine: "A sealed barrel with a warning sign on it."
 - id: 17308
-  examine: "A wooden barrel for storage."
 - id: 17309
-  examine: "The ideal place to study."
 - id: 17310
 - id: 17311
-  examine: "A posh looking chair."
 - id: 17312
-  examine: "A posh looking bench."
 - id: 17313
-  examine: "Keeps the neighbours out!"
 - id: 17314
-  examine: "Keeps the neighbours out!"
 - id: 17315
-  examine: "Keeps the neighbours out!"
 - id: 17316
-  examine: "A door."
 - id: 17317
-  examine: "A door."
 - id: 17318
 - id: 17319
-  examine: "Shelves filled with interesting books."
 - id: 17320
-  examine: "Shelves filled with interesting books."
 - id: 17321
-  examine: "Shelves filled with interesting books."
 - id: 17322
-  examine: "Dead tree parts piled together neatly."
 - id: 17323
-  examine: "It's amazing what bees produce!"
 - id: 17324
 - id: 17325
-  examine: "A fire burns cosily in the fireplace."
 - id: 17326
 - id: 17327
 - id: 17328
@@ -27522,161 +26662,93 @@
 - id: 17332
 - id: 17333
 - id: 17334
-  examine: "I don't want to go down there!"
 - id: 17335
-  examine: "I don't want to go down there!"
 - id: 17336
-  examine: "I don't want to go down there!"
 - id: 17337
-  examine: "I don't want to go down there!"
 - id: 17338
-  examine: "I don't want to go down there!"
 - id: 17339
-  examine: "I don't want to go down there!"
 - id: 17340
-  examine: "I don't want to go down there!"
 - id: 17341
-  examine: "I don't want to go down there!"
 - id: 17342
-  examine: "I don't want to go down there!"
 - id: 17343
-  examine: "I don't want to go down there!"
 - id: 17344
-  examine: "I don't want to go down there!"
 - id: 17345
-  examine: "I don't want to go down there!"
 - id: 17346
 - id: 17347
 - id: 17348
-  examine: "A table."
 - id: 17349
 - id: 17350
-  examine: "Large rocks."
 - id: 17351
-  examine: "Large rocks."
 - id: 17352
-  examine: "Large rocks."
 - id: 17353
-  examine: "Large rocks."
 - id: 17354
-  examine: "Large rocks."
 - id: 17355
-  examine: "Large rocks."
 - id: 17356
-  examine: "Large rocks."
 - id: 17357
-  examine: "Large rocks."
 - id: 17358
-  examine: "Large rocks."
 - id: 17359
 - id: 17360
 - id: 17361
 - id: 17362
-  examine: "Large urn."
 - id: 17363
 - id: 17364
-  examine: "A rock."
 - id: 17365
-  examine: "A small rock."
 - id: 17366
-  examine: "A rock."
 - id: 17367
-  examine: "A stone tablet."
 - id: 17368
-  examine: "The place I found the stone tablet."
 - id: 17369
 - id: 17370
-  examine: "Should I go down there?"
 - id: 17371
-  examine: "Should I go down there?"
 - id: 17372
-  examine: "Should I go down there?"
 - id: 17373
-  examine: "Should I go down there?"
 - id: 17374
   depleted: 17626
-  examine: "Should I go down there?"
 - id: 17375
   depleted: 17631
-  examine: "Should I go down there?"
 - id: 17376
   depleted: 17632
-  examine: "Should I go down there?"
 - id: 17377
   depleted: 17633
-  examine: "Should I go down there?"
 - id: 17378
   depleted: 17634
-  examine: "Should I go down there?"
 - id: 17379
   depleted: 17638
-  examine: "Should I go down there?"
 - id: 17380
   depleted: 17657
-  examine: "Should I go down there?"
 - id: 17381
   depleted: 17659
-  examine: "Should I go down there?"
 - id: 17382
-  examine: "A good source of books!"
 - id: 17383
-  examine: "It's useless."
 - id: 17384
   depleted: 17660
-  examine: "I can climb down this."
 - id: 17385
   depleted: 17661
-  examine: "I can climb this."
 - id: 17386
   depleted: 17662
-  examine: "I can climb down this."
 - id: 17387
   depleted: 17663
-  examine: "I can climb this."
 - id: 17388
-  examine: "Not much use really."
 - id: 17389
-  examine: "This leads downwards."
 - id: 17390
-  examine: "These can be useful."
 - id: 17391
-  examine: "Steps made from natural rock."
 - id: 17392
-  examine: "Handy for boarding boats."
 - id: 17393
-  examine: "Handy for boarding boats."
 - id: 17394
-  examine: "Handy for boarding boats."
 - id: 17395
-  examine: "Handy for boarding boats."
 - id: 17396
-  examine: "Handy for boarding boats."
 - id: 17397
-  examine: "Handy for boarding boats."
 - id: 17398
-  examine: "Handy for boarding boats."
 - id: 17399
-  examine: "Handy for boarding boats."
 - id: 17400
-  examine: "Handy for boarding boats."
 - id: 17401
-  examine: "Handy for boarding boats."
 - id: 17402
-  examine: "Handy for boarding boats."
 - id: 17403
-  examine: "Handy for boarding boats."
 - id: 17404
-  examine: "Handy for boarding boats."
 - id: 17405
-  examine: "Handy for boarding boats."
 - id: 17406
-  examine: "Handy for boarding boats."
 - id: 17407
-  examine: "Handy for boarding boats."
 - id: 17408
-  examine: "Handy for boarding boats."
 - id: 17409
-  examine: "Handy for boarding boats."
 - id: 17410
 - id: 17411
 - id: 17412
@@ -27691,60 +26763,37 @@
 - id: 17421
 - id: 17422
 - id: 17423
-  examine: "This drain leads from the sink to the sewers below."
 - id: 17424
-  examine: "This drain leads from the sink to the sewers below."
 - id: 17425
-  examine: "A very impressive sword rests behind the glass."
 - id: 17426
-  examine: "A very impressive sword rests behind the glass."
 - id: 17427
-  examine: "This case used to contain Silverlight."
 - id: 17428
   depleted: 17665
 - id: 17429
-  examine: "An old rusty key in a puddle of mud."
 - id: 17430
-  examine: "A puddle of mud. Ooh, how exciting."
 - id: 17431
 - id: 17432
   depleted: 17675
-  examine: "hmm, seems this leads from the drain in the kitchen."
 - id: 17433
-  examine: "A wardrobe brought forth by magic."
 - id: 17434
-  examine: "A wardrobe brought forth by magic."
 - id: 17435
-  examine: "An evil presence seems to rest in the stone table."
 - id: 17436
-  examine: "An evil presence seems to rest in the stone table."
 - id: 17437
   depleted: 17698
-  examine: "An evil presence seems to rest in the stone table."
 - id: 17438
-  examine: "The stone table has been shattered."
 - id: 17439
-  examine: "What could this ornate stone circle be for?"
 - id: 17440
-  examine: "What could this ornate stone circle be for?"
 - id: 17441
-  examine: "What could this ornate stone circle be for?"
 - id: 17442
-  examine: "What could this ornate stone circle be for?"
 - id: 17443
-  examine: "What could this ornate stone circle be for?"
 - id: 17444
-  examine: "What could this ornate stone circle be for?"
 - id: 17445
-  examine: "What could this ornate stone circle be for?"
 - id: 17446
 - id: 17447
 - id: 17448
 - id: 17449
 - id: 17450
-  examine: "Another beast on the extinct creature list."
 - id: 17451
-  examine: "A civilized game of chess."
 - id: 17452
 - id: 17453
 - id: 17454
@@ -27774,28 +26823,17 @@
 - id: 17475
 - id: 17476
 - id: 17477
-  examine: "Probably looked better mounted on the dragon's neck."
 - id: 17478
-  examine: "Probably looked better mounted on the dragon's neck."
 - id: 17479
-  examine: "Not what I would pick as wall decoration."
 - id: 17480
-  examine: "Not what I would pick as wall decoration."
 - id: 17481
-  examine: "Not what I would pick as wall decoration."
 - id: 17482
-  examine: "Not what I would pick as wall decoration."
 - id: 17483
-  examine: "Not what I would pick as wall decoration."
 - id: 17484
-  examine: "Not what I would pick as wall decoration."
 - id: 17485
-  examine: "Not what I would pick as wall decoration."
 - id: 17486
-  examine: "Not what I would pick as wall decoration."
 - id: 17487
 - id: 17488
-  examine: "No way am I going in there!"
 - id: 17489
 - id: 17490
 - id: 17491
@@ -27806,13 +26844,10 @@
 - id: 17496
   depleted: 17765
 - id: 17497
-  examine: "Blocking the path."
 - id: 17498
   depleted: 17779
-  examine: "Blocking the path."
 - id: 17499
 - id: 17500
-  examine: "Blocking the path."
 - id: 17501
 - id: 17502
 - id: 17503
@@ -27823,13 +26858,9 @@
 - id: 17507
   depleted: 17847
 - id: 17508
-  examine: "Pipes pumping sludge from the castle."
 - id: 17509
-  examine: "Pipes pumping sludge from the castle."
 - id: 17510
-  examine: "Pipes pumping sludge from the castle."
 - id: 17511
-  examine: "Pipes pumping sludge from the castle."
 - id: 17512
   depleted: 17848
 - id: 17513
@@ -27869,45 +26900,26 @@
 - id: 17543
 - id: 17544
 - id: 17545
-  examine: "Poor-looking table."
 - id: 17546
-  examine: "Poor-looking table with a plate on it."
 - id: 17547
-  examine: "To sit on."
 - id: 17548
-  examine: "To sit on."
 - id: 17549
-  examine: "To sit on."
 - id: 17550
-  examine: "To sit on."
 - id: 17551
-  examine: "To sit on."
 - id: 17552
-  examine: "Tipped over."
 - id: 17553
-  examine: "To sleep in."
 - id: 17554
-  examine: "To sleep in."
 - id: 17555
-  examine: "To sleep in."
 - id: 17556
-  examine: "Fill it with things."
 - id: 17557
   depleted: 17853
-  examine: "Fill it with things."
 - id: 17558
-  examine: "Fill it with things."
 - id: 17559
-  examine: "Has got some stuff in it."
 - id: 17560
-  examine: "Fill it with things."
 - id: 17561
-  examine: "Fill them with things."
 - id: 17562
-  examine: "Fill them with things."
 - id: 17563
   depleted: 17854
-  examine: "A safe place to jump down to."
 - id: 17564
 - id: 17565
 - id: 17566
@@ -27945,9 +26957,7 @@
 - id: 17598
 - id: 17599
 - id: 17600
-  examine: "A crude-looking door fashioned from random bits of wood."
 - id: 17601
-  examine: "Blocking the path."
 - id: 17602
 - id: 17603
 - id: 17604
@@ -27974,9 +26984,7 @@
 - id: 17625
   depleted: 17855
 - id: 17626
-  examine: "The remains of the wall."
 - id: 17627
-  examine: "Some clothes hang here to dry."
 - id: 17628
 - id: 17629
 - id: 17630
@@ -27985,101 +26993,59 @@
 - id: 17633
 - id: 17634
 - id: 17635
-  examine: "Old scaffolding."
 - id: 17636
-  examine: "Old scaffolding."
 - id: 17637
-  examine: "A ladder leading back down to the mines."
 - id: 17638
 - id: 17639
 - id: 17640
-  examine: "An old fireplace."
 - id: 17641
-  examine: "An old fireplace."
 - id: 17642
-  examine: "An old fireplace."
 - id: 17643
-  examine: "An old fireplace."
 - id: 17644
-  examine: "A barricade blocking the path."
 - id: 17645
-  examine: "A barricade blocking the path."
 - id: 17646
-  examine: "A barricade blocking the path."
 - id: 17647
-  examine: "A sickle logo - showing me the way?"
 - id: 17648
-  examine: "This must be important."
 - id: 17649
 - id: 17650
 - id: 17651
 - id: 17652
 - id: 17653
 - id: 17654
-  examine: "A wooden barrel for storage."
 - id: 17655
-  examine: "For storage."
 - id: 17656
-  examine: "Some wooden crates."
 - id: 17657
-  examine: "Some wooden boxes."
 - id: 17658
-  examine: "A wooden crate."
 - id: 17659
-  examine: "These stairs don't seem broken. Maybe I should use them."
 - id: 17660
-  examine: "These stairs don't seem broken. Maybe I should use them."
 - id: 17661
-  examine: "A table."
 - id: 17662
-  examine: "It's a small table."
 - id: 17663
-  examine: "Good for sitting on."
 - id: 17664
 - id: 17665
 - id: 17666
-  examine: "A table made from crates and a section of ghetto wall."
 - id: 17667
-  examine: "A wooden stool."
 - id: 17668
-  examine: "A bunk bed."
 - id: 17669
-  examine: "A bunk bed."
 - id: 17670
-  examine: "A blackboard."
 - id: 17671
-  examine: "A locker."
 - id: 17672
-  examine: "A locker."
 - id: 17673
 - id: 17674
 - id: 17675
 - id: 17676
-  examine: "A wall made from stone."
 - id: 17677
-  examine: "Blocking the path."
 - id: 17678
-  examine: "Blocking the path."
 - id: 17679
-  examine: "I could jump on this!"
 - id: 17680
-  examine: "A wall made from stone."
 - id: 17681
-  examine: "Blocking the path."
 - id: 17682
-  examine: "Blocking the path."
 - id: 17683
-  examine: "Blocking the path."
 - id: 17684
-  examine: "Blocking the path."
 - id: 17685
-  examine: "Blocking the path."
 - id: 17686
-  examine: "Blocking the path."
 - id: 17687
-  examine: "Blocking the path."
 - id: 17688
-  examine: "Blocking the path."
 - id: 17689
 - id: 17690
 - id: 17691
@@ -28090,12 +27056,10 @@
 - id: 17696
 - id: 17697
 - id: 17698
-  examine: "A broken wall."
 - id: 17699
 - id: 17700
 - id: 17701
 - id: 17702
-  examine: "Floor."
 - id: 17703
 - id: 17704
 - id: 17705
@@ -28103,13 +27067,9 @@
 - id: 17707
 - id: 17708
 - id: 17709
-  examine: "Floor."
 - id: 17710
-  examine: "Floor."
 - id: 17711
-  examine: "Floor."
 - id: 17712
-  examine: "Floor."
 - id: 17713
 - id: 17714
 - id: 17715
@@ -28155,31 +27115,18 @@
 - id: 17755
 - id: 17756
 - id: 17757
-  examine: "Once an elegant chair."
 - id: 17758
-  examine: "A well-used chair."
 - id: 17759
-  examine: "An old chair."
 - id: 17760
-  examine: "An old chair."
 - id: 17761
-  examine: "An old chair."
 - id: 17762
-  examine: "An old table."
 - id: 17763
-  examine: "A bookcase filled with books."
 - id: 17764
-  examine: "Looks like an old church bench."
 - id: 17765
-  examine: "A very old grandfather clock."
 - id: 17766
-  examine: "A dusty-looking fireplace."
 - id: 17767
-  examine: "A dusty-looking fireplace."
 - id: 17768
-  examine: "A dusty-looking fireplace."
 - id: 17769
-  examine: "A large vase."
 - id: 17770
 - id: 17771
 - id: 17772
@@ -28193,25 +27140,15 @@
 - id: 17780
 - id: 17781
 - id: 17782
-  examine: "Fence end."
 - id: 17783
-  examine: "Fence mid."
 - id: 17784
-  examine: "Fence corner."
 - id: 17785
-  examine: "Fence t-piece."
 - id: 17786
-  examine: "A part of the fence."
 - id: 17787
-  examine: "The fence looks old."
 - id: 17788
-  examine: "The fence looks very old."
 - id: 17789
-  examine: "Looks like bits of the old fence."
 - id: 17790
-  examine: "The fence looks old and is crumbling."
 - id: 17791
-  examine: "The fence looks old and is crumbling."
 - id: 17792
 - id: 17793
 - id: 17794
@@ -28249,7 +27186,6 @@
 - id: 17826
 - id: 17827
 - id: 17828
-  examine: "A rocky wall."
 - id: 17829
 - id: 17830
 - id: 17831
@@ -28268,27 +27204,16 @@
 - id: 17844
 - id: 17845
 - id: 17846
-  examine: "Should I go down there?"
 - id: 17847
-  examine: "Should I go down there?"
 - id: 17848
-  examine: "Should I go down there?"
 - id: 17849
-  examine: "Should I go down there?"
 - id: 17850
-  examine: "Should I go down there?"
 - id: 17851
-  examine: "Should I go down there?"
 - id: 17852
-  examine: "Should I go down there?"
 - id: 17853
-  examine: "Should I go down there?"
 - id: 17854
-  examine: "Should I go down there?"
 - id: 17855
-  examine: "Should I go down there?"
 - id: 17856
-  examine: "Should I go down there?"
 - id: 17857
 - id: 17858
 - id: 17859
@@ -28314,69 +27239,40 @@
 - id: 17877
 - id: 17878
 - id: 17879
-  examine: "Should I go down there?"
 - id: 17880
-  examine: "Should I go down there?"
 - id: 17881
-  examine: "Should I go down there?"
 - id: 17882
-  examine: "Should I go down there?"
 - id: 17883
-  examine: "Should I go down there?"
 - id: 17884
-  examine: "Should I go down there?"
 - id: 17885
-  examine: "Should I go down there?"
 - id: 17886
-  examine: "Should I go down there?"
 - id: 17887
-  examine: "Should I go down there?"
 - id: 17888
-  examine: "Should I go down there?"
 - id: 17889
-  examine: "Should I go down there?"
 - id: 17890
-  examine: "A dusty-looking bookshelf."
 - id: 17891
-  examine: "A dusty-looking bookshelf."
 - id: 17892
 - id: 17893
-  examine: "An old lab table."
 - id: 17894
-  examine: "An old lab table."
 - id: 17895
-  examine: "An old lab table."
 - id: 17896
-  examine: "An old lab table."
 - id: 17897
-  examine: "A broken lab tube."
 - id: 17898
-  examine: "A lab tube."
 - id: 17899
-  examine: "An old experiment booth."
 - id: 17900
 - id: 17901
 - id: 17902
 - id: 17903
   depleted: 17872
 - id: 17904
-  examine: "A wooden barrel for storage."
 - id: 17905
-  examine: "For storage."
 - id: 17906
-  examine: "Some wooden crates."
 - id: 17907
-  examine: "Some wooden boxes."
 - id: 17908
-  examine: "A wooden crate."
 - id: 17909
-  examine: "A wooden stool."
 - id: 17910
-  examine: "A wooden stool."
 - id: 17911
-  examine: "I wonder what awaits me on the other side?"
 - id: 17912
-  examine: "I wonder what awaits me on the other side?"
 - id: 17913
 - id: 17914
 - id: 17915
@@ -28402,24 +27298,15 @@
   depleted: 17970
 - id: 17933
 - id: 17934
-  examine: "Blocking the path."
 - id: 17935
-  examine: "Blocking the path."
 - id: 17936
-  examine: "Blocking the path."
 - id: 17937
-  examine: "Blocking the path."
 - id: 17938
-  examine: "Blocking the path."
 - id: 17939
-  examine: "Blocking the path."
 - id: 17940
-  examine: "Blocking the path."
 - id: 17941
-  examine: "Looks like a fake wall."
 - id: 17942
 - id: 17943
-  examine: "Looks like a fake wall."
 - id: 17944
 - id: 17945
 - id: 17946
@@ -28430,133 +27317,74 @@
 - id: 17951
 - id: 17952
 - id: 17953
-  examine: "It's not a schooner, it's a sailboat."
 - id: 17954
-  examine: "It's not a schooner, it's a sailboat."
 - id: 17955
-  examine: "It's not a schooner, it's a sailboat."
 - id: 17956
-  examine: "This is too damaged for the boat to be launched."
 - id: 17957
-  examine: "This has been repaired so the boat can be launched."
 - id: 17958
-  examine: "Rocks."
 - id: 17959
-  examine: "Rocks."
 - id: 17960
-  examine: "Rocks."
 - id: 17961
-  examine: "Boat."
 - id: 17962
   depleted: 17965
-  examine: "Look like normal rocks with a faint glow."
 - id: 17963
-  examine: "Look like normal rocks with a faint glow."
 - id: 17964
-  examine: "Look like normal rocks with a faint glow."
 - id: 17965
-  examine: "This rock face looks empty."
 - id: 17966
-  examine: "Daeyalt ore is placed in here."
 - id: 17967
-  examine: "Daeyalt ore is placed in here."
 - id: 17968
-  examine: "Daeyalt ore is placed in here."
 - id: 17969
-  examine: "Daeyalt ore is placed in here."
 - id: 17970
-  examine: "Rocks."
 - id: 17971
-  examine: "Rocks."
 - id: 17972
-  examine: "Rocks."
 - id: 17973
-  examine: "Blocking the path."
 - id: 17974
-  examine: "Where does this lead?"
 - id: 17975
-  examine: "Where does this lead?"
 - id: 17976
-  examine: "These stairs don't seem broken. Maybe I should use them."
 - id: 17977
-  examine: "These stairs look pretty wrecked. Perhaps one day they can be fixed..."
 - id: 17978
-  examine: "These stairs don't seem broken. Maybe I should use them."
 - id: 17979
-  examine: "These stairs look pretty wrecked. Perhaps one day they can be fixed..."
 - id: 17980
-  examine: "This wall doesn't look too solid. Maybe I should look closer."
 - id: 17981
 - id: 17982
   depleted: 17972
-  examine: "A silver sickle stuck to the wall."
 - id: 17983
-  examine: "A tattered-looking rug."
 - id: 17984
-  examine: "I wonder what's under it?"
 - id: 17985
-  examine: "I wonder what's down there?"
 - id: 17986
-  examine: "Where does this lead?"
 - id: 17987
-  examine: "A box full of papyrus."
 - id: 17988
-  examine: "There is some disturbed ground under the bush."
 - id: 17989
-  examine: "There seems to be a leg sticking out from this bush."
 - id: 17990
-  examine: "A bush."
 - id: 17991
-  examine: "Two small bushes."
 - id: 17992
 - id: 17993
 - id: 17994
 - id: 17995
-  examine: "Where does this lead?"
 - id: 17996
   depleted: 17997
-  examine: "Where does this lead?"
 - id: 17997
-  examine: "Where does this lead?"
 - id: 17998
-  examine: "Where does this lead?"
 - id: 17999
-  examine: "Where does this lead?"
 - id: 18000
-  examine: "Where does this lead?"
 - id: 18001
-  examine: "Where does this lead?"
 - id: 18002
-  examine: "Where does this lead?"
 - id: 18003
 - id: 18004
 - id: 18005
 - id: 18006
-  examine: "A wooden barrel, curiously full of bones which you think came from fish."
 - id: 18007
-  examine: "A corner table."
 - id: 18008
-  examine: "A cutting table."
 - id: 18009
-  examine: "Once a holder of fish."
 - id: 18010
-  examine: "This display has old water and fish scales in it. It stinks."
 - id: 18011
-  examine: "An empty wooden barrel."
 - id: 18012
-  examine: "A broken wooden barrel. It smells of fish."
 - id: 18013
-  examine: "Some dust covered crates."
 - id: 18014
-  examine: "A small table with a broken till."
 - id: 18015
-  examine: "A wooden barrel for storage."
 - id: 18016
-  examine: "A dusty pub counter; it's been scavenged."
 - id: 18017
-  examine: "A dusty pub counter; not unlike countless others."
 - id: 18018
-  examine: "A broken, dusty pub counter."
 - id: 18019
 - id: 18020
 - id: 18021
@@ -28567,183 +27395,96 @@
 - id: 18026
 - id: 18027
 - id: 18028
-  examine: "A skeleton."
 - id: 18029
-  examine: "A skeleton."
 - id: 18030
-  examine: "A broken odd-looking machine."
 - id: 18031
-  examine: "Blocking the path."
 - id: 18032
-  examine: "Blocking the path."
 - id: 18033
-  examine: "Loose, squeaky floorboards that look moveable."
 - id: 18034
-  examine: "A fallen floorboard that can be used like a ladder."
 - id: 18035
-  examine: "Loose, squeaky floorboards that look moveable."
 - id: 18036
-  examine: "A fallen floorboard that can be used like a ladder."
 - id: 18037
-  examine: "A pile of rubble."
 - id: 18038
-  examine: "A pile of rubble."
 - id: 18039
-  examine: "An empty fireplace."
 - id: 18040
-  examine: "This old tapestry has an interesting design on it."
 - id: 18041
-  examine: "This old tapestry has been slashed."
 - id: 18042
-  examine: "A painting."
 - id: 18043
-  examine: "A painting."
 - id: 18044
-  examine: "A painting."
 - id: 18045
-  examine: "A statue of a female vampyre; her arms are up in the air."
 - id: 18046
-  examine: "A statue of a female vampyre; she holds a large ornate key."
 - id: 18047
-  examine: "A solid-looking wooden door."
 - id: 18048
-  examine: "A solid-looking wooden door."
 - id: 18049
-  examine: "I can climb down these stairs."
 - id: 18050
-  examine: "I can climb up these stairs."
 - id: 18051
-  examine: "A nice sturdy looking table."
 - id: 18052
-  examine: "Was once a noble case for housing runes."
 - id: 18053
-  examine: "Rubble from the destroyed wall."
 - id: 18054
-  examine: "A barricade blocking the path."
 - id: 18055
-  examine: "A barricade blocking the path."
 - id: 18056
-  examine: "Looks like normal rocks."
 - id: 18057
-  examine: "This door is made out of very poor looking planks of wood."
 - id: 18058
-  examine: "This door is made out of very poor looking planks of wood."
 - id: 18059
-  examine: "A poor-looking table."
 - id: 18060
-  examine: "A trapdoor hidden by a table."
 - id: 18061
-  examine: "An underground tunnel."
 - id: 18062
-  examine: "Poor-looking table."
 - id: 18063
-  examine: "A trapdoor hidden by a table."
 - id: 18064
-  examine: "A table attached to a trapdoor."
 - id: 18065
-  examine: "A selection of very basic cooking utensils."
 - id: 18066
-  examine: "A bit crumbly; has a ladder top attached."
 - id: 18067
-  examine: "Blocking the path."
 - id: 18068
-  examine: "The top of this ladder seems to be missing."
 - id: 18069
-  examine: "The ladder seems to fit together well."
 - id: 18070
-  examine: "Some old, rickety floorboards."
 - id: 18071
-  examine: "Some old, rickety floorboards."
 - id: 18072
-  examine: "Some old, rickety floorboards."
 - id: 18073
-  examine: "Some old, rickety floorboards."
 - id: 18074
-  examine: "This doesn't look too sturdy."
 - id: 18075
-  examine: "A door that is falling down."
 - id: 18076
-  examine: "Some old, rickety floorboards."
 - id: 18077
-  examine: "Some old, rickety floorboards."
 - id: 18078
-  examine: "This gap seems big enough for me to go under."
 - id: 18079
-  examine: "This doesn't look too sturdy."
 - id: 18080
-  examine: "A door that is falling down."
 - id: 18081
-  examine: "Some old, rickety floorboards."
 - id: 18082
-  examine: "Some old, rickety floorboards."
 - id: 18083
 - id: 18084
 - id: 18085
-  examine: "An underground tunnel."
 - id: 18086
-  examine: "Plank shelves."
 - id: 18087
-  examine: "Plank shelves."
 - id: 18088
-  examine: "This gap seems big enough for me to go under."
 - id: 18089
-  examine: "Some old, rickety floorboards."
 - id: 18090
-  examine: "Some old, rickety floorboards."
 - id: 18091
-  examine: "A door made from wooden planks."
 - id: 18092
-  examine: "A door made from wooden planks."
 - id: 18093
-  examine: "Some old, rickety floorboards."
 - id: 18094
-  examine: "Some old, rickety floorboards."
 - id: 18095
-  examine: "Plank shelves."
 - id: 18096
-  examine: "Plank shelves."
 - id: 18097
-  examine: "Some old, rickety floorboards."
 - id: 18098
-  examine: "Some old, rickety floorboards."
 - id: 18099
-  examine: "For hanging clothes on."
 - id: 18100
-  examine: "For hanging clothes on."
 - id: 18101
-  examine: "This doesn't look too sturdy."
 - id: 18102
-  examine: "A door that is falling down."
 - id: 18103
-  examine: "Some old, rickety floorboards."
 - id: 18104
-  examine: "Some old, rickety floorboards."
 - id: 18105
-  examine: "Plank shelves."
 - id: 18106
-  examine: "Plank shelves."
 - id: 18107
-  examine: "Plank shelves."
 - id: 18108
-  examine: "Plank shelves."
 - id: 18109
-  examine: "Some old, rickety floorboards."
 - id: 18110
-  examine: "Some old, rickety floorboards."
 - id: 18111
-  examine: "Some old, rickety floorboards."
 - id: 18112
-  examine: "Some old, rickety floorboards."
 - id: 18113
-  examine: "Some old, rickety floorboards."
 - id: 18114
-  examine: "Some old, rickety floorboards."
 - id: 18115
 - id: 18116
 - id: 18117
-  examine: "Some old, rickety floorboards."
 - id: 18118
-  examine: "Some old, rickety floorboards."
 - id: 18119
 - id: 18120
 - id: 18121
@@ -28763,7 +27504,6 @@
 - id: 18135
 - id: 18136
 - id: 18137
-  examine: "A very strange-looking tree."
 - id: 18138
 - id: 18139
 - id: 18140
@@ -28771,9 +27511,7 @@
 - id: 18142
 - id: 18143
 - id: 18144
-  examine: "A silver sickle stuck to the wall."
 - id: 18145
-  examine: "A silver sickle stuck to the wall."
 - id: 18146
 - id: 18147
 - id: 18148
@@ -28788,7 +27526,6 @@
 - id: 18157
 - id: 18158
 - id: 18159
-  examine: "A passageway leading somewhere."
 - id: 18160
 - id: 18161
 - id: 18162
@@ -28799,48 +27536,30 @@
 - id: 18167
   depleted: 18051
 - id: 18168
-  examine: "Keeps the wind out."
 - id: 18169
 - id: 18170
-  examine: "Doesn't look like it works."
 - id: 18171
-  examine: "Rough but adequate."
 - id: 18172
-  examine: "A relaxing hanging bed."
 - id: 18173
 - id: 18174
 - id: 18175
 - id: 18176
-  examine: "A nice, sturdy looking table."
 - id: 18177
-  examine: "An open display case."
 - id: 18178
-  examine: "A display case."
 - id: 18179
-  examine: "A broken lobster trap."
 - id: 18180
 - id: 18181
 - id: 18182
-  examine: "An ale barrel."
 - id: 18183
-  examine: "A bucket for night soil. I wouldn't go near it."
 - id: 18184
-  examine: "The nameplate reads J.O'Niall."
 - id: 18185
-  examine: "Looks kind of like a man made of metal."
 - id: 18186
-  examine: "An empty rowboat."
 - id: 18187
-  examine: "A rowboat with shipped oars."
 - id: 18188
 - id: 18189
-  examine: "A heavily damaged rowboat."
 - id: 18190
-  examine: "A heavily damaged rowboat."
 - id: 18191
-  examine: "A heavily damaged rowboat."
 - id: 18192
-  examine: "A heavily damaged rowboat."
 - id: 18193
 - id: 18194
 - id: 18195
@@ -28850,22 +27569,16 @@
 - id: 18199
 - id: 18200
 - id: 18201
-  examine: "A barrel full of rain water."
 - id: 18202
-  examine: "Some fishy smelling crates."
 - id: 18203
-  examine: "A couple of wooden crates."
 - id: 18204
-  examine: "A fishy smelling crate."
 - id: 18205
 - id: 18206
 - id: 18207
 - id: 18208
-  examine: "A wooden barrel for storage."
 - id: 18209
 - id: 18210
 - id: 18211
-  examine: "An old life buoy and a tattered rope."
 - id: 18212
 - id: 18213
 - id: 18214
@@ -28878,51 +27591,28 @@
 - id: 18221
 - id: 18222
 - id: 18223
-  examine: "Stops bits of building falling on me."
 - id: 18224
-  examine: "Looks expensive."
 - id: 18225
-  examine: "A tree in autumn."
 - id: 18226
-  examine: "A sepia painting of an idyllic valley."
 - id: 18227
-  examine: "I think it represents the turmoil of the artist's tortured soul."
 - id: 18228
-  examine: "Stuffed sailfish."
 - id: 18229
-  examine: "Why do they never mount the tail end? Why always the head?"
 - id: 18230
-  examine: "Why do they never mount the tail end? Why always the head?"
 - id: 18231
-  examine: "A large costly vase."
 - id: 18232
-  examine: "A small vase."
 - id: 18233
-  examine: "A fancy vase set."
 - id: 18234
-  examine: "Allows access to the level above."
 - id: 18235
-  examine: "Allows access to the level below."
 - id: 18236
-  examine: "Allows access to the level above."
 - id: 18237
-  examine: "Allows access to the level below."
 - id: 18238
-  examine: "A decorative teak bench."
 - id: 18239
-  examine: "A selection of Mayor Hobb's books."
 - id: 18240
-  examine: "For keeping things in."
 - id: 18241
-  examine: "A clothing storage device."
 - id: 18242
-  examine: "This looks old, but well used."
 - id: 18243
-  examine: "An old anchor."
 - id: 18244
-  examine: "Looks snug."
 - id: 18245
-  examine: "A holy book of Saradomin."
 - id: 18246
 - id: 18247
 - id: 18248
@@ -28936,16 +27626,11 @@
 - id: 18256
 - id: 18257
 - id: 18258
-  examine: "An altar with a symbol of Saradomin."
 - id: 18259
 - id: 18260
-  examine: "Here is the church and here is the steeple; open the door and it's empty."
 - id: 18261
-  examine: "A ruined old pillar."
 - id: 18262
-  examine: "A ruined old pillar."
 - id: 18263
-  examine: "An old Temple Knight statue."
 - id: 18264
 - id: 18265
 - id: 18266
@@ -28953,7 +27638,6 @@
 - id: 18268
 - id: 18269
 - id: 18270
-  examine: "It doesn't smell too good."
 - id: 18271
 - id: 18272
 - id: 18273
@@ -28991,15 +27675,10 @@
 - id: 18305
 - id: 18306
 - id: 18307
-  examine: "A passageway leading somewhere."
 - id: 18308
-  examine: "A passageway leading up."
 - id: 18309
-  examine: "A passageway leading up."
 - id: 18310
-  examine: "A passageway leading down."
 - id: 18311
-  examine: "A passageway leading down."
 - id: 18312
 - id: 18313
 - id: 18314
@@ -29013,13 +27692,9 @@
 - id: 18322
 - id: 18323
 - id: 18324
-  examine: "Going up?"
 - id: 18325
-  examine: "Going down?"
 - id: 18326
-  examine: "A wooden crane with a lever and flywheel."
 - id: 18327
-  examine: "A wooden crane with a lever and flywheel."
 - id: 18328
 - id: 18329
   depleted: 18330
@@ -29037,7 +27712,6 @@
 - id: 18341
 - id: 18342
 - id: 18343
-  examine: "Queen's lair's wall corner."
 - id: 18344
 - id: 18345
 - id: 18346
@@ -29046,22 +27720,16 @@
 - id: 18349
 - id: 18350
 - id: 18351
-  examine: "Nasty looking device."
 - id: 18352
-  examine: "Might be worth searching."
 - id: 18353
-  examine: "Might be worth searching."
 - id: 18354
-  examine: "Exit to the ruin."
 - id: 18355
 - id: 18356
 - id: 18357
 - id: 18358
   depleted: 18386
 - id: 18359
-  examine: "An odd looking section of wall."
 - id: 18360
-  examine: "I wonder where this leads?"
 - id: 18361
 - id: 18362
 - id: 18363
@@ -29082,9 +27750,7 @@
 - id: 18378
 - id: 18379
 - id: 18380
-  examine: "Wall with a hole."
 - id: 18381
-  examine: "Wall with a poor repair job."
 - id: 18382
 - id: 18383
 - id: 18384
@@ -29103,15 +27769,11 @@
 - id: 18397
 - id: 18398
 - id: 18399
-  examine: "Barrel of fish bones."
 - id: 18400
-  examine: "Ice container."
 - id: 18401
 - id: 18402
 - id: 18403
-  examine: "Kennith's favourite ball."
 - id: 18404
-  examine: "Message in a bottle."
 - id: 18405
 - id: 18406
 - id: 18407
@@ -29119,17 +27781,11 @@
 - id: 18409
 - id: 18410
 - id: 18411
-  examine: "This bit of fence has fallen down."
 - id: 18412
-  examine: "Returns you to relative safety."
 - id: 18413
-  examine: "They give off an aura of awesome power."
 - id: 18414
-  examine: "They give off an aura of awesome power."
 - id: 18415
-  examine: "They give off an aura of awesome power."
 - id: 18416
-  examine: "A stinky hole."
 - id: 18417
 - id: 18418
 - id: 18419
@@ -29148,7 +27804,6 @@
 - id: 18432
 - id: 18433
 - id: 18434
-  examine: "Exploding goo."
 - id: 18435
 - id: 18436
 - id: 18437
@@ -29161,37 +27816,23 @@
 - id: 18444
 - id: 18445
 - id: 18446
-  examine: "A rotten barrel."
 - id: 18447
-  examine: "A wrecked longboat."
 - id: 18448
-  examine: "A wrecked longboat."
 - id: 18449
-  examine: "A wrecked longboat."
 - id: 18450
-  examine: "A wrecked longboat."
 - id: 18451
-  examine: "A wrecked longboat."
 - id: 18452
-  examine: "A spooky, rotting, longboat wreck."
 - id: 18453
 - id: 18454
 - id: 18455
 - id: 18456
 - id: 18457
-  examine: "Looks snug."
 - id: 18458
-  examine: "Kennith's bed."
 - id: 18459
-  examine: "Broken floats."
 - id: 18460
-  examine: "A boat skeleton."
 - id: 18461
-  examine: "Shipwreck crow nest."
 - id: 18462
-  examine: "Floating crate."
 - id: 18463
-  examine: "Floating crate."
 - id: 18464
 - id: 18465
 - id: 18466
@@ -29211,7 +27852,6 @@
 - id: 18480
 - id: 18481
 - id: 18482
-  examine: "A large fish."
 - id: 18483
 - id: 18484
 - id: 18485
@@ -29220,18 +27860,12 @@
 - id: 18488
 - id: 18489
   depleted: 18472
-  examine: "The door is closed."
 - id: 18490
-  examine: "The door is open."
 - id: 18491
-  examine: "The bank teller will serve you from here."
 - id: 18492
-  examine: "Closed for business."
 - id: 18493
-  examine: "This tells you which way is which."
 - id: 18494
 - id: 18495
-  examine: "A good source of books!"
 - id: 18496
 - id: 18497
 - id: 18498
@@ -29239,54 +27873,35 @@
 - id: 18500
   depleted: 18499
 - id: 18501
-  examine: "It's used for loading and unloading fishing boats."
 - id: 18502
 - id: 18503
 - id: 18504
 - id: 18505
-  examine: "A strange crack cuts into the wall."
 - id: 18506
-  examine: "A wooden crate for storage."
 - id: 18507
-  examine: "A wooden crate for storage."
 - id: 18508
-  examine: "A pile of crates for storage."
 - id: 18509
-  examine: "Flow gate controls."
 - id: 18510
-  examine: "Flow gate controls."
 - id: 18511
-  examine: "It spins."
 - id: 18512
-  examine: "It spins."
 - id: 18513
 - id: 18514
 - id: 18515
-  examine: "Big bellows."
 - id: 18516
-  examine: "Big bellows."
 - id: 18517
 - id: 18518
 - id: 18519
-  examine: "A small trough full of lava."
 - id: 18520
-  examine: "A small trough full of lava."
 - id: 18521
-  examine: "A small trough full of lava."
 - id: 18522
-  examine: "A small trough full of lava."
 - id: 18523
-  examine: "A small trough full of lava."
 - id: 18524
 - id: 18525
-  examine: "A furnace with an air blast pipe."
 - id: 18526
-  examine: "A furnace with an air blast pipe."
 - id: 18527
 - id: 18528
 - id: 18529
 - id: 18530
-  examine: "Water powered machinery."
 - id: 18531
 - id: 18532
 - id: 18533
@@ -29345,7 +27960,6 @@
 - id: 18585
 - id: 18586
 - id: 18587
-  examine: "Water powered machinery."
 - id: 18588
 - id: 18589
 - id: 18590
@@ -29353,17 +27967,11 @@
 - id: 18592
 - id: 18593
 - id: 18594
-  examine: "Unpowered machinery."
 - id: 18595
-  examine: "It's a closed hatch."
 - id: 18596
-  examine: "It's an open hatch."
 - id: 18597
-  examine: "I can climb down here."
 - id: 18598
-  examine: "I can climb these."
 - id: 18599
-  examine: "I can climb these."
 - id: 18600
 - id: 18601
 - id: 18602
@@ -29375,203 +27983,108 @@
 - id: 18608
 - id: 18609
 - id: 18610
-  examine: "Stairs leading up to a gantry."
 - id: 18611
-  examine: "Stairs leading down from a gantry."
 - id: 18612
-  examine: "A wooden crate for storage."
 - id: 18613
-  examine: "A wooden crate for storage."
 - id: 18614
-  examine: "A pile of crates for storage."
 - id: 18615
-  examine: "A pile of crates for storage."
 - id: 18616
-  examine: "A wooden crate for storage."
 - id: 18617
-  examine: "A wooden crate for storage."
 - id: 18618
-  examine: "A wooden crate for storage."
 - id: 18619
-  examine: "A wooden crate for storage."
 - id: 18620
-  examine: "I wonder what it does."
 - id: 18621
-  examine: "I wonder what it does."
 - id: 18622
-  examine: "I wonder what it does."
 - id: 18623
-  examine: "An empty claw."
 - id: 18624
-  examine: "An empty claw."
 - id: 18625
-  examine: "An empty claw."
 - id: 18626
-  examine: "An empty claw."
 - id: 18627
-  examine: "A heavy claw."
 - id: 18628
-  examine: "A heavy claw."
 - id: 18629
-  examine: "A heavy claw."
 - id: 18630
-  examine: "A heavy claw."
 - id: 18631
-  examine: "A heavy claw."
 - id: 18632
-  examine: "A heavy claw."
 - id: 18633
-  examine: "A heavy claw."
 - id: 18634
-  examine: "A heavy claw."
 - id: 18635
-  examine: "A broken claw."
 - id: 18636
-  examine: "A broken claw."
 - id: 18637
-  examine: "A broken claw."
 - id: 18638
-  examine: "A broken claw."
 - id: 18639
 - id: 18640
-  examine: "I wonder what it does."
 - id: 18641
-  examine: "The inner workings for the press are in here."
 - id: 18642
-  examine: "A magical steam press."
 - id: 18643
-  examine: "A magical steam press."
 - id: 18644
-  examine: "A magical steam press."
 - id: 18645
-  examine: "A magical steam press."
 - id: 18646
-  examine: "A valve to start and stop the flow of water."
 - id: 18647
-  examine: "A valve to start and stop the flow of water."
 - id: 18648
-  examine: "I wonder what it does."
 - id: 18649
-  examine: "It turns..."
 - id: 18650
-  examine: "A section of piping with a hole in it."
 - id: 18651
-  examine: "A watertight door."
 - id: 18652
-  examine: "A watertight door."
 - id: 18653
-  examine: "A watertight door."
 - id: 18654
-  examine: "A watertight door."
 - id: 18655
-  examine: "A watertight door."
 - id: 18656
-  examine: "A watertight door."
 - id: 18657
-  examine: "A watertight door."
 - id: 18658
-  examine: "A watertight door."
 - id: 18659
-  examine: "A watertight door."
 - id: 18660
-  examine: "Looks wet."
 - id: 18661
-  examine: "Looks wet."
 - id: 18662
 - id: 18663
-  examine: "I wonder what it does."
 - id: 18664
-  examine: "A cog might fit on here."
 - id: 18665
-  examine: "A cog might fit on here."
 - id: 18666
-  examine: "A cog might fit on here."
 - id: 18667
-  examine: "It's small."
 - id: 18668
-  examine: "It's medium."
 - id: 18669
-  examine: "It's large."
 - id: 18670
-  examine: "It's small."
 - id: 18671
-  examine: "It's medium."
 - id: 18672
-  examine: "It's large."
 - id: 18673
-  examine: "It's small."
 - id: 18674
-  examine: "It's medium."
 - id: 18675
-  examine: "It's large."
 - id: 18676
   depleted: 18709
-  examine: "It's small."
 - id: 18677
-  examine: "It's medium."
 - id: 18678
-  examine: "It's large."
 - id: 18679
-  examine: "It's small."
 - id: 18680
-  examine: "It's medium."
 - id: 18681
-  examine: "It's large."
 - id: 18682
-  examine: "It's small."
 - id: 18683
-  examine: "It's medium."
 - id: 18684
-  examine: "It's large."
 - id: 18685
-  examine: "A magical wind tunnel."
 - id: 18686
-  examine: "A magical wind tunnel."
 - id: 18687
-  examine: "A magical wind tunnel."
 - id: 18688
 - id: 18689
 - id: 18690
-  examine: "A magical extractor."
 - id: 18691
-  examine: "A magical extractor."
 - id: 18692
-  examine: "A magical extractor."
 - id: 18693
-  examine: "A magical extractor."
 - id: 18694
-  examine: "A magical extractor."
 - id: 18695
-  examine: "A magical extractor."
 - id: 18696
-  examine: "A magical extractor."
 - id: 18697
 - id: 18698
-  examine: "Has a mind symbol on it."
 - id: 18699
-  examine: "Has a mind symbol on it."
 - id: 18700
-  examine: "Has a mind symbol on it."
 - id: 18701
-  examine: "Has a mind symbol on it."
 - id: 18702
-  examine: "Locked for now..."
 - id: 18703
-  examine: "Locked for now..."
 - id: 18704
-  examine: "Seems to connect this level to the one above!"
 - id: 18705
-  examine: "Seems to connect this level to the one above!"
 - id: 18706
-  examine: "Seems to connect this level to the one above!"
 - id: 18707
-  examine: "Seems to connect this level to the one above!"
 - id: 18708
 - id: 18709
 - id: 18710
-  examine: "I can climb these."
 - id: 18711
-  examine: "A crate full of schematics."
 - id: 18712
 - id: 18713
 - id: 18714
@@ -29587,7 +28100,6 @@
 - id: 18724
 - id: 18725
 - id: 18726
-  examine: "Piping with a blue line marked on it."
 - id: 18727
 - id: 18728
 - id: 18729
@@ -29608,15 +28120,11 @@
 - id: 18744
 - id: 18745
 - id: 18746
-  examine: "Is that a shopping trolley?"
 - id: 18747
-  examine: "Tracks for the carts to run over."
 - id: 18748
 - id: 18749
 - id: 18750
-  examine: "Tracks for the carts to run over."
 - id: 18751
-  examine: "Tracks for the carts to run over."
 - id: 18752
 - id: 18753
 - id: 18754
@@ -29624,196 +28132,104 @@
 - id: 18756
 - id: 18757
 - id: 18758
-  examine: "A magical wind tunnel."
 - id: 18759
-  examine: "A magical wind tunnel."
 - id: 18760
-  examine: "A magical wind tunnel."
 - id: 18761
 - id: 18762
 - id: 18763
 - id: 18764
 - id: 18765
 - id: 18766
-  examine: "A cape rack for you to hang your capes on."
 - id: 18767
-  examine: "A cape rack for you to hang your capes on."
 - id: 18768
-  examine: "A cape rack for you to hang your capes on."
 - id: 18769
-  examine: "A cape rack for you to hang your capes on."
 - id: 18770
-  examine: "A cape rack for you to hang your capes on."
 - id: 18771
-  examine: "A cape rack for you to hang your capes on."
 - id: 18772
-  examine: "A box for you to keep clothing."
 - id: 18773
-  examine: "A box for you to keep clothing."
 - id: 18774
-  examine: "A box for you to keep clothing."
 - id: 18775
-  examine: "A box for you to keep clothing."
 - id: 18776
-  examine: "A box for you to keep clothing."
 - id: 18777
-  examine: "A box for you to keep clothing."
 - id: 18778
-  examine: "A case for you to keep your armour in."
 - id: 18779
-  examine: "A case for you to keep your armour in."
 - id: 18780
-  examine: "A case for you to keep your armour in."
 - id: 18781
-  examine: "A case for you to keep your armour in."
 - id: 18782
-  examine: "A case for you to keep your armour in."
 - id: 18783
-  examine: "A case for you to keep your armour in."
 - id: 18784
-  examine: "Stores a variety of different clothing."
 - id: 18785
-  examine: "Stores a variety of different clothing."
 - id: 18786
-  examine: "Stores a variety of different clothing."
 - id: 18787
-  examine: "Stores a variety of different clothing."
 - id: 18788
-  examine: "Stores a variety of different clothing."
 - id: 18789
-  examine: "Stores a variety of different clothing."
 - id: 18790
-  examine: "Stores a variety of different clothing."
 - id: 18791
-  examine: "Stores a variety of different clothing."
 - id: 18792
-  examine: "Stores a variety of different clothing."
 - id: 18793
-  examine: "Stores a variety of different clothing."
 - id: 18794
-  examine: "Stores a variety of different clothing."
 - id: 18795
-  examine: "Stores a variety of different clothing."
 - id: 18796
-  examine: "Stores a variety of different clothing."
 - id: 18797
-  examine: "Stores a variety of different clothing."
 - id: 18798
-  examine: "Stores holiday items."
 - id: 18799
-  examine: "Stores holiday items."
 - id: 18800
-  examine: "Stores holiday items."
 - id: 18801
-  examine: "Stores holiday items."
 - id: 18802
-  examine: "Stores holiday items."
 - id: 18803
-  examine: "Stores holiday items."
 - id: 18804
-  examine: "Stores your precious belongings."
 - id: 18805
-  examine: "Stores your precious belongings."
 - id: 18806
-  examine: "Stores your precious belongings."
 - id: 18807
-  examine: "Stores your precious belongings."
 - id: 18808
-  examine: "Stores your precious belongings."
 - id: 18809
-  examine: "Stores your precious belongings."
 - id: 18810
-  examine: "A cape rack for you to hang your capes on."
 - id: 18811
-  examine: "Stores a variety of different clothing."
 - id: 18812
-  examine: "Stores holiday items."
 - id: 18813
-  examine: "Stores your precious belongings."
 - id: 18814
-  examine: "A box for you to keep clothing."
 - id: 18815
-  examine: "A case for you to keep your armour in."
 - id: 18816
 - id: 18817
-  examine: "Small rocks."
 - id: 18818
-  examine: "You can grow herbs in this Farming patch."
 - id: 18819
-  examine: "You can grow herbs in this Farming patch."
 - id: 18820
-  examine: "You can grow herbs in this Farming patch."
 - id: 18821
-  examine: "You can grow herbs in this Farming patch."
 - id: 18822
-  examine: "A herb is growing in this patch."
 - id: 18823
-  examine: "A herb is growing in this patch."
 - id: 18824
-  examine: "A herb is growing in this patch."
 - id: 18825
-  examine: "A herb is growing in this patch."
 - id: 18826
-  examine: "A herb is growing in this patch."
 - id: 18827
-  examine: "These herbs have become diseased."
 - id: 18828
-  examine: "These herbs have become diseased."
 - id: 18829
-  examine: "These herbs have become diseased."
 - id: 18830
-  examine: "These herbs have become diseased and died."
 - id: 18831
-  examine: "These herbs have become diseased and died."
 - id: 18832
-  examine: "These herbs have become diseased and died."
 - id: 18833
-  examine: "Lets me climb back into the Troll Stronghold."
 - id: 18834
-  examine: "The way up to the roof."
 - id: 18835
-  examine: "It looks like somebody's trying to grow it!"
 - id: 18836
-  examine: "It looks like somebody's trying to grow it!"
 - id: 18837
-  examine: "It looks like somebody's trying to grow it!"
 - id: 18838
-  examine: "It looks like somebody's trying to grow it!"
 - id: 18839
-  examine: "It looks like somebody's trying to grow it!"
 - id: 18840
-  examine: "It looks like somebody's trying to grow them!"
 - id: 18841
-  examine: "Oh look, a dolphin."
 - id: 18842
-  examine: "Oh look, a fish."
 - id: 18843
-  examine: "I don't think I'll be using this."
 - id: 18844
 - id: 18845
-  examine: "Doesn't look very promising."
 - id: 18846
-  examine: "Still not ready to be used as a farming patch."
 - id: 18847
-  examine: "Very thick weeds have grown in this farming patch."
 - id: 18848
-  examine: "Thick weeds have grown in this farming patch."
 - id: 18849
-  examine: "A few weeds have grown in this farming patch."
 - id: 18850
-  examine: "My Arm could grow something here."
 - id: 18851
-  examine: "My Arm's hardy gout tuber is growing here."
 - id: 18852
-  examine: "This will need curing before it dies."
 - id: 18853
-  examine: "Hardy, but apparently not immortal."
 - id: 18854
-  examine: "My Arm's hardy gout tuber is growing here."
 - id: 18855
-  examine: "My Arm's hardy goutweed is ready to be harvested."
 - id: 18856
-  examine: "Popular on sandy beaches where fruity cocktails may be found."
 - id: 18857
 - id: 18858
   depleted: 18857
@@ -29824,85 +28240,49 @@
 - id: 18862
 - id: 18863
 - id: 18864
-  examine: "Aww, drunken dwarfie gone splat."
 - id: 18865
-  examine: "What a waste of such a fine liquor."
 - id: 18866
-  examine: "The leprechaun must have legged it."
 - id: 18867
 - id: 18868
 - id: 18869
-  examine: "Half hearted attempt to keep prisoners locked away."
 - id: 18870
-  examine: "Half hearted attempt to keep prisoners locked away."
 - id: 18871
-  examine: "A rocky rock."
 - id: 18872
-  examine: "A rocky rock."
 - id: 18873
-  examine: "A rocky rock."
 - id: 18874
-  examine: "A sign that suggests danger."
 - id: 18875
-  examine: "How do these things manage to grow?"
 - id: 18876
-  examine: "A sign on a cactus."
 - id: 18877
-  examine: "Tracks in the sand."
 - id: 18878
-  examine: "Tracks in the sand."
 - id: 18879
-  examine: "Tracks in the sand."
 - id: 18880
-  examine: "Tracks in the sand."
 - id: 18881
-  examine: "Tracks in the sand."
 - id: 18882
-  examine: "Tracks in the sand."
 - id: 18883
-  examine: "Tracks in the sand."
 - id: 18884
-  examine: "Tracks in the sand."
 - id: 18885
-  examine: "Tracks in the sand."
 - id: 18886
-  examine: "Tracks in the sand."
 - id: 18887
-  examine: "A wooden barrel for storage."
 - id: 18888
-  examine: "Slaves are using this to pull up barrels of rocks from down below."
 - id: 18889
-  examine: "A wooden crate."
 - id: 18890
-  examine: "A wooden crate."
 - id: 18891
 - id: 18892
-  examine: "A deposit of rocks."
 - id: 18893
-  examine: "A deposit of rocks."
 - id: 18894
-  examine: "A deposit of rocks."
 - id: 18895
-  examine: "A deposit of rocks."
 - id: 18896
 - id: 18897
 - id: 18898
-  examine: "Tracks in the sand."
 - id: 18899
-  examine: "Tracks in the sand."
 - id: 18900
-  examine: "Tracks in the sand."
 - id: 18901
 - id: 18902
-  examine: "For putting things on."
 - id: 18903
-  examine: "Allows access to above level."
 - id: 18904
-  examine: "Allows access to level below."
 - id: 18905
 - id: 18906
 - id: 18907
-  examine: "A solid looking chest, it belongs to Captain Siad."
 - id: 18908
 - id: 18909
 - id: 18910
@@ -29914,20 +28294,13 @@
 - id: 18916
 - id: 18917
 - id: 18918
-  examine: "A wooden crate."
 - id: 18919
-  examine: "A wooden crate."
 - id: 18920
-  examine: "A sealed barrel with a warning sign on it."
 - id: 18921
-  examine: "A wooden barrel for storage."
 - id: 18922
   depleted: 19008
-  examine: "A quick way down."
 - id: 18923
-  examine: "Cliff top."
 - id: 18924
-  examine: "Cliff top."
 - id: 18925
 - id: 18926
 - id: 18927
@@ -29943,7 +28316,6 @@
 - id: 18936
 - id: 18937
 - id: 18938
-  examine: "Danger, Not safe for humans."
 - id: 18939
 - id: 18940
 - id: 18941
@@ -29952,56 +28324,36 @@
 - id: 18944
 - id: 18945
 - id: 18946
-  examine: "Keeps mine carts from rolling away."
 - id: 18947
 - id: 18948
 - id: 18949
 - id: 18950
 - id: 18951
-  examine: "Slaves are placing barrels on this to haul them to the surface."
 - id: 18952
-  examine: "Stoney!"
 - id: 18953
-  examine: "Stoney!"
 - id: 18954
-  examine: "Stoney!"
 - id: 18955
-  examine: "Looks like he's been dead a while now..."
 - id: 18956
-  examine: "I don't think he'd mind us checking for his wallet now..."
 - id: 18957
-  examine: "I'm sure he died of natural causes. Like a massive dragon or something..."
 - id: 18958
-  examine: "The cart which takes barrels of rocks from the mining encampment to Al-Kharid."
 - id: 18959
-  examine: "The cart which takes barrels of rocks from the mining encampment to Al-Kharid."
 - id: 18960
-  examine: "A big strong camel, used for pulling carts full of minerals."
 - id: 18961
-  examine: "Rocky!"
 - id: 18962
-  examine: "A barrel containing rocks and mining debris."
 - id: 18963
 - id: 18964
-  examine: "Even this door looks half starved - and appears to be eyeing you up as lunch."
 - id: 18965
-  examine: "Even this door looks half starved - and appears to be eyeing you up as lunch."
 - id: 18966
 - id: 18967
-  examine: "A rope hangs here."
 - id: 18968
-  examine: "A rope hangs here."
 - id: 18969
-  examine: "A rope hangs here."
 - id: 18970
 - id: 18971
 - id: 18972
   depleted: 19048
 - id: 18973
-  examine: "Stairs leading down."
 - id: 18974
   depleted: 19052
-  examine: "Stairs leading down."
 - id: 18975
 - id: 18976
 - id: 18977
@@ -30010,25 +28362,18 @@
 - id: 18980
 - id: 18981
 - id: 18982
-  examine: "Looks like I could balance across there."
 - id: 18983
 - id: 18984
 - id: 18985
 - id: 18986
 - id: 18987
-  examine: "I can climb down this."
 - id: 18988
-  examine: "I can climb this."
 - id: 18989
-  examine: "I can climb down this."
 - id: 18990
-  examine: "I can climb this."
 - id: 18991
   depleted: 19003
-  examine: "I can climb these stairs."
 - id: 18992
   depleted: 19004
-  examine: "They go down."
 - id: 18993
   depleted: 19005
 - id: 18994
@@ -30039,28 +28384,19 @@
   depleted: 19005
 - id: 18997
   depleted: 19003
-  examine: "Looks like he could do with a drink and a mop."
 - id: 18998
   depleted: 19004
-  examine: "These bones have been picked clean... something around here is hungry!"
 - id: 18999
   depleted: 19005
-  examine: "He looks hungry!"
 - id: 19000
   depleted: 19003
-  examine: "A huge sack of grain in the middle of famine."
 - id: 19001
   depleted: 19004
-  examine: "This rope is threadbare and thin. Climb this to go back to the beginning."
 - id: 19002
   depleted: 19005
-  examine: "As you look closer you see that this rope is threadbare and thin."
 - id: 19003
-  examine: "A very rickety ladder."
 - id: 19004
-  examine: "A very rickety ladder."
 - id: 19005
-  examine: "If you are of sufficient experience, you may take a shortcut here."
 - id: 19006
   depleted: 19055
 - id: 19007
@@ -30091,175 +28427,93 @@
   depleted: 19009
 - id: 19025
   depleted: 19010
-  examine: "A passageway leading somewhere."
 - id: 19026
   depleted: 19011
-  examine: "A passageway leading somewhere."
 - id: 19027
-  examine: "A passageway leading up."
 - id: 19028
-  examine: "A passageway leading up."
 - id: 19029
-  examine: "A passageway leading down."
 - id: 19030
-  examine: "A large pile of snow."
 - id: 19031
-  examine: "A large pile of snow."
 - id: 19032
-  examine: "A tunnel leading under the wall."
 - id: 19033
-  examine: "A large pile of snow."
 - id: 19034
-  examine: "A large pile of snow."
 - id: 19035
-  examine: "A large pile of snow."
 - id: 19036
-  examine: "A tunnel leading under the wall."
 - id: 19037
-  examine: "This tunnel seems to lead out of the cave."
 - id: 19038
-  examine: "A pretty wintumber tree."
 - id: 19039
-  examine: "There are quite a few explosive sounds inside..."
 - id: 19040
-  examine: "You really don't want to slip off this."
 - id: 19041
 - id: 19042
-  examine: "A very slippery stepping stone"
 - id: 19043
-  examine: "Leads to another section of the cave."
 - id: 19044
 - id: 19045
 - id: 19046
 - id: 19047
-  examine: "A rough-looking wooden ladder."
 - id: 19048
-  examine: "A rough-looking wooden ladder."
 - id: 19049
-  examine: "A rough-looking wooden ladder."
 - id: 19050
-  examine: "A rough-looking wooden ladder."
 - id: 19051
-  examine: "The barbarians will take things to and from the bank for you."
 - id: 19052
-  examine: "How am I going to get down there?"
 - id: 19053
-  examine: "How am I going to get down there?"
 - id: 19054
-  examine: "This compost bin contains compost (5/15)."
 - id: 19055
-  examine: "This compost bin contains compost (6/15)."
 - id: 19056
-  examine: "This compost bin contains compost (7/15)."
 - id: 19057
-  examine: "This compost bin contains compost (8/15)."
 - id: 19058
-  examine: "This compost bin contains compost (9/15)."
 - id: 19059
-  examine: "This compost bin contains compost (10/15)."
 - id: 19060
-  examine: "This compost bin contains compost (11/15)."
 - id: 19061
-  examine: "This compost bin contains compost (12/15)."
 - id: 19062
-  examine: "This compost bin contains compost (13/15)."
 - id: 19063
-  examine: "This compost bin contains compost (14/15)."
 - id: 19064
-  examine: "This compost bin is full of compost."
 - id: 19065
 - id: 19066
-  examine: "This compost bin contains supercompostable items (1/15)."
 - id: 19067
-  examine: "This compost bin contains supercompostable items (2/15)."
 - id: 19068
-  examine: "This compost bin contains supercompostable items (3/15)."
 - id: 19069
-  examine: "This compost bin contains supercompostable items (4/15)."
 - id: 19070
-  examine: "This compost bin contains supercompostable items (5/15)."
 - id: 19071
-  examine: "This compost bin contains supercompostable items (6/15)."
 - id: 19072
-  examine: "This compost bin contains supercompostable items (7/15)."
 - id: 19073
-  examine: "This compost bin contains supercompostable items (8/15)."
 - id: 19074
-  examine: "This compost bin contains supercompostable items (9/15)."
 - id: 19075
-  examine: "This compost bin contains supercompostable items (10/15)."
 - id: 19076
-  examine: "This compost bin contains supercompostable items (11/15)."
 - id: 19077
-  examine: "This compost bin contains supercompostable items (12/15)."
 - id: 19078
-  examine: "This compost bin contains supercompostable items (13/15)."
 - id: 19079
-  examine: "This compost bin contains supercompostable items (14/15)."
 - id: 19080
-  examine: "This compost bin is full of supercompostable items."
 - id: 19081
-  examine: "Vegetation is rotting in here to make supercompost."
 - id: 19082
-  examine: "The supercompost is ready."
 - id: 19083
-  examine: "This compost bin contains supercompost (1/15)."
 - id: 19084
-  examine: "This compost bin contains supercompost (2/15)."
 - id: 19085
-  examine: "This compost bin contains supercompost (3/15)."
 - id: 19086
-  examine: "This compost bin contains supercompost (4/15)."
 - id: 19087
-  examine: "This compost bin contains supercompost (5/15)."
 - id: 19088
-  examine: "This compost bin contains supercompost (6/15)."
 - id: 19089
-  examine: "This compost bin contains supercompost (7/15)."
 - id: 19090
-  examine: "This compost bin contains supercompost (8/15)."
 - id: 19091
-  examine: "This compost bin contains supercompost (9/15)."
 - id: 19092
-  examine: "This compost bin contains supercompost (10/15)."
 - id: 19093
-  examine: "This compost bin contains supercompost (11/15)."
 - id: 19094
-  examine: "This compost bin contains supercompost (12/15)."
 - id: 19095
-  examine: "This compost bin contains supercompost (13/15)."
 - id: 19096
-  examine: "This compost bin contains supercompost (14/15)."
 - id: 19097
-  examine: "This compost bin is full of supercompost."
 - id: 19098
-  examine: "This compost bin contains a tomato."
 - id: 19099
-  examine: "This compost bin contains two tomatoes."
 - id: 19100
-  examine: "This compost bin contains three tomatoes."
 - id: 19101
-  examine: "This compost bin contains four tomatoes."
 - id: 19102
-  examine: "This compost bin contains five tomatoes."
 - id: 19103
-  examine: "This compost bin contains six tomatoes."
 - id: 19104
-  examine: "This compost bin contains seven tomatoes."
 - id: 19105
-  examine: "This compost bin contains eight tomatoes."
 - id: 19106
-  examine: "This compost bin contains nine tomatoes."
 - id: 19107
-  examine: "This compost bin contains ten tomatoes."
 - id: 19108
-  examine: "This compost bin contains eleven tomatoes."
 - id: 19109
-  examine: "This compost bin contains twelve tomatoes."
 - id: 19110
-  examine: "This compost bin contains thirteen tomatoes."
 - id: 19111
-  examine: "This compost bin contains fourteen tomatoes."
 - id: 19112
 - id: 19113
 - id: 19114
@@ -30274,21 +28528,13 @@
 - id: 19123
 - id: 19124
 - id: 19125
-  examine: "Ick, dirt."
 - id: 19126
-  examine: "A floating wooden plank."
 - id: 19127
-  examine: "Lit to remember the souls of the departed."
 - id: 19128
-  examine: "An air balloon basket."
 - id: 19129
-  examine: "An air balloon basket."
 - id: 19130
-  examine: "An air balloon."
 - id: 19131
-  examine: "A big rock."
 - id: 19132
-  examine: "A balloon basket frame."
 - id: 19133
 - id: 19134
 - id: 19135
@@ -30302,7 +28548,6 @@
 - id: 19143
 - id: 19144
 - id: 19145
-  examine: "Shrine to the glory of Saradomin."
 - id: 19146
 - id: 19147
 - id: 19148
@@ -30314,37 +28559,24 @@
 - id: 19154
 - id: 19155
 - id: 19156
-  examine: "What remains of the balloon..."
 - id: 19157
-  examine: "Auguste's bed."
 - id: 19158
-  examine: "It has some of Auguste's notes on."
 - id: 19159
-  examine: "Auguste's bookcase."
 - id: 19160
 - id: 19161
-  examine: "What remains of the basket."
 - id: 19162
-  examine: "What remains of the basket."
 - id: 19163
 - id: 19164
-  examine: "What remains of the balloon..."
 - id: 19165
-  examine: "One of the most common trees in RuneScape."
 - id: 19166
-  examine: "A commonly found tree."
 - id: 19167
-  examine: "A commonly found tree."
 - id: 19168
 - id: 19169
 - id: 19170
 - id: 19171
-  examine: "Hmmm... I wonder if it's loose enough to get through."
 - id: 19172
-  examine: "Danger - Very deadly creatures below!"
 - id: 19173
 - id: 19174
-  examine: "A passageway leading down."
 - id: 19175
 - id: 19176
 - id: 19177
@@ -30372,69 +28604,41 @@
 - id: 19199
 - id: 19200
 - id: 19201
-  examine: "Stairs leading down."
 - id: 19202
-  examine: "Stairs leading down."
 - id: 19203
 - id: 19204
 - id: 19205
 - id: 19206
-  examine: "It seems to be looking at you!"
 - id: 19207
-  examine: "It seems to be looking at you!"
 - id: 19208
 - id: 19209
-  examine: "It seems to be looking at you!"
 - id: 19210
-  examine: "It seems to be looking at you!"
 - id: 19211
 - id: 19212
 - id: 19213
 - id: 19214
 - id: 19215
-  examine: "A large flat boulder. It looks like it could be useful for something."
 - id: 19216
-  examine: "A large flat boulder. It looks like it could be useful for something."
 - id: 19217
-  examine: "Someone could get their fingers caught in that."
 - id: 19218
-  examine: "Someone could get their fingers caught in that."
 - id: 19219
-  examine: "Someone could get their fingers caught in that."
 - id: 19220
-  examine: "Similar to a fish in name only."
 - id: 19221
-  examine: "A falconry perch."
 - id: 19222
-  examine: "I can climb over the fence with this."
 - id: 19223
-  examine: "A magical catching box."
 - id: 19224
-  examine: "A magical catching box."
 - id: 19225
-  examine: "A magical catching box."
 - id: 19226
-  examine: "A magical catching box."
 - id: 19227
-  examine: "A suitable place for a pit trap."
 - id: 19228
-  examine: "Dangerous; someone could trip right into that."
 - id: 19229
-  examine: "It looks like something fell through the branches on top."
 - id: 19230
-  examine: "It looks like something fell through the branches on top."
 - id: 19231
-  examine: "Something has fallen into this trap."
 - id: 19232
-  examine: "Something has fallen into this trap."
 - id: 19233
-  examine: "Something has fallen into this trap."
 - id: 19234
-  examine: "Something has fallen into this trap."
 - id: 19235
-  examine: "Something has fallen into this trap."
 - id: 19236
-  examine: "Something has fallen into this trap."
 - id: 19237
 - id: 19238
 - id: 19239
@@ -30532,216 +28736,113 @@
 - id: 19331
 - id: 19332
 - id: 19333
-  examine: "The snare will tighten around animals passing through."
 - id: 19334
-  examine: "Whatever it caught must have escaped."
 - id: 19335
-  examine: "There's something caught in it."
 - id: 19336
-  examine: "There's something caught in it."
 - id: 19337
-  examine: "Who knows what lies within..."
 - id: 19338
-  examine: "Nobody home?"
 - id: 19339
-  examine: "A small fern-like plant."
 - id: 19340
-  examine: "A small fern-like plant."
 - id: 19341
-  examine: "A small fern-like plant."
 - id: 19342
-  examine: "A small fern-like plant."
 - id: 19343
-  examine: "A small fern-like plant."
 - id: 19344
-  examine: "A small fern-like plant."
 - id: 19345
-  examine: "A small fern-like plant."
 - id: 19346
-  examine: "A small fern-like plant."
 - id: 19347
-  examine: "A small fern-like plant."
 - id: 19348
-  examine: "A small fern-like plant."
 - id: 19349
-  examine: "A small fern-like plant."
 - id: 19350
-  examine: "A small fern-like plant."
 - id: 19351
-  examine: "A small fern-like plant."
 - id: 19352
-  examine: "A small fern-like plant."
 - id: 19353
-  examine: "A small fern-like plant."
 - id: 19354
-  examine: "A small fern-like plant."
 - id: 19355
-  examine: "A small fern-like plant."
 - id: 19356
-  examine: "A small fern-like plant."
 - id: 19357
-  examine: "A small fern-like plant."
 - id: 19358
-  examine: "A small fern-like plant."
 - id: 19359
-  examine: "A small fern-like plant."
 - id: 19360
-  examine: "A small fern-like plant."
 - id: 19361
-  examine: "A small fern-like plant."
 - id: 19362
-  examine: "A small fern-like plant."
 - id: 19363
-  examine: "A small fern-like plant."
 - id: 19364
-  examine: "A small fern-like plant."
 - id: 19365
-  examine: "A small fern-like plant."
 - id: 19366
-  examine: "A small fern-like plant."
 - id: 19367
-  examine: "A small fern-like plant."
 - id: 19368
-  examine: "A small fern-like plant."
 - id: 19369
-  examine: "A small fern-like plant."
 - id: 19370
-  examine: "A small fern-like plant."
 - id: 19371
-  examine: "A small fern-like plant."
 - id: 19372
-  examine: "A small fern-like plant."
 - id: 19373
-  examine: "A small fern-like plant."
 - id: 19374
-  examine: "A small fern-like plant."
 - id: 19375
-  examine: "A small fern-like plant."
 - id: 19376
-  examine: "A small fern-like plant."
 - id: 19377
-  examine: "A small fern-like plant."
 - id: 19378
-  examine: "A small fern-like plant."
 - id: 19379
-  examine: "A small fern-like plant."
 - id: 19380
-  examine: "A small fern-like plant."
 - id: 19381
-  examine: "A small fern-like plant."
 - id: 19382
-  examine: "A small fern-like plant."
 - id: 19383
-  examine: "A small fern-like plant."
 - id: 19384
-  examine: "A small fern-like plant."
 - id: 19385
-  examine: "A small fern-like plant."
 - id: 19386
-  examine: "A small fern-like plant."
 - id: 19387
-  examine: "A small fern-like plant."
 - id: 19388
-  examine: "How do these things manage to grow?"
 - id: 19389
-  examine: "How do these things manage to grow?"
 - id: 19390
-  examine: "A deposit of rocks."
 - id: 19391
-  examine: "How do these things manage to grow?"
 - id: 19392
-  examine: "How do these things manage to grow?"
 - id: 19393
-  examine: "A deposit of rocks."
 - id: 19394
-  examine: "How do these things manage to grow?"
 - id: 19395
-  examine: "How do these things manage to grow?"
 - id: 19396
-  examine: "A deposit of rocks."
 - id: 19397
-  examine: "A deposit of rocks."
 - id: 19398
-  examine: "How do these things manage to grow?"
 - id: 19399
-  examine: "How do these things manage to grow?"
 - id: 19400
-  examine: "A deposit of rocks."
 - id: 19401
-  examine: "How do these things manage to grow?"
 - id: 19402
-  examine: "A deposit of rocks."
 - id: 19403
-  examine: "It looks like some sort of large fern."
 - id: 19404
-  examine: "A low-lying fern."
 - id: 19405
-  examine: "It looks like some sort of large fern."
 - id: 19406
-  examine: "A low-lying fern."
 - id: 19407
-  examine: "It looks like some sort of large fern."
 - id: 19408
-  examine: "A low-lying fern."
 - id: 19409
-  examine: "A low-lying fern."
 - id: 19410
-  examine: "It looks like some sort of large fern."
 - id: 19411
-  examine: "A low-lying fern."
 - id: 19412
-  examine: "It looks like some sort of large fern."
 - id: 19413
-  examine: "A low-lying fern."
 - id: 19414
-  examine: "It looks like some sort of large fern."
 - id: 19415
-  examine: "A low-lying fern."
 - id: 19416
-  examine: "It looks like some sort of large fern."
 - id: 19417
-  examine: "A low-lying fern."
 - id: 19418
-  examine: "This old tree is rotting away."
 - id: 19419
-  examine: "It's too small for a human to fit down here."
 - id: 19420
-  examine: "It's too small for a human to fit down here."
 - id: 19421
-  examine: "It's too small for a human to fit down here."
 - id: 19422
-  examine: "This old tree is rotting away."
 - id: 19423
-  examine: "It's too small for a human to fit down here."
 - id: 19424
-  examine: "It's too small for a human to fit down here."
 - id: 19425
-  examine: "This old tree is rotting away."
 - id: 19426
-  examine: "It's too small for a human to fit down here."
 - id: 19427
-  examine: "A commonly found bush."
 - id: 19428
-  examine: "A commonly found bush."
 - id: 19429
-  examine: "A commonly found bush."
 - id: 19430
-  examine: "This sand looks like it's been disturbed recently."
 - id: 19431
 - id: 19432
 - id: 19433
 - id: 19434
-  examine: "It's too small for a human to fit down here."
 - id: 19435
-  examine: "Part of the ice face has collapsed here."
 - id: 19436
 - id: 19437
 - id: 19438
-  examine: "Looks like the home of some small mammal."
 - id: 19439
-  examine: "Looks like the home of some small mammal."
 - id: 19440
-  examine: "Looks like the home of some small mammal."
 - id: 19441
 - id: 19442
 - id: 19443
@@ -30796,11 +28897,8 @@
 - id: 19490
 - id: 19491
 - id: 19492
-  examine: "Looks like the home of some small mammal."
 - id: 19493
-  examine: "Looks like the home of some small mammal."
 - id: 19494
-  examine: "Looks like the home of some small mammal."
 - id: 19495
 - id: 19496
 - id: 19497
@@ -30861,9 +28959,7 @@
 - id: 19551
   depleted: 19567
 - id: 19552
-  examine: "Looks like the home of some small mammal."
 - id: 19553
-  examine: "Looks like the home of some small mammal."
 - id: 19554
 - id: 19555
 - id: 19556
@@ -30904,9 +29000,7 @@
 - id: 19591
 - id: 19592
 - id: 19593
-  examine: "Looks like the home of some small mammal."
 - id: 19594
-  examine: "Looks like the home of some small mammal."
 - id: 19595
 - id: 19596
 - id: 19597
@@ -30954,9 +29048,7 @@
 - id: 19638
 - id: 19639
 - id: 19640
-  examine: "It looks like some kind of burrow into the ice."
 - id: 19641
-  examine: "It looks like some kind of burrow into the ice."
 - id: 19642
 - id: 19643
 - id: 19644
@@ -30996,9 +29088,7 @@
 - id: 19678
 - id: 19679
 - id: 19680
-  examine: "A passageway leading somewhere."
 - id: 19681
-  examine: "A passageway leading somewhere."
 - id: 19682
 - id: 19683
 - id: 19684
@@ -31008,9 +29098,7 @@
 - id: 19688
 - id: 19689
 - id: 19690
-  examine: "A conveniently step shaped chunk of ice."
 - id: 19691
-  examine: "A conveniently step shaped chunk of ice."
 - id: 19692
 - id: 19693
 - id: 19694
@@ -31020,7 +29108,6 @@
 - id: 19697
 - id: 19698
 - id: 19699
-  examine: "A counter made of plain wooden planks."
 - id: 19700
 - id: 19701
 - id: 19702
@@ -31074,27 +29161,18 @@
 - id: 19750
 - id: 19751
 - id: 19752
-  examine: "A confusing term. Sliding down rocks like these would surely hurt."
 - id: 19753
-  examine: "A dingy tunnel leads into the side of the hill."
 - id: 19754
-  examine: "Deep scratches seem to have been made in the lip of the cave entrance."
 - id: 19755
 - id: 19756
 - id: 19757
 - id: 19758
 - id: 19759
-  examine: "This tunnel seems to lead out of the cave."
 - id: 19760
-  examine: "This tunnel seems to lead out of the cave."
 - id: 19761
-  examine: "Deep scratches seem to have been made in the lip of the cave entrance."
 - id: 19762
-  examine: "A dingy tunnel leads into the side of the cliff."
 - id: 19763
-  examine: "This tunnel seems to lead out of the cave."
 - id: 19764
-  examine: "This tunnel seems to lead out of the cave."
 - id: 19765
 - id: 19766
 - id: 19767
@@ -31122,17 +29200,13 @@
 - id: 19789
 - id: 19790
 - id: 19791
-  examine: "This tunnel seems to lead out of the cave."
 - id: 19792
-  examine: "This tunnel seems to lead out of the cave."
 - id: 19793
 - id: 19794
 - id: 19795
 - id: 19796
 - id: 19797
-  examine: "Deep scratches seem to have been made in the lip of the cave entrance."
 - id: 19798
-  examine: "A dingy tunnel leads into the side of the cliff."
 - id: 19799
 - id: 19800
 - id: 19801
@@ -31143,15 +29217,10 @@
 - id: 19806
 - id: 19807
 - id: 19808
-  examine: "A deposit of rocks."
 - id: 19809
-  examine: "A dingy tunnel leads into the side of the mountain."
 - id: 19810
-  examine: "Deep scratches seem to have been made in the lip of the cave entrance."
 - id: 19811
-  examine: "This tunnel seems to lead out of the cave."
 - id: 19812
-  examine: "This tunnel seems to lead out of the cave."
 - id: 19813
 - id: 19814
 - id: 19815
@@ -31179,26 +29248,19 @@
 - id: 19837
 - id: 19838
 - id: 19839
-  examine: "The almost fractal style of these plants is fascinating."
 - id: 19840
-  examine: "Some kind of low-lying jungle fern."
 - id: 19841
 - id: 19842
 - id: 19843
 - id: 19844
 - id: 19845
 - id: 19846
-  examine: "They're rather icy, but it might be possible to climb them anyway."
 - id: 19847
-  examine: "They're rather icy, but it might be possible to climb them anyway."
 - id: 19848
 - id: 19849
-  examine: "A rocky outcrop."
 - id: 19850
 - id: 19851
-  examine: "Someone could get their fingers caught in that."
 - id: 19852
-  examine: "Cute."
 - id: 19853
 - id: 19854
 - id: 19855
@@ -31217,136 +29279,86 @@
 - id: 19868
 - id: 19869
 - id: 19870
-  examine: "This gate seems to be shaped like a pair of wings."
 - id: 19871
-  examine: "This gate seems to be shaped like a pair of wings."
 - id: 19872
 - id: 19873
 - id: 19874
 - id: 19875
 - id: 19876
 - id: 19877
-  examine: "A small lever seems to be set in the beak of this eagle carving."
 - id: 19878
-  examine: "A small lever seems to be set in the beak of this eagle carving."
 - id: 19879
 - id: 19880
 - id: 19881
-  examine: "There's a small pot simmering gently above the fire."
 - id: 19882
 - id: 19883
 - id: 19884
-  examine: "It's just irresponsible to leave a fire unattended like this."
 - id: 19885
-  examine: "These books are stacked very neatly."
 - id: 19886
-  examine: "These books have been strewn all over the place."
 - id: 19887
-  examine: "There's an assortment of camping equipment here."
 - id: 19888
-  examine: "The camping equipment has just been scattered all over the ground."
 - id: 19889
 - id: 19890
 - id: 19891
-  examine: "This leads back outside."
 - id: 19892
 - id: 19893
 - id: 19894
-  examine: "This tunnels leads back up to the higher levels of the cave."
 - id: 19895
 - id: 19896
 - id: 19897
-  examine: "This tunnels leads further down into the depths of the cave system."
 - id: 19898
 - id: 19899
 - id: 19900
-  examine: "This tunnels leads back up to the higher levels of the cave."
 - id: 19901
 - id: 19902
 - id: 19903
-  examine: "This tunnels leads further down into the depths of the cave system."
 - id: 19904
 - id: 19905
 - id: 19906
-  examine: "This tunnels leads back up to the higher levels of the cave."
 - id: 19907
 - id: 19908
 - id: 19909
-  examine: "This tunnels further down into the depths of the cave system."
 - id: 19910
 - id: 19911
-  examine: "It looks like there should be something sitting on top of this."
 - id: 19912
 - id: 19913
 - id: 19914
-  examine: "There seems to be some sort of eagle engraved on this door."
 - id: 19915
-  examine: "There seems to be some sort of eagle engraved on this door."
 - id: 19916
-  examine: "There seems to be some sort of eagle engraved on this door."
 - id: 19917
-  examine: "There seems to be some sort of eagle engraved on this door."
 - id: 19918
-  examine: "There seems to be some sort of eagle engraved on this door."
 - id: 19919
-  examine: "A large container of something that looks like birdseed."
 - id: 19920
-  examine: "It's a bird feeder. Seed goes in at the side."
 - id: 19921
-  examine: "It's a bird feeder. There's seed in it."
 - id: 19922
-  examine: "Probably a bit too big for fly-fishing."
 - id: 19923
-  examine: "This area of rock doesn't seem to match the rest of the cliff face."
 - id: 19924
-  examine: "Part of the cliff face has moved outwards to reveal a tunnel."
 - id: 19925
-  examine: "This area of rock doesn't seem to match the rest of the cliff face."
 - id: 19926
-  examine: "Part of the cliff face has moved outwards to reveal a tunnel."
 - id: 19927
 - id: 19928
-  examine: "A busted table."
 - id: 19929
-  examine: "A busted chair."
 - id: 19930
-  examine: "Whatever this was, it is now ruined."
 - id: 19931
-  examine: "A busted chest."
 - id: 19932
-  examine: "A weary bookcase."
 - id: 19933
-  examine: "A weary chair."
 - id: 19934
-  examine: "A weary chest piece."
 - id: 19935
-  examine: "It's sitting in some sort of track that's running along the floor."
 - id: 19936
-  examine: "This can be filled using the chute at the side."
 - id: 19937
-  examine: "This can be filled using the chute at the side."
 - id: 19938
-  examine: "This can be filled using the chute at the side."
 - id: 19939
-  examine: "This can be filled using the chute at the side."
 - id: 19940
-  examine: "This can be filled using the chute at the side."
 - id: 19941
-  examine: "This can be filled using the chute at the side."
 - id: 19942
-  examine: "This can be filled using the chute at the side."
 - id: 19943
-  examine: "This can be filled using the chute at the side."
 - id: 19944
-  examine: "This can be filled using the chute at the side."
 - id: 19945
-  examine: "The word 'reset' seems to be inscribed on the handle, I wonder what that means."
 - id: 19946
 - id: 19947
 - id: 19948
 - id: 19949
 - id: 19950
-  examine: "There seems to be some kind of feather sitting on top of the pedestal."
 - id: 19951
 - id: 19952
 - id: 19953
@@ -31364,50 +29376,28 @@
 - id: 19965
 - id: 19966
 - id: 19967
-  examine: "It looks like it gets thin quite quick.  I wouldn't want to go down there myself."
 - id: 19968
 - id: 19969
-  examine: "Some small pieces of rock seem to have broken off and fallen into the corridor."
 - id: 19970
-  examine: "Some small pieces of rock seem to have broken off and fallen into the corridor."
 - id: 19971
-  examine: "Some small pieces of rock seem to have broken off and fallen into the corridor."
 - id: 19972
-  examine: "Some small pieces of rock seem to have broken off and fallen into the corridor."
 - id: 19973
-  examine: "Some small pieces of rock seem to have broken off and fallen into the corridor."
 - id: 19974
-  examine: "It looks like there should be something sitting on top of this."
 - id: 19975
-  examine: "There seems to be some kind of feather sitting on top of the pedestal."
 - id: 19976
-  examine: "I wonder what this is attached to."
 - id: 19977
-  examine: "I wonder what this is attached to."
 - id: 19978
-  examine: "I wonder what this is attached to."
 - id: 19979
-  examine: "I wonder what this is attached to."
 - id: 19980
-  examine: "There seems to be some sort of netting on the ground around this pedestal."
 - id: 19981
-  examine: "Well it's no good to me up there."
 - id: 19982
-  examine: "Well it's no good to me up there."
 - id: 19983
-  examine: "Well it's no good to me up there."
 - id: 19984
-  examine: "There seems to be some kind of feather sitting on top of the pedestal."
 - id: 19985
-  examine: "Maybe this vine could be trained up the cliff with an appropriate cane or spar."
 - id: 19986
-  examine: "It's been wrapped around the canes; maybe it will grow up the cliff now."
 - id: 19987
-  examine: "It seems to be growing very quickly."
 - id: 19988
-  examine: "It might be strong enough to climb up now."
 - id: 19989
-  examine: "It might be strong enough to climb up now."
 - id: 19990
 - id: 19991
 - id: 19992
@@ -31415,27 +29405,17 @@
 - id: 19994
 - id: 19995
 - id: 19996
-  examine: "Dead and half-buried."
 - id: 19997
-  examine: "Dead animal head. Lovely."
 - id: 19998
-  examine: "Spooky."
 - id: 19999
-  examine: "A dog's idea of heaven."
 - id: 20000
-  examine: "Hot!"
 - id: 20001
-  examine: "Hot!"
 - id: 20002
 - id: 20003
 - id: 20004
-  examine: "A scary rope bridge."
 - id: 20005
-  examine: "A scary rope bridge."
 - id: 20006
-  examine: "A scary rope bridge."
 - id: 20007
-  examine: "A scary rope bridge."
 - id: 20008
 - id: 20009
 - id: 20010
@@ -31451,77 +29431,49 @@
 - id: 20020
 - id: 20021
 - id: 20022
-  examine: "A crystal needs to be placed here to charge the machine."
 - id: 20023
-  examine: "A crystal is placed here to charge the machine."
 - id: 20024
-  examine: "A crystal is placed here to charge the machine."
 - id: 20025
 - id: 20026
-  examine: "A crystal needs to be placed here to charge the machine."
 - id: 20027
-  examine: "A crystal is placed here to charge the machine."
 - id: 20028
-  examine: "A crystal is placed here to charge the machine."
 - id: 20029
 - id: 20030
-  examine: "A crystal needs to be placed here to charge the machine."
 - id: 20031
-  examine: "A crystal is placed here to charge the machine."
 - id: 20032
-  examine: "A crystal is placed here to charge the machine."
 - id: 20033
 - id: 20034
-  examine: "A crystal needs to be placed here to charge the machine."
 - id: 20035
-  examine: "A crystal is placed here to charge the machine."
 - id: 20036
-  examine: "A crystal is placed here to charge the machine."
 - id: 20037
 - id: 20038
-  examine: "A switch to activate the machine."
 - id: 20039
-  examine: "A switch to activate the machine."
 - id: 20040
-  examine: "A machine that needs to be powered by crystals."
 - id: 20041
 - id: 20042
 - id: 20043
 - id: 20044
 - id: 20045
-  examine: "A gate."
 - id: 20046
-  examine: "A gate."
 - id: 20047
 - id: 20048
 - id: 20049
-  examine: "A gate."
 - id: 20050
-  examine: "A gate."
 - id: 20051
 - id: 20052
 - id: 20053
 - id: 20054
 - id: 20055
 - id: 20056
-  examine: "I could climb up this."
 - id: 20057
-  examine: "Trellis."
 - id: 20058
-  examine: "A table."
 - id: 20059
-  examine: "A wooden stool."
 - id: 20060
-  examine: "A table."
 - id: 20061
-  examine: "What kind of sick person keeps a skull on their wall?"
 - id: 20062
-  examine: "Esoteric artefacts."
 - id: 20063
-  examine: "Neatly made up."
 - id: 20064
 - id: 20065
-  examine: "A chair."
 - id: 20066
 - id: 20067
 - id: 20068
@@ -31541,133 +29493,73 @@
 - id: 20082
 - id: 20083
 - id: 20084
-  examine: "A rather strategically placed hole, which appears to be in the ground."
 - id: 20085
-  examine: "A rather strategically placed hole, which appears to be in the ground."
 - id: 20086
 - id: 20087
-  examine: "An entrance to Gu'Tanoth."
 - id: 20088
-  examine: "An entrance to Gu'Tanoth."
 - id: 20089
-  examine: "An entrance to Gu'Tanoth."
 - id: 20090
-  examine: "An entrance to Gu'Tanoth."
 - id: 20091
 - id: 20092
 - id: 20093
 - id: 20094
 - id: 20095
-  examine: "Perhaps I should search it."
 - id: 20096
-  examine: "This bed has seen better days."
 - id: 20097
-  examine: "New feathers, a bit of care and this bed is now comfortable!"
 - id: 20098
 - id: 20099
-  examine: "This compost bin contains fifteen tomatoes."
 - id: 20100
-  examine: "Tomatoes are rotting in here."
 - id: 20101
-  examine: "The rotten tomatoes are ready."
 - id: 20102
-  examine: "This compost bin contains a rotten tomato."
 - id: 20103
-  examine: "This compost bin contains two rotten tomatoes."
 - id: 20104
-  examine: "This compost bin contains three rotten tomatoes."
 - id: 20105
-  examine: "This compost bin contains four rotten tomatoes."
 - id: 20106
-  examine: "This compost bin contains five rotten tomatoes."
 - id: 20107
-  examine: "This compost bin contains six rotten tomatoes."
 - id: 20108
-  examine: "This compost bin contains seven rotten tomatoes."
 - id: 20109
-  examine: "This compost bin contains eight rotten tomatoes."
 - id: 20110
-  examine: "This compost bin contains nine rotten tomatoes."
 - id: 20111
-  examine: "This compost bin contains ten rotten tomatoes."
 - id: 20112
-  examine: "This compost bin contains eleven rotten tomatoes."
 - id: 20113
-  examine: "This compost bin contains twelve rotten tomatoes."
 - id: 20114
-  examine: "This compost bin contains thirteen rotten tomatoes."
 - id: 20115
-  examine: "This compost bin contains fourteen rotten tomatoes."
 - id: 20116
-  examine: "This compost bin contains fifteen rotten tomatoes."
 - id: 20117
-  examine: "Turns vegetation into compost."
 - id: 20118
 - id: 20119
-  examine: "Turns vegetation into compost."
 - id: 20120
-  examine: "This compost bin contains compostable items (1/15)."
 - id: 20121
-  examine: "This compost bin contains compostable items (2/15)."
 - id: 20122
-  examine: "This compost bin contains compostable items (3/15)."
 - id: 20123
-  examine: "This compost bin contains compostable items (4/15)."
 - id: 20124
-  examine: "This compost bin contains compostable items (5/15)."
 - id: 20125
-  examine: "This compost bin contains compostable items (6/15)."
 - id: 20126
-  examine: "This compost bin contains compostable items (7/15)."
 - id: 20127
-  examine: "The bank teller will serve you from here."
 - id: 20128
-  examine: "Someone could get their fingers caught in that."
 - id: 20129
-  examine: "Someone could get their fingers caught in that."
 - id: 20130
-  examine: "Someone could get their fingers caught in that."
 - id: 20131
-  examine: "Someone could get their fingers caught in that."
 - id: 20132
 - id: 20133
-  examine: "An egg launcher!"
 - id: 20134
-  examine: "A blackboard with a plan of attack chalked on."
 - id: 20135
-  examine: "Sharp and pointy!"
 - id: 20136
-  examine: "I wonder where it leads..."
 - id: 20137
-  examine: "I wonder where it leads..."
 - id: 20138
-  examine: "I wonder where it leads..."
 - id: 20139
-  examine: "I wonder where it leads..."
 - id: 20140
-  examine: "I wonder where it leads..."
 - id: 20141
-  examine: "I wonder where it leads..."
 - id: 20142
-  examine: "I wonder where it leads..."
 - id: 20143
-  examine: "I wonder where it leads..."
 - id: 20144
-  examine: "I wonder where it leads..."
 - id: 20145
-  examine: "I wonder where it leads..."
 - id: 20146
-  examine: "I wonder where it leads..."
 - id: 20147
-  examine: "I wonder where it leads..."
 - id: 20148
-  examine: "A winch for lowering the trapdoor."
 - id: 20149
-  examine: "A table with recruitment scrolls on top."
 - id: 20150
-  examine: "I wonder what it tastes like."
 - id: 20151
-  examine: "The Penance Runners are attracted to this cave."
 - id: 20152
 - id: 20153
 - id: 20154
@@ -31681,15 +29573,10 @@
 - id: 20162
 - id: 20163
 - id: 20164
-  examine: "I wouldn't like to meet him in a dark alley."
 - id: 20165
-  examine: "I wonder where these creatures came from."
 - id: 20166
-  examine: "This reminds me of my aunt."
 - id: 20167
-  examine: "Eye-eye!"
 - id: 20168
-  examine: "A one-eyed monster."
 - id: 20169
 - id: 20170
 - id: 20171
@@ -31705,67 +29592,40 @@
 - id: 20181
 - id: 20182
 - id: 20183
-  examine: "Wave room 1."
 - id: 20184
-  examine: "Wave room 2."
 - id: 20185
-  examine: "Wave room 3."
 - id: 20186
-  examine: "Wave room 4."
 - id: 20187
-  examine: "Wave room 5."
 - id: 20188
-  examine: "Wave room 6."
 - id: 20189
-  examine: "Wave room 7."
 - id: 20190
-  examine: "Wave room 8."
 - id: 20191
-  examine: "Wave room 9."
 - id: 20192
-  examine: "Wave room 10."
 - id: 20193
-  examine: "This ladder leads down to the Penance fighting arena."
 - id: 20194
-  examine: "This ladder leads up to the barbarian military building."
 - id: 20195
 - id: 20196
 - id: 20197
 - id: 20198
 - id: 20199
-  examine: "A door to wave area 1."
 - id: 20200
-  examine: "A door to wave area 2."
 - id: 20201
-  examine: "A door to wave area 3."
 - id: 20202
-  examine: "A door to wave area 4."
 - id: 20203
-  examine: "A door to wave area 5."
 - id: 20204
-  examine: "A door to wave area 6."
 - id: 20205
-  examine: "A door to wave area 7."
 - id: 20206
-  examine: "A door to wave area 8."
 - id: 20207
-  examine: "A door to wave area 9."
 - id: 20208
-  examine: "A door to wave area 10."
 - id: 20209
-  examine: "Door to the quick-start room."
 - id: 20210
-  examine: "A pipe I can squeeze through."
 - id: 20211
-  examine: "This must be climbed over."
 - id: 20212
 - id: 20213
 - id: 20214
 - id: 20215
 - id: 20216
-  examine: "A wooden crate."
 - id: 20217
-  examine: "A wooden barrel for storage."
 - id: 20218
 - id: 20219
 - id: 20220
@@ -31775,50 +29635,31 @@
 - id: 20224
 - id: 20225
 - id: 20226
-  examine: "This ladder leads down to the recruitment arena."
 - id: 20227
-  examine: "This ladder leads up to the barbarian military building."
 - id: 20228
-  examine: "This compost bin contains compostable items (8/15)."
 - id: 20229
-  examine: "The scroll has information on the quick-start room."
 - id: 20230
-  examine: "Sharp and pointy!"
 - id: 20231
-  examine: "Sharp and pointy!"
 - id: 20232
-  examine: "Hot, hot, hot!"
 - id: 20233
-  examine: "A crater filled with poison."
 - id: 20234
-  examine: "Hot and steamy lava!"
 - id: 20235
-  examine: "A deadly substance, to be sure!"
 - id: 20236
 - id: 20237
-  examine: "The Penance seem to come from here."
 - id: 20238
-  examine: "The barricade should stop the Penance...for now."
 - id: 20239
-  examine: "The Penance seem to come from here."
 - id: 20240
 - id: 20241
-  examine: "Provides items for the Attacker role."
 - id: 20242
-  examine: "Gives stuff for the Defender."
 - id: 20243
-  examine: "Anyone playing Healer can get items from here."
 - id: 20244
 - id: 20245
 - id: 20246
 - id: 20247
-  examine: "Don't be shy!"
 - id: 20248
 - id: 20249
 - id: 20250
-  examine: "Now that is just plain weird!"
 - id: 20251
-  examine: "Devoid of spiky bits."
 - id: 20252
 - id: 20253
 - id: 20254
@@ -31827,58 +29668,35 @@
 - id: 20257
 - id: 20258
 - id: 20259
-  examine: "Wow! I can fire eggs!"
 - id: 20260
-  examine: "I can put eggs in here."
 - id: 20261
-  examine: "I can put eggs in here."
 - id: 20262
-  examine: "I can put eggs in here."
 - id: 20263
-  examine: "Woo hoo! I can fire eggs!"
 - id: 20264
-  examine: "A hopper for eggs."
 - id: 20265
-  examine: "A hopper for eggs."
 - id: 20266
-  examine: "A hopper for eggs."
 - id: 20267
 - id: 20268
 - id: 20269
 - id: 20270
 - id: 20271
-  examine: "It's the floor..."
 - id: 20272
-  examine: "Looks suspicious."
 - id: 20273
-  examine: "Odd markings."
 - id: 20274
-  examine: "The trapdoor is shut tight."
 - id: 20275
-  examine: "Allows access to level below."
 - id: 20276
 - id: 20277
-  examine: "The trapdoor is shut tight."
 - id: 20278
-  examine: "Allows access to level below."
 - id: 20279
-  examine: "Allows access to level below."
 - id: 20280
-  examine: "Allows access to above level."
 - id: 20281
-  examine: "Allows access to above level."
 - id: 20282
 - id: 20283
 - id: 20284
-  examine: "Allows access to above level."
 - id: 20285
-  examine: "Allows access to level below."
 - id: 20286
-  examine: "Allows access to above level."
 - id: 20287
-  examine: "Allows access to level below."
 - id: 20288
-  examine: "Kaleef is dead, killed by some evil beast."
 - id: 20289
 - id: 20290
 - id: 20291
@@ -31888,13 +29706,9 @@
 - id: 20295
 - id: 20296
 - id: 20297
-  examine: "Now that's what I call slimline!"
 - id: 20298
-  examine: "He looks very relaxed."
 - id: 20299
-  examine: "Now he's just too thin."
 - id: 20300
-  examine: "He hasn't eaten in a long time."
 - id: 20301
 - id: 20302
 - id: 20303
@@ -31917,111 +29731,63 @@
 - id: 20320
 - id: 20321
 - id: 20322
-  examine: "A very solid stone door."
 - id: 20323
-  examine: "A private booth."
 - id: 20324
-  examine: "A private booth."
 - id: 20325
-  examine: "The bank teller will serve you from here."
 - id: 20326
-  examine: "This bank booth is too damaged to use."
 - id: 20327
-  examine: "This bank booth is too damaged to use."
 - id: 20328
-  examine: "This bank booth is too damaged to use."
 - id: 20329
-  examine: "A table."
 - id: 20330
-  examine: "A table."
 - id: 20331
-  examine: "A dagger market stall."
 - id: 20332
-  examine: "A market stall."
 - id: 20333
 - id: 20334
 - id: 20335
-  examine: "It's the floor..."
 - id: 20336
 - id: 20337
 - id: 20338
 - id: 20339
 - id: 20340
-  examine: "It's barricaded shut."
 - id: 20341
-  examine: "There's no way of getting in there."
 - id: 20342
-  examine: "Best used with a horse."
 - id: 20343
-  examine: "Best used with a horse."
 - id: 20344
-  examine: "Garments for the discerning."
 - id: 20345
-  examine: "Gone-off bread, cakes and pastries."
 - id: 20346
-  examine: "Finest precious stones."
 - id: 20347
-  examine: "These will keep you warm."
 - id: 20348
-  examine: "The spice is right."
 - id: 20349
-  examine: "An empty market stall."
 - id: 20350
-  examine: "Fine brews from exotic regions."
 - id: 20351
-  examine: "It's a small table."
 - id: 20352
-  examine: "Good for sitting on."
 - id: 20353
-  examine: "Allows access to above level."
 - id: 20354
-  examine: "Allows access to level below."
 - id: 20355
 - id: 20356
-  examine: "Allows access to above level."
 - id: 20357
-  examine: "Allows access to level below."
 - id: 20358
-  examine: "After working with livestock, why not wash your hands?"
 - id: 20359
-  examine: "A wooden wheelbarrow."
 - id: 20360
-  examine: "Work bench with clamps."
 - id: 20361
 - id: 20362
-  examine: "There are a few books on this shelf."
 - id: 20363
 - id: 20364
-  examine: "Tailor made for needlework supplies."
 - id: 20365
-  examine: "Used for spinning thread."
 - id: 20366
 - id: 20367
-  examine: "A wooden crate."
 - id: 20368
-  examine: "A wooden crate."
 - id: 20369
-  examine: "Some wooden boxes."
 - id: 20370
-  examine: "Dead tree parts piled together neatly."
 - id: 20371
-  examine: "Oops."
 - id: 20372
-  examine: "This old tree is rotting away."
 - id: 20373
-  examine: "Someone's been chopping logs."
 - id: 20374
-  examine: "Someone's been chopping logs."
 - id: 20375
-  examine: "Used for fashioning clay items."
 - id: 20376
-  examine: "I'm guessing it's for making women's clothes."
 - id: 20377
-  examine: "An altar."
 - id: 20378
-  examine: "An altar."
 - id: 20379
-  examine: "A broken altar."
 - id: 20380
 - id: 20381
 - id: 20382
@@ -32029,15 +29795,11 @@
 - id: 20384
 - id: 20385
 - id: 20386
-  examine: "Great for sleeping in."
 - id: 20387
-  examine: "Great for sleeping in."
 - id: 20388
-  examine: "Bits related to sewing."
 - id: 20389
 - id: 20390
 - id: 20391
-  examine: "Great."
 - id: 20392
 - id: 20393
 - id: 20394
@@ -32049,127 +29811,84 @@
 - id: 20400
 - id: 20401
 - id: 20402
-  examine: "Keeps mine carts from rolling away."
 - id: 20403
 - id: 20404
 - id: 20405
 - id: 20406
 - id: 20407
   depleted: 20440
-  examine: "A mineral vein."
 - id: 20408
   depleted: 20440
-  examine: "A mineral vein."
 - id: 20409
-  examine: "A mineral vein."
 - id: 20410
   depleted: 20441
-  examine: "A mineral vein."
 - id: 20411
   depleted: 20439
-  examine: "A mineral vein."
 - id: 20412
   depleted: 20442
-  examine: "A mineral vein."
 - id: 20413
   depleted: 20440
-  examine: "A mineral vein."
 - id: 20414
   depleted: 20441
-  examine: "A mineral vein."
 - id: 20415
   depleted: 20439
-  examine: "A mineral vein."
 - id: 20416
   depleted: 20442
-  examine: "A mineral vein."
 - id: 20417
   depleted: 20440
-  examine: "A mineral vein."
 - id: 20418
   depleted: 20441
-  examine: "A mineral vein."
 - id: 20419
   depleted: 20439
-  examine: "A mineral vein."
 - id: 20420
   depleted: 20442
-  examine: "A mineral vein."
 - id: 20421
   depleted: 20440
-  examine: "A mineral vein."
 - id: 20422
   depleted: 20441
-  examine: "A mineral vein."
 - id: 20423
   depleted: 20439
-  examine: "A mineral vein."
 - id: 20424
-  examine: "A mineral vein."
 - id: 20425
   depleted: 20440
-  examine: "A mineral vein."
 - id: 20426
-  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 20427
 - id: 20428
 - id: 20429
-  examine: "A wooden crate."
 - id: 20430
-  examine: "A wooden crate."
 - id: 20431
-  examine: "A wooden barrel for storage."
 - id: 20432
 - id: 20433
-  examine: "It looks cramped and dark."
 - id: 20434
 - id: 20435
-  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 20436
 - id: 20437
 - id: 20438
 - id: 20439
-  examine: "There is no ore currently available in this vein."
 - id: 20440
-  examine: "There is no ore currently available in this vein."
 - id: 20441
-  examine: "There is no ore currently available in this vein."
 - id: 20442
-  examine: "There is no ore currently available in this vein."
 - id: 20443
   depleted: 20441
-  examine: "A mineral vein."
 - id: 20444
   depleted: 20439
-  examine: "A mineral vein."
 - id: 20445
   depleted: 20442
-  examine: "A mineral vein."
 - id: 20446
   depleted: 20441
-  examine: "A mineral vein."
 - id: 20447
   depleted: 20439
-  examine: "A mineral vein."
 - id: 20448
   depleted: 20442
-  examine: "A mineral vein."
 - id: 20449
   depleted: 20441
-  examine: "A mineral vein."
 - id: 20450
   depleted: 20439
-  examine: "A mineral vein."
 - id: 20451
-  examine: "A mineral vein."
 - id: 20452
-  examine: "A passageway leading up."
 - id: 20453
-  examine: "A passageway leading up."
 - id: 20454
-  examine: "A passageway leading down."
 - id: 20455
-  examine: "A passageway leading down."
 - id: 20456
 - id: 20457
 - id: 20458
@@ -32197,191 +29916,98 @@
 - id: 20480
 - id: 20481
 - id: 20482
-  examine: "A passageway leading somewhere."
 - id: 20483
-  examine: "A passageway leading somewhere."
 - id: 20484
-  examine: "Stairs leading down."
 - id: 20485
-  examine: "A passageway leading somewhere."
 - id: 20486
-  examine: "Stairs leading down."
 - id: 20487
-  examine: "Stairs leading down."
 - id: 20488
-  examine: "A passageway leading somewhere."
 - id: 20489
-  examine: "A passageway leading somewhere."
 - id: 20490
-  examine: "A passageway leading somewhere."
 - id: 20491
-  examine: "A passageway leading somewhere."
 - id: 20492
-  examine: "A passageway leading somewhere."
 - id: 20493
-  examine: "A passageway leading somewhere."
 - id: 20494
-  examine: "Stairs leading down."
 - id: 20495
-  examine: "A passageway leading somewhere."
 - id: 20496
-  examine: "Stairs leading down."
 - id: 20497
-  examine: "A passageway leading down."
 - id: 20498
-  examine: "A passageway leading somewhere."
 - id: 20499
-  examine: "A passageway leading somewhere."
 - id: 20500
-  examine: "A passageway leading somewhere."
 - id: 20501
-  examine: "A passageway leading somewhere."
 - id: 20502
-  examine: "A passageway leading somewhere."
 - id: 20503
-  examine: "A passageway leading somewhere."
 - id: 20504
-  examine: "A passageway leading somewhere."
 - id: 20505
-  examine: "A passageway leading somewhere."
 - id: 20506
-  examine: "A passageway leading somewhere."
 - id: 20507
-  examine: "A passageway leading somewhere."
 - id: 20508
-  examine: "Stairs leading down."
 - id: 20509
-  examine: "A passageway leading somewhere."
 - id: 20510
-  examine: "A passageway leading somewhere."
 - id: 20511
-  examine: "A passageway leading somewhere."
 - id: 20512
-  examine: "A passageway leading somewhere."
 - id: 20513
-  examine: "A passageway leading somewhere."
 - id: 20514
-  examine: "A passageway leading somewhere."
 - id: 20515
-  examine: "A passageway leading somewhere."
 - id: 20516
-  examine: "A passageway leading somewhere."
 - id: 20517
-  examine: "A passageway leading somewhere."
 - id: 20518
-  examine: "A passageway leading somewhere."
 - id: 20519
-  examine: "A passageway leading somewhere."
 - id: 20520
-  examine: "A passageway leading somewhere."
 - id: 20521
-  examine: "A passageway leading somewhere."
 - id: 20522
-  examine: "A passageway leading somewhere."
 - id: 20523
-  examine: "A passageway leading somewhere."
 - id: 20524
-  examine: "A passageway leading somewhere."
 - id: 20525
-  examine: "A passageway leading somewhere."
 - id: 20526
-  examine: "A passageway leading somewhere."
 - id: 20527
-  examine: "A passageway leading somewhere."
 - id: 20528
-  examine: "A passageway leading somewhere."
 - id: 20529
-  examine: "A passageway leading somewhere."
 - id: 20530
-  examine: "A passageway leading somewhere."
 - id: 20531
-  examine: "A passageway leading somewhere."
 - id: 20532
-  examine: "A passageway leading somewhere."
 - id: 20533
-  examine: "A passageway leading somewhere."
 - id: 20534
-  examine: "A passageway leading somewhere."
 - id: 20535
-  examine: "A passageway leading somewhere."
 - id: 20536
-  examine: "A passageway leading somewhere."
 - id: 20537
-  examine: "A passageway leading somewhere."
 - id: 20538
-  examine: "A passageway leading somewhere."
 - id: 20539
-  examine: "A passageway leading somewhere."
 - id: 20540
-  examine: "A pillar I could stand on."
 - id: 20541
-  examine: "A pillar I could stand on."
 - id: 20542
-  examine: "A pillar I could stand on."
 - id: 20543
-  examine: "A pillar I could stand on."
 - id: 20544
-  examine: "A pillar I could stand on."
 - id: 20545
-  examine: "A pillar I could stand on."
 - id: 20546
-  examine: "A pillar I could stand on."
 - id: 20547
-  examine: "A pillar I could stand on."
 - id: 20548
-  examine: "A pillar I could stand on."
 - id: 20549
-  examine: "A pillar I could stand on."
 - id: 20550
-  examine: "A pillar I could stand on."
 - id: 20551
-  examine: "A pillar I could stand on."
 - id: 20552
-  examine: "A pillar I could stand on."
 - id: 20553
-  examine: "A pillar I could stand on."
 - id: 20554
-  examine: "A pillar I could stand on."
 - id: 20555
-  examine: "A pillar I could stand on."
 - id: 20556
-  examine: "A pillar I could stand on."
 - id: 20557
-  examine: "A pillar I could stand on."
 - id: 20558
-  examine: "This ledge is allegedly made of stone."
 - id: 20559
-  examine: "This ledge is allegedly made of stone."
 - id: 20560
-  examine: "This ledge is allegedly made of stone."
 - id: 20561
-  examine: "This ledge is allegedly made of stone."
 - id: 20562
-  examine: "This ledge is allegedly made of stone."
 - id: 20563
-  examine: "This ledge is allegedly made of stone."
 - id: 20564
-  examine: "This ledge is allegedly made of stone."
 - id: 20565
-  examine: "This ledge is allegedly made of stone."
 - id: 20566
-  examine: "This ledge is allegedly made of stone."
 - id: 20567
-  examine: "This ledge is allegedly made of stone."
 - id: 20568
-  examine: "This ledge is allegedly made of stone."
 - id: 20569
-  examine: "This ledge is allegedly made of stone."
 - id: 20570
-  examine: "Here to make the trap work."
 - id: 20571
-  examine: "Why would a log be hung up there?"
 - id: 20572
-  examine: "Why would a log be hung up there?"
 - id: 20573
-  examine: "Why would a log be hung up there?"
 - id: 20574
-  examine: "Why would a log be hung up there?"
 - id: 20575
 - id: 20576
 - id: 20577
@@ -32391,119 +30017,62 @@
 - id: 20581
 - id: 20582
 - id: 20583
-  examine: "There's something different about the floor."
 - id: 20584
-  examine: "There's something different about the floor."
 - id: 20585
-  examine: "There's something different about the floor."
 - id: 20586
-  examine: "There's something different about the floor."
 - id: 20587
-  examine: "There's something different about the floor."
 - id: 20588
-  examine: "Looks suspicious."
 - id: 20589
-  examine: "Looks suspicious."
 - id: 20590
-  examine: "Looks suspicious."
 - id: 20591
-  examine: "Looks suspicious."
 - id: 20592
-  examine: "Looks suspicious."
 - id: 20593
-  examine: "Looks suspicious."
 - id: 20594
-  examine: "Looks suspicious."
 - id: 20595
-  examine: "Looks suspicious."
 - id: 20596
-  examine: "Looks suspicious."
 - id: 20597
-  examine: "Looks suspicious."
 - id: 20598
-  examine: "Looks suspicious."
 - id: 20599
-  examine: "Looks suspicious."
 - id: 20600
-  examine: "Looks jammed."
 - id: 20601
-  examine: "Looks jammed."
 - id: 20602
-  examine: "Looks jammed."
 - id: 20603
-  examine: "Looks jammed."
 - id: 20604
-  examine: "Looks jammed."
 - id: 20605
-  examine: "Looks jammed."
 - id: 20606
-  examine: "Looks jammed."
 - id: 20607
-  examine: "Looks jammed."
 - id: 20608
-  examine: "Looks suspicious."
 - id: 20609
-  examine: "Looks suspicious."
 - id: 20610
-  examine: "Looks suspicious."
 - id: 20611
-  examine: "Looks suspicious."
 - id: 20612
-  examine: "Looks suspicious."
 - id: 20613
-  examine: "Looks suspicious."
 - id: 20614
-  examine: "Looks suspicious."
 - id: 20615
-  examine: "Looks suspicious."
 - id: 20616
-  examine: "Looks suspicious."
 - id: 20617
-  examine: "Looks suspicious."
 - id: 20618
-  examine: "Looks suspicious."
 - id: 20619
-  examine: "Looks suspicious."
 - id: 20620
-  examine: "Looks suspicious."
 - id: 20621
-  examine: "Looks suspicious."
 - id: 20622
-  examine: "Looks suspicious."
 - id: 20623
-  examine: "Looks suspicious."
 - id: 20624
-  examine: "Looks suspicious."
 - id: 20625
-  examine: "Looks suspicious."
 - id: 20626
-  examine: "Looks suspicious."
 - id: 20627
-  examine: "Looks suspicious."
 - id: 20628
-  examine: "Looks suspicious."
 - id: 20629
-  examine: "Looks suspicious."
 - id: 20630
-  examine: "Looks suspicious."
 - id: 20631
-  examine: "Looks suspicious."
 - id: 20632
-  examine: "Looks different."
 - id: 20633
-  examine: "Looks different."
 - id: 20634
-  examine: "Looks different."
 - id: 20635
-  examine: "Looks different."
 - id: 20636
-  examine: "Looks different."
 - id: 20637
-  examine: "Looks different."
 - id: 20638
-  examine: "Looks different."
 - id: 20639
-  examine: "Looks different."
 - id: 20640
 - id: 20641
 - id: 20642
@@ -32511,24 +30080,16 @@
 - id: 20644
 - id: 20645
 - id: 20646
-  examine: "Looks like one of Gianne Jr's deliveries didn't make it on time."
 - id: 20647
-  examine: "Someone could get their fingers caught in that."
 - id: 20648
-  examine: "It looks like something's been squashed by this."
 - id: 20649
-  examine: "It looks like something's been squashed by this."
 - id: 20650
-  examine: "It looks like something's been squashed by this."
 - id: 20651
-  examine: "It looks like something's been squashed by this."
 - id: 20652
-  examine: "Someone could get their fingers caught in that."
 - id: 20653
 - id: 20654
 - id: 20655
 - id: 20656
-  examine: "An oasis of peace in the nightmare of war."
 - id: 20657
 - id: 20658
 - id: 20659
@@ -32538,33 +30099,21 @@
 - id: 20663
 - id: 20664
 - id: 20665
-  examine: "A victim of war...looks like he's been dead a while now..."
 - id: 20666
-  examine: "Danger... weak surface beyond gate. Digging may lead to cave-ins."
 - id: 20667
-  examine: "I can climb these stairs."
 - id: 20668
-  examine: "I can climb these stairs."
 - id: 20669
-  examine: "I can climb these stairs."
 - id: 20670
-  examine: "I can climb these stairs."
 - id: 20671
-  examine: "I can climb these stairs."
 - id: 20672
-  examine: "I can climb these stairs."
 - id: 20673
-  examine: "I can climb this."
 - id: 20674
 - id: 20675
 - id: 20676
 - id: 20677
 - id: 20678
-  examine: "I wonder what is awaiting me on the other side?"
 - id: 20679
-  examine: "I wonder what is awaiting me on the other side?"
 - id: 20680
-  examine: "I wonder what is awaiting me on the other side?"
 - id: 20681
 - id: 20682
 - id: 20683
@@ -32582,11 +30131,8 @@
 - id: 20695
 - id: 20696
 - id: 20697
-  examine: "I wonder what awaits me on the other side?"
 - id: 20698
-  examine: "I wonder what awaits me on the other side?"
 - id: 20699
-  examine: "I wonder what awaits me on the other side?"
 - id: 20700
 - id: 20701
 - id: 20702
@@ -32604,26 +30150,17 @@
 - id: 20714
 - id: 20715
 - id: 20716
-  examine: "A crude torch stuck in the ground."
 - id: 20717
 - id: 20718
 - id: 20719
 - id: 20720
-  examine: "A large stone coffin."
 - id: 20721
-  examine: "A large stone coffin."
 - id: 20722
-  examine: "A large stone coffin."
 - id: 20723
-  examine: "A large stone chest."
 - id: 20724
-  examine: "A large stone chest."
 - id: 20725
-  examine: "Looks like he's been dead a while now..."
 - id: 20726
-  examine: "I don't think he'd mind us checking for his wallet now..."
 - id: 20727
-  examine: "I'm sure he died of natural causes. Like a massive dragon or something..."
 - id: 20728
 - id: 20729
 - id: 20730
@@ -32637,7 +30174,6 @@
 - id: 20738
 - id: 20739
 - id: 20740
-  examine: "The groundskeeper's bed."
 - id: 20741
 - id: 20742
 - id: 20743
@@ -32668,49 +30204,30 @@
 - id: 20768
 - id: 20769
 - id: 20770
-  examine: "A large stone coffin."
 - id: 20771
-  examine: "A large stone coffin."
 - id: 20772
-  examine: "A large stone coffin."
 - id: 20773
-  examine: "It's locked."
 - id: 20774
 - id: 20775
 - id: 20776
-  examine: "It might still work..."
 - id: 20777
 - id: 20778
 - id: 20779
 - id: 20780
-  examine: "I don't think he'd mind us checking for his wallet now..."
 - id: 20781
-  examine: "I'm sure he died of natural causes.  Like a massive dragon or something..."
 - id: 20782
-  examine: "A chain rope - looks pretty painful if you slip."
 - id: 20783
-  examine: "Looks pretty painful if you slip. Climb this to go back to the beginning of this level."
 - id: 20784
-  examine: "Spears make a good ladder it seems..."
 - id: 20785
-  examine: "Spears make a good ladder it seems..."
 - id: 20786
-  examine: "If you are of sufficient experience, you may take a shortcut through this level."
 - id: 20787
-  examine: "Danger - Possibly deadly creatures below!"
 - id: 20788
-  examine: "He looks a bit past it... wonder what's in his bag."
 - id: 20789
-  examine: "Part of Glough's advanced apparatus."
 - id: 20790
-  examine: "The entrance to the Stronghold of Security."
 - id: 20791
-  examine: "An empty barrel."
 - id: 20792
-  examine: "A barrel full of mushed apples."
 - id: 20793
 - id: 20794
-  examine: "This tap runs from the apple crushing barrel."
 - id: 20795
 - id: 20796
 - id: 20797
@@ -32718,101 +30235,61 @@
 - id: 20799
 - id: 20800
 - id: 20801
-  examine: "A mat for exercises."
 - id: 20802
-  examine: "I wonder if I can hit a bullseye?"
 - id: 20803
-  examine: "One of the most common trees in RuneScape."
 - id: 20804
-  examine: "A commonly found tree."
 - id: 20805
 - id: 20806
-  examine: "A beautiful old oak."
 - id: 20807
-  examine: "Hay There."
 - id: 20808
-  examine: "A pile of straw."
 - id: 20809
-  examine: "Some hay."
 - id: 20810
-  examine: "A mat for exercises."
 - id: 20811
-  examine: "Fairground style claw."
 - id: 20812
 - id: 20813
-  examine: "Claw control panel."
 - id: 20814
 - id: 20815
 - id: 20816
 - id: 20817
-  examine: "The door is closed."
 - id: 20818
 - id: 20819
 - id: 20820
-  examine: "Crates."
 - id: 20821
-  examine: "Crate."
 - id: 20822
 - id: 20823
-  examine: "Crates that smell."
 - id: 20824
-  examine: "Big rusty cogs."
 - id: 20825
-  examine: "Rusty machinery."
 - id: 20826
-  examine: "Someone certainly believes in having lots of barrels!"
 - id: 20827
-  examine: "An ale barrel."
 - id: 20828
-  examine: "If they store fish in this dirty old barrow, I hope they clean them later!"
 - id: 20829
 - id: 20830
 - id: 20831
 - id: 20832
 - id: 20833
 - id: 20834
-  examine: "Pile of sacks."
 - id: 20835
-  examine: "Pile of sacks."
 - id: 20836
-  examine: "Pull me!"
 - id: 20837
-  examine: "Doesn't look like the way out."
 - id: 20838
-  examine: "Doesn't look like the way out."
 - id: 20839
-  examine: "A glowing barrier of energy prevents your escape."
 - id: 20840
 - id: 20841
 - id: 20842
 - id: 20843
-  examine: "A portal back to the real world..."
 - id: 20844
-  examine: "One of the most common trees in RuneScape."
 - id: 20845
-  examine: "A commonly found tree."
 - id: 20846
-  examine: "Beehive part."
 - id: 20847
-  examine: "Beehive part."
 - id: 20848
-  examine: "Beehive part."
 - id: 20849
-  examine: "Beehive part."
 - id: 20850
-  examine: "Interface surround."
 - id: 20851
-  examine: "Button up."
 - id: 20852
-  examine: "Button down."
 - id: 20853
-  examine: "Button left."
 - id: 20854
-  examine: "Button right."
 - id: 20855
-  examine: "Button build."
 - id: 20856
-  examine: "A beehive."
 - id: 20857
 - id: 20858
 - id: 20859
@@ -32827,125 +30304,68 @@
 - id: 20868
 - id: 20869
 - id: 20870
-  examine: "This compost bin contains compostable items (9/15)."
 - id: 20871
-  examine: "This compost bin contains compostable items (10/15)."
 - id: 20872
-  examine: "This compost bin contains compostable items (11/15)."
 - id: 20873
-  examine: "Sturdy metal bars."
 - id: 20874
 - id: 20875
 - id: 20876
-  examine: "An overgrown dungeon entrance."
 - id: 20877
-  examine: "A closed overgrown dungeon entrance."
 - id: 20878
-  examine: "The way to go when I get scared."
 - id: 20879
 - id: 20880
 - id: 20881
 - id: 20882
-  examine: "I hope I don't fall off this."
 - id: 20883
 - id: 20884
-  examine: "I hope I don't fall off this."
 - id: 20885
-  examine: "Smells pretty bad!"
 - id: 20886
-  examine: "This compost bin contains compostable items (12/15)."
 - id: 20887
-  examine: "This compost bin contains compostable items (13/15)."
 - id: 20888
-  examine: "This compost bin contains compostable items (14/15)."
 - id: 20889
-  examine: "This compost bin is full of compostable items."
 - id: 20890
-  examine: "Vegetation is rotting in here to make compost."
 - id: 20891
-  examine: "The compost is ready."
 - id: 20892
-  examine: "This compost bin contains compost (1/15)."
 - id: 20893
-  examine: "This compost bin contains compost (2/15)."
 - id: 20894
-  examine: "This compost bin contains compost (3/15)."
 - id: 20895
-  examine: "This compost bin contains compost (4/15)."
 - id: 20896
-  examine: "This compost bin contains compost (5/15)."
 - id: 20897
-  examine: "This compost bin contains compost (6/15)."
 - id: 20898
-  examine: "This compost bin contains compost (7/15)."
 - id: 20899
-  examine: "This compost bin contains compost (8/15)."
 - id: 20900
-  examine: "This compost bin contains compost (9/15)."
 - id: 20901
-  examine: "This compost bin contains compost (10/15)."
 - id: 20902
-  examine: "This compost bin contains compost (11/15)."
 - id: 20903
-  examine: "This compost bin contains compost (12/15)."
 - id: 20904
-  examine: "This compost bin contains compost (13/15)."
 - id: 20905
-  examine: "This compost bin contains compost (14/15)."
 - id: 20906
-  examine: "This compost bin is full of compost."
 - id: 20907
-  examine: "This compost bin contains supercompostable items (1/15)."
 - id: 20908
-  examine: "This compost bin contains supercompostable items (2/15)."
 - id: 20909
-  examine: "This compost bin contains supercompostable items (3/15)."
 - id: 20910
-  examine: "This compost bin contains supercompostable items (4/15)."
 - id: 20911
-  examine: "This compost bin contains supercompostable items (5/15)."
 - id: 20912
-  examine: "This compost bin contains supercompostable items (6/15)."
 - id: 20913
-  examine: "This compost bin contains supercompostable items (7/15)."
 - id: 20914
-  examine: "This compost bin contains supercompostable items (8/15)."
 - id: 20915
-  examine: "This compost bin contains supercompostable items (9/15)."
 - id: 20916
-  examine: "This compost bin contains supercompostable items (10/15)."
 - id: 20917
-  examine: "This compost bin contains supercompostable items (11/15)."
 - id: 20918
-  examine: "This compost bin contains supercompostable items (12/15)."
 - id: 20919
-  examine: "This compost bin contains supercompostable items (13/15)."
 - id: 20920
-  examine: "This compost bin contains supercompostable items (14/15)."
 - id: 20921
-  examine: "This compost bin is full of supercompostable items."
 - id: 20922
-  examine: "Vegetation is rotting in here to make supercompost."
 - id: 20923
-  examine: "The supercompost is ready."
 - id: 20924
-  examine: "This compost bin contains supercompost (1/15)."
 - id: 20925
-  examine: "The door is closed."
 - id: 20926
-  examine: "I can see fish swimming in the water."
 - id: 20927
-  examine: "I can see fish swimming in the water."
 - id: 20928
-  examine: "I can see fish swimming in the water."
 - id: 20929
-  examine: "I can see fish swimming in the water."
 - id: 20930
-  examine: "I can see fish swimming in the water."
 - id: 20931
-  examine: "Ooh. It glows. Looks like an exit."
 - id: 20932
-  examine: "Ooh. It glows. Looks like an exit."
 - id: 20933
 - id: 20934
 - id: 20935
@@ -32960,24 +30380,16 @@
 - id: 20944
 - id: 20945
 - id: 20946
-  examine: "Anyone lost an ark?"
 - id: 20947
-  examine: "Phew, no evil ghosts in here..."
 - id: 20948
-  examine: "Looks like some sort of door."
 - id: 20949
-  examine: "Looks like some sort of door."
 - id: 20950
 - id: 20951
 - id: 20952
 - id: 20953
-  examine: "The bust of a Pharaoh. Busted."
 - id: 20954
-  examine: "The bust of a Pharaoh. Busted."
 - id: 20955
-  examine: "An obelisk littered with hieroglyphics."
 - id: 20956
-  examine: "I wonder where this leads."
 - id: 20957
 - id: 20958
 - id: 20959
@@ -32996,28 +30408,19 @@
 - id: 20972
 - id: 20973
 - id: 20974
-  examine: "I wonder where this leads."
 - id: 20975
-  examine: "I wonder where this leads."
 - id: 20976
-  examine: "I wonder where this leads."
 - id: 20977
-  examine: "I wonder where this leads."
 - id: 20978
-  examine: "I wonder where this leads."
 - id: 20979
-  examine: "I wonder where this leads."
 - id: 20980
 - id: 20981
 - id: 20982
 - id: 20983
 - id: 20984
 - id: 20985
-  examine: "A burned mummy."
 - id: 20986
-  examine: "A burned mummy."
 - id: 20987
-  examine: "I wonder where this leads."
 - id: 20988
 - id: 20989
 - id: 20990
@@ -33026,74 +30429,46 @@
 - id: 20993
 - id: 20994
 - id: 20995
-  examine: "So evil masterminds can get around."
 - id: 20996
-  examine: "Plotting time."
 - id: 20997
 - id: 20998
 - id: 20999
-  examine: "Sit down and chill."
 - id: 21000
-  examine: "Oh no, they try to take over Runescape!"
 - id: 21001
-  examine: "They put the terror into interrogation."
 - id: 21002
-  examine: "A steam generator."
 - id: 21003
 - id: 21004
 - id: 21005
 - id: 21006
 - id: 21007
 - id: 21008
-  examine: "A powerful drill."
 - id: 21009
-  examine: "A powerful lathe."
 - id: 21010
-  examine: "Oh my goodness!"
 - id: 21011
 - id: 21012
 - id: 21013
-  examine: "A mixture of ice and metal."
 - id: 21014
-  examine: "Empty."
 - id: 21015
-  examine: "A few crates."
 - id: 21016
-  examine: "It's a barrel."
 - id: 21017
 - id: 21018
-  examine: "For working at."
 - id: 21019
-  examine: "Lots of tools."
 - id: 21020
 - id: 21021
 - id: 21022
-  examine: "Too cold to sleep in."
 - id: 21023
-  examine: "Locked lockers."
 - id: 21024
-  examine: "Locked lockers."
 - id: 21025
-  examine: "A big violin."
 - id: 21026
-  examine: "Needs thumbs to play."
 - id: 21027
-  examine: "Hmm stringy."
 - id: 21028
-  examine: "Hard to play with flippers."
 - id: 21029
-  examine: "Miles Davis is looking for this..."
 - id: 21030
-  examine: "I only know chopsticks..."
 - id: 21031
-  examine: "A stool."
 - id: 21032
-  examine: "An overlooked instrument in jazz."
 - id: 21033
-  examine: "They've been discarded."
 - id: 21034
 - id: 21035
-  examine: "I can climb up."
 - id: 21036
 - id: 21037
 - id: 21038
@@ -33114,7 +30489,6 @@
 - id: 21053
 - id: 21054
 - id: 21055
-  examine: "Looks like it controls the doors."
 - id: 21056
 - id: 21057
 - id: 21058
@@ -33125,13 +30499,9 @@
 - id: 21063
 - id: 21064
 - id: 21065
-  examine: "Door-like."
 - id: 21066
-  examine: "Locked."
 - id: 21067
-  examine: "Locked."
 - id: 21068
-  examine: "Locked."
 - id: 21069
 - id: 21070
 - id: 21071
@@ -33149,22 +30519,16 @@
 - id: 21083
 - id: 21084
 - id: 21085
-  examine: "A gas powered light."
 - id: 21086
-  examine: "Might open the door."
 - id: 21087
 - id: 21088
 - id: 21089
 - id: 21090
 - id: 21091
 - id: 21092
-  examine: "It looks like they're trying to fly!"
 - id: 21093
-  examine: "It looks like they're trying to fly!"
 - id: 21094
-  examine: "It looks like they're trying to fly!"
 - id: 21095
-  examine: "Use this to get out of the water."
 - id: 21096
 - id: 21097
 - id: 21098
@@ -33176,9 +30540,7 @@
 - id: 21104
 - id: 21105
 - id: 21106
-  examine: "Start the course here."
 - id: 21107
-  examine: "It's pointing in the direction I should go."
 - id: 21108
 - id: 21109
 - id: 21110
@@ -33192,34 +30554,20 @@
 - id: 21118
 - id: 21119
 - id: 21120
-  examine: "For stepping on."
 - id: 21121
-  examine: "For stepping on."
 - id: 21122
-  examine: "For stepping on."
 - id: 21123
-  examine: "For stepping on."
 - id: 21124
-  examine: "For stepping on."
 - id: 21125
 - id: 21126
-  examine: "For stepping on."
 - id: 21127
-  examine: "For stepping on."
 - id: 21128
-  examine: "For stepping on."
 - id: 21129
-  examine: "For stepping on."
 - id: 21130
-  examine: "For stepping on."
 - id: 21131
-  examine: "For stepping on."
 - id: 21132
-  examine: "For stepping on."
 - id: 21133
-  examine: "For stepping on."
 - id: 21134
-  examine: "They look sharp."
 - id: 21135
 - id: 21136
 - id: 21137
@@ -33228,87 +30576,51 @@
 - id: 21140
 - id: 21141
 - id: 21142
-  examine: "Whee!"
 - id: 21143
-  examine: "Whee!"
 - id: 21144
 - id: 21145
 - id: 21146
 - id: 21147
-  examine: "It's a wooden platform."
 - id: 21148
-  examine: "It's sparkly."
 - id: 21149
-  examine: "It's sparkly."
 - id: 21150
-  examine: "It's sparkly."
 - id: 21151
-  examine: "It's sparkly."
 - id: 21152
-  examine: "It's sparkly."
 - id: 21153
-  examine: "It's sparkly."
 - id: 21154
-  examine: "It's sparkly."
 - id: 21155
-  examine: "It's sparkly."
 - id: 21156
-  examine: "It's sparkly."
 - id: 21157
-  examine: "A curious crack."
 - id: 21158
-  examine: "Looks curious."
 - id: 21159
-  examine: "Looks curious."
 - id: 21160
-  examine: "Door-like."
 - id: 21161
-  examine: "Door-like."
 - id: 21162
-  examine: "Door-like."
 - id: 21163
 - id: 21164
-  examine: "Door-like."
 - id: 21165
 - id: 21166
-  examine: "Locked."
 - id: 21167
-  examine: "Door-like."
 - id: 21168
 - id: 21169
-  examine: "Door-like."
 - id: 21170
-  examine: "Door-like."
 - id: 21171
-  examine: "Door-like."
 - id: 21172
-  examine: "A gate."
 - id: 21173
 - id: 21174
 - id: 21175
-  examine: "Sturdy looking."
 - id: 21176
-  examine: "Sturdy looking."
 - id: 21177
-  examine: "Sturdy looking."
 - id: 21178
 - id: 21179
-  examine: "A place to build a bird hide?"
 - id: 21180
-  examine: "Needs disguising."
 - id: 21181
-  examine: "I can spy from here!"
 - id: 21182
-  examine: "All my hard work ruined!"
 - id: 21183
-  examine: "Looks like penguin tracks."
 - id: 21184
-  examine: "Looks like penguin tracks."
 - id: 21185
-  examine: "Looks like penguin tracks."
 - id: 21186
 - id: 21187
-  examine: "It heads straight down."
 - id: 21188
 - id: 21189
 - id: 21190
@@ -33321,11 +30633,8 @@
 - id: 21197
 - id: 21198
 - id: 21199
-  examine: "It's feels fluffy."
 - id: 21200
-  examine: "It's feels fluffy."
 - id: 21201
-  examine: "Bunker doors."
 - id: 21202
 - id: 21203
 - id: 21204
@@ -33368,7 +30677,6 @@
 - id: 21241
 - id: 21242
 - id: 21243
-  examine: "Door-like."
 - id: 21244
 - id: 21245
 - id: 21246
@@ -33376,164 +30684,94 @@
 - id: 21248
 - id: 21249
 - id: 21250
-  examine: "Can convert eggs from one type to another."
 - id: 21251
-  examine: "I wonder where this leads."
 - id: 21252
-  examine: "I wonder where this leads."
 - id: 21253
-  examine: "I wonder where this leads."
 - id: 21254
-  examine: "I wonder where this leads."
 - id: 21255
-  examine: "What treasures does this sarcophagus contain?"
 - id: 21256
-  examine: "Has this sarcophagus been plundered yet?"
 - id: 21257
-  examine: "It's opening...."
 - id: 21258
-  examine: "It looks like a sarcophagus."
 - id: 21259
-  examine: "This looks like it was looted a long time ago."
 - id: 21260
-  examine: "It looks like a sarcophagus."
 - id: 21261
-  examine: "An ornate looking urn."
 - id: 21262
-  examine: "An ornate looking urn."
 - id: 21263
-  examine: "An ornate looking urn."
 - id: 21264
-  examine: "An empty urn."
 - id: 21265
-  examine: "An ornate looking urn."
 - id: 21266
-  examine: "An ornate looking urn."
 - id: 21267
-  examine: "An ornate looking urn."
 - id: 21268
-  examine: "A looted urn."
 - id: 21269
-  examine: "Ooh! It's got a snake in!"
 - id: 21270
-  examine: "Ooh! It's got a snake in!"
 - id: 21271
-  examine: "A place to cremate the dead. Needs a body."
 - id: 21272
-  examine: "A place to cremate the dead. Needs a light."
 - id: 21273
   depleted: 21274
-  examine: "Ooh! It's got a snake in!"
 - id: 21274
-  examine: "The stump of a pine tree."
 - id: 21275
   depleted: 450
-  examine: "Ooh! It's got a snake in!"
 - id: 21276
   depleted: 21297
-  examine: "Trust in me...."
 - id: 21277
   depleted: 21298
-  examine: "Trust in me...."
 - id: 21278
   depleted: 450
-  examine: "Trust in me...."
 - id: 21279
   depleted: 21297
-  examine: "Trust in me...."
 - id: 21280
   depleted: 21298
-  examine: "Potentially perforating."
 - id: 21281
   depleted: 450
-  examine: "This compost bin contains supercompost (2/15)."
 - id: 21282
   depleted: 21297
-  examine: "This compost bin contains supercompost (3/15)."
 - id: 21283
   depleted: 21298
-  examine: "This compost bin contains supercompost (4/15)."
 - id: 21284
   depleted: 450
-  examine: "This compost bin contains supercompost (5/15)."
 - id: 21285
   depleted: 21297
-  examine: "This compost bin contains supercompost (6/15)."
 - id: 21286
   depleted: 21298
-  examine: "This compost bin contains supercompost (7/15)."
 - id: 21287
   depleted: 450
-  examine: "This compost bin contains supercompost (8/15)."
 - id: 21288
   depleted: 21297
-  examine: "This compost bin contains supercompost (9/15)."
 - id: 21289
   depleted: 21298
-  examine: "This compost bin contains supercompost (10/15)."
 - id: 21290
-  examine: "This compost bin contains supercompost (11/15)."
 - id: 21291
-  examine: "This compost bin contains supercompost (12/15)."
 - id: 21292
-  examine: "This compost bin contains supercompost (13/15)."
 - id: 21293
   depleted: 450
-  examine: "This compost bin contains supercompost (14/15)."
 - id: 21294
   depleted: 21297
-  examine: "This compost bin is full of supercompost."
 - id: 21295
   depleted: 21298
-  examine: "This compost bin contains a tomato."
 - id: 21296
-  examine: "This compost bin contains two tomatoes."
 - id: 21297
-  examine: "This compost bin contains three tomatoes."
 - id: 21298
-  examine: "This compost bin contains four tomatoes."
 - id: 21299
-  examine: "Might be worth opening?"
 - id: 21300
-  examine: "Might be worth searching?"
 - id: 21301
-  examine: "An open bank chest."
 - id: 21302
-  examine: "Cook your food here."
 - id: 21303
-  examine: "For smelting metal."
 - id: 21304
-  examine: "For spinning things."
 - id: 21305
-  examine: "A stump on which wood is cut."
 - id: 21306
-  examine: "Bridge supports."
 - id: 21307
-  examine: "Bridge supports."
 - id: 21308
-  examine: "Bridge supports."
 - id: 21309
-  examine: "Bridge supports."
 - id: 21310
-  examine: "Bridge supports."
 - id: 21311
-  examine: "Bridge supports."
 - id: 21312
-  examine: "Bridge supports."
 - id: 21313
-  examine: "Bridge supports."
 - id: 21314
-  examine: "Bridge supports."
 - id: 21315
-  examine: "Bridge supports."
 - id: 21316
-  examine: "Bridge supports."
 - id: 21317
-  examine: "Bridge supports."
 - id: 21318
-  examine: "Bridge supports."
 - id: 21319
-  examine: "Bridge supports."
 - id: 21320
 - id: 21321
 - id: 21322
@@ -33555,13 +30793,9 @@
 - id: 21338
 - id: 21339
 - id: 21340
-  examine: "Sturdy wooden door."
 - id: 21341
-  examine: "Sturdy wooden door."
 - id: 21342
-  examine: "Sturdy wooden door."
 - id: 21343
-  examine: "Sturdy wooden door."
 - id: 21344
 - id: 21345
 - id: 21346
@@ -33573,22 +30807,14 @@
 - id: 21352
 - id: 21353
 - id: 21354
-  examine: "The ideal thing to sit on."
 - id: 21355
-  examine: "Warm water spouts from the ground."
 - id: 21356
-  examine: "Warm water source."
 - id: 21357
 - id: 21358
-  examine: "A bankers table."
 - id: 21359
-  examine: "It's a bit broken."
 - id: 21360
-  examine: "A table."
 - id: 21361
-  examine: "Not so good for sitting on."
 - id: 21362
-  examine: "It's a bed!"
 - id: 21363
 - id: 21364
 - id: 21365
@@ -33615,41 +30841,24 @@
 - id: 21386
 - id: 21387
 - id: 21388
-  examine: "A table with herbal equipment on it."
 - id: 21389
-  examine: "A table with carpentry tools on it."
 - id: 21390
-  examine: "Some farm sacks."
 - id: 21391
 - id: 21392
 - id: 21393
-  examine: "A Fremennik throne."
 - id: 21394
-  examine: "A warning bell."
 - id: 21395
-  examine: "I can climb this."
 - id: 21396
-  examine: "I can climb this."
 - id: 21397
-  examine: "A sturdy metal door."
 - id: 21398
-  examine: "A sturdy metal door."
 - id: 21399
-  examine: "A sturdy metal door."
 - id: 21400
-  examine: "A sturdy metal door."
 - id: 21401
-  examine: "A sturdy metal door."
 - id: 21402
-  examine: "A sturdy metal door."
 - id: 21403
-  examine: "A closed, sturdy metal door."
 - id: 21404
-  examine: "An open, sturdy metal door."
 - id: 21405
-  examine: "A closed, sturdy metal door."
 - id: 21406
-  examine: "An open, sturdy metal door."
 - id: 21407
 - id: 21408
 - id: 21409
@@ -33681,26 +30890,16 @@
 - id: 21435
 - id: 21436
 - id: 21437
-  examine: "A display case, full of axes."
 - id: 21438
-  examine: "A display case, full of swords."
 - id: 21439
-  examine: "A table, displaying swords."
 - id: 21440
 - id: 21441
-  examine: "A table for preparing fish."
 - id: 21442
-  examine: "A container for storing mineral ores."
 - id: 21443
-  examine: "A table for working with ores."
 - id: 21444
-  examine: "A pile of raw mineral ores."
 - id: 21445
-  examine: "A shield display."
 - id: 21446
-  examine: "A shield display."
 - id: 21447
-  examine: "A shelf, displaying armour."
 - id: 21448
 - id: 21449
 - id: 21450
@@ -33708,24 +30907,17 @@
 - id: 21452
 - id: 21453
 - id: 21454
-  examine: "A pile of rocks."
 - id: 21455
-  examine: "I can climb down these stairs."
 - id: 21456
 - id: 21457
 - id: 21458
 - id: 21459
-  examine: "A supporting arch."
 - id: 21460
-  examine: "A supporting arch."
 - id: 21461
-  examine: "A supporting arch."
 - id: 21462
 - id: 21463
 - id: 21464
-  examine: "A sturdy-looking throne."
 - id: 21465
-  examine: "A stone torch."
 - id: 21466
 - id: 21467
 - id: 21468
@@ -33761,33 +30953,21 @@
 - id: 21498
 - id: 21499
 - id: 21500
-  examine: "A banner bearing the Jatizso insignia."
 - id: 21501
-  examine: "A banner bearing the Neitiznot insignia."
 - id: 21502
 - id: 21503
 - id: 21504
 - id: 21505
-  examine: "Keeps the trolls out."
 - id: 21506
-  examine: "Doesn't keep the trolls out if it's open!"
 - id: 21507
-  examine: "Keeps the trolls out."
 - id: 21508
-  examine: "Doesn't keep the trolls out if it's open!"
 - id: 21509
-  examine: "Don't look down."
 - id: 21510
-  examine: "Really, don't look down."
 - id: 21511
 - id: 21512
-  examine: "Allows access to above level."
 - id: 21513
-  examine: "Allows access to level below."
 - id: 21514
-  examine: "Allows access to palisade walkway."
 - id: 21515
-  examine: "Allows access to the ground level."
 - id: 21516
 - id: 21517
 - id: 21518
@@ -33802,27 +30982,16 @@
 - id: 21527
 - id: 21528
 - id: 21529
-  examine: "Should I go down there?"
 - id: 21530
-  examine: "Should I go down there?"
 - id: 21531
-  examine: "Should I go down there?"
 - id: 21532
-  examine: "Should I go down there?"
 - id: 21533
-  examine: "Should I go down there?"
 - id: 21534
-  examine: "Should I go down there?"
 - id: 21535
-  examine: "Should I go down there?"
 - id: 21536
-  examine: "Should I go down there?"
 - id: 21537
-  examine: "Should I go down there?"
 - id: 21538
-  examine: "Should I go down there?"
 - id: 21539
-  examine: "Should I go down there?"
 - id: 21540
 - id: 21541
 - id: 21542
@@ -33844,7 +31013,6 @@
 - id: 21558
 - id: 21559
 - id: 21560
-  examine: "Return to the surface."
 - id: 21561
 - id: 21562
 - id: 21563
@@ -33854,102 +31022,60 @@
 - id: 21567
 - id: 21568
 - id: 21569
-  examine: "They grow well in the dark."
 - id: 21570
-  examine: "They grow well in the dark."
 - id: 21571
-  examine: "A rock."
 - id: 21572
-  examine: "A small rock."
 - id: 21573
-  examine: "A rock."
 - id: 21574
-  examine: "A pile of large rocks."
 - id: 21575
-  examine: "A pile of large rocks."
 - id: 21576
 - id: 21577
 - id: 21578
-  examine: "I can climb up these stairs."
 - id: 21579
 - id: 21580
-  examine: "Access to the caves."
 - id: 21581
-  examine: "Access to the caves."
 - id: 21582
-  examine: "Access to the caves."
 - id: 21583
-  examine: "Access to the caves."
 - id: 21584
-  examine: "Access to the caves."
 - id: 21585
-  examine: "Access to the caves."
 - id: 21586
-  examine: "Access to the caves."
 - id: 21587
-  examine: "Access to the caves."
 - id: 21588
-  examine: "Access to the caves."
 - id: 21589
-  examine: "Access to the caves."
 - id: 21590
-  examine: "Access to the caves."
 - id: 21591
-  examine: "The exit from the cave."
 - id: 21592
-  examine: "The exit from the cave."
 - id: 21593
-  examine: "A ladder leading down."
 - id: 21594
-  examine: "The exit from the cave."
 - id: 21595
-  examine: "The exit from the cave."
 - id: 21596
-  examine: "The exit from the cave."
 - id: 21597
-  examine: "The exit from the cave."
 - id: 21598
-  examine: "The exit from the cave."
 - id: 21599
-  examine: "The exit from the cave."
 - id: 21600
-  examine: "A flimsy, wooden gate."
 - id: 21601
-  examine: "An open gate."
 - id: 21602
 - id: 21603
-  examine: "A broken barrel and pieces of wood."
 - id: 21604
 - id: 21605
 - id: 21606
 - id: 21607
-  examine: "A chair made from stone."
 - id: 21608
-  examine: "A table with swords on it."
 - id: 21609
-  examine: "A table with plates and mugs on it."
 - id: 21610
-  examine: "A table with plates and mugs on it."
 - id: 21611
-  examine: "A bed to sleep in."
 - id: 21612
-  examine: "A stone crate with some stuff in it."
 - id: 21613
 - id: 21614
-  examine: "A shelf with some cups on it."
 - id: 21615
-  examine: "A shelf with some cups on it."
 - id: 21616
 - id: 21617
 - id: 21618
 - id: 21619
 - id: 21620
-  examine: "Firey."
 - id: 21621
 - id: 21622
-  examine: "Not so impressive anymore!"
 - id: 21623
-  examine: "Even less impressive!"
 - id: 21624
 - id: 21625
 - id: 21626
@@ -33961,13 +31087,9 @@
 - id: 21632
 - id: 21633
 - id: 21634
-  examine: "A short longboat!"
 - id: 21635
-  examine: "A Fremennik flag."
 - id: 21636
-  examine: "A Fremennik flag."
 - id: 21637
-  examine: "A Fremennik flag."
 - id: 21638
 - id: 21639
 - id: 21640
@@ -33998,63 +31120,34 @@
 - id: 21665
 - id: 21666
 - id: 21667
-  examine: "A shining light."
 - id: 21668
-  examine: "This compost bin contains five tomatoes."
 - id: 21669
-  examine: "This compost bin contains six tomatoes."
 - id: 21670
-  examine: "This compost bin contains seven tomatoes."
 - id: 21671
-  examine: "This compost bin contains eight tomatoes."
 - id: 21672
-  examine: "This compost bin contains nine tomatoes."
 - id: 21673
-  examine: "This compost bin contains ten tomatoes."
 - id: 21674
-  examine: "This compost bin contains eleven tomatoes."
 - id: 21675
-  examine: "This compost bin contains twelve tomatoes."
 - id: 21676
-  examine: "This compost bin contains thirteen tomatoes."
 - id: 21677
-  examine: "This compost bin contains fourteen tomatoes."
 - id: 21678
-  examine: "This compost bin contains fifteen tomatoes."
 - id: 21679
-  examine: "Tomatoes are rotting in here."
 - id: 21680
-  examine: "The rotten tomatoes are ready."
 - id: 21681
-  examine: "This compost bin contains a rotten tomato."
 - id: 21682
-  examine: "This compost bin contains two rotten tomatoes."
 - id: 21683
-  examine: "This compost bin contains three rotten tomatoes."
 - id: 21684
-  examine: "This compost bin contains four rotten tomatoes."
 - id: 21685
-  examine: "This compost bin contains five rotten tomatoes."
 - id: 21686
-  examine: "This compost bin contains six rotten tomatoes."
 - id: 21687
-  examine: "This compost bin contains seven rotten tomatoes."
 - id: 21688
-  examine: "This compost bin contains eight rotten tomatoes."
 - id: 21689
-  examine: "This compost bin contains nine rotten tomatoes."
 - id: 21690
-  examine: "This compost bin contains ten rotten tomatoes."
 - id: 21691
-  examine: "This compost bin contains eleven rotten tomatoes."
 - id: 21692
-  examine: "This compost bin contains twelve rotten tomatoes."
 - id: 21693
-  examine: "This compost bin contains thirteen rotten tomatoes."
 - id: 21694
-  examine: "This compost bin contains fourteen rotten tomatoes."
 - id: 21695
-  examine: "This compost bin contains fifteen rotten tomatoes."
 - id: 21696
 - id: 21697
 - id: 21698
@@ -34082,53 +31175,31 @@
 - id: 21720
 - id: 21721
 - id: 21722
-  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 21723
-  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 21724
-  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 21725
-  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 21726
-  examine: "These stairs seem to have been hewn out of the rock itself."
 - id: 21727
-  examine: "A pipe I can squeeze through."
 - id: 21728
-  examine: "A pipe I can squeeze through."
 - id: 21729
 - id: 21730
 - id: 21731
-  examine: "Thick vines blocking your way."
 - id: 21732
-  examine: "Thick vines blocking your way."
 - id: 21733
-  examine: "Thick vines blocking your way."
 - id: 21734
-  examine: "Thick vines blocking your way."
 - id: 21735
-  examine: "Thick vines blocking your way."
 - id: 21736
 - id: 21737
 - id: 21738
-  examine: "I can jump from this stepping stone."
 - id: 21739
-  examine: "I can jump from this stepping stone."
 - id: 21740
-  examine: "Not good for eating."
 - id: 21741
-  examine: "I doubt that's edible."
 - id: 21742
-  examine: "I doubt that's edible."
 - id: 21743
-  examine: "I doubt that's edible."
 - id: 21744
-  examine: "Now that's what I call slimline!"
 - id: 21745
-  examine: "He looks very relaxed."
 - id: 21746
-  examine: "Now he's just too thin."
 - id: 21747
-  examine: "He hasn't eaten in a long time."
 - id: 21748
 - id: 21749
 - id: 21750
@@ -34154,9 +31225,7 @@
 - id: 21770
 - id: 21771
 - id: 21772
-  examine: "A portcullis operated by a winch."
 - id: 21773
-  examine: "The skull of an archaic beast, it has devoured many souls."
 - id: 21774
 - id: 21775
 - id: 21776
@@ -34165,9 +31234,7 @@
 - id: 21779
 - id: 21780
 - id: 21781
-  examine: "I can climb this."
 - id: 21782
-  examine: "I can climb down this."
 - id: 21783
 - id: 21784
 - id: 21785
@@ -34178,24 +31245,17 @@
 - id: 21790
 - id: 21791
 - id: 21792
-  examine: "Ideal for Cooking on."
 - id: 21793
-  examine: "Four legs and a top."
 - id: 21794
-  examine: "Some cluttered shelves filled with potions and scrolls."
 - id: 21795
-  examine: "A fire burns brightly here."
 - id: 21796
 - id: 21797
 - id: 21798
 - id: 21799
 - id: 21800
-  examine: "A crack in the wall."
 - id: 21801
 - id: 21802
-  examine: "Now that's what I call slimline!"
 - id: 21803
-  examine: "He looks very relaxed."
 - id: 21804
 - id: 21805
 - id: 21806
@@ -34207,7 +31267,6 @@
 - id: 21812
 - id: 21813
 - id: 21814
-  examine: "This door is closed."
 - id: 21815
 - id: 21816
 - id: 21817
@@ -34238,17 +31297,11 @@
 - id: 21842
 - id: 21843
 - id: 21844
-  examine: "Like the building's arteries."
 - id: 21845
-  examine: "Like the building's arteries."
 - id: 21846
-  examine: "Like the building's arteries."
 - id: 21847
-  examine: "Like the building's arteries."
 - id: 21848
-  examine: "Like arteries."
 - id: 21849
-  examine: "Thou shalt not pass!"
 - id: 21850
 - id: 21851
 - id: 21852
@@ -34268,37 +31321,21 @@
 - id: 21866
 - id: 21867
 - id: 21868
-  examine: "Should I go down there? I think not!"
 - id: 21869
-  examine: "It's fixed now."
 - id: 21870
-  examine: "Looks half finished."
 - id: 21871
-  examine: "They allow you to change altitude."
 - id: 21872
-  examine: "They allow you to change altitude."
 - id: 21873
-  examine: "Can I deal with the pressure?"
 - id: 21874
-  examine: "Seems they are adding some liquid here."
 - id: 21875
-  examine: "A water pipe. Plain and simple."
 - id: 21876
-  examine: "A water pipe. Plain and simple."
 - id: 21877
-  examine: "A water pipe. Plain and simple."
 - id: 21878
-  examine: "A water pipe. Plain and simple."
 - id: 21879
-  examine: "Doesn't look like it would actually melt anything."
 - id: 21880
-  examine: "Why do they build things like this?"
 - id: 21881
-  examine: "Seems fixed to me."
 - id: 21882
-  examine: "A sort of hollow rod."
 - id: 21883
-  examine: "A sort of hollow rod."
 - id: 21884
 - id: 21885
 - id: 21886
@@ -34306,13 +31343,10 @@
 - id: 21888
 - id: 21889
 - id: 21890
-  examine: "Looks strong enough to me."
 - id: 21891
 - id: 21892
 - id: 21893
-  examine: "A very nice altar."
 - id: 21894
-  examine: "It's ALIVE!"
 - id: 21895
 - id: 21896
 - id: 21897
@@ -34320,88 +31354,50 @@
 - id: 21899
 - id: 21900
 - id: 21901
-  examine: "What on RuneScape is that?"
 - id: 21902
-  examine: "A well of life."
 - id: 21903
-  examine: "A well of life."
 - id: 21904
-  examine: "A well of life."
 - id: 21905
-  examine: "Seems to be supplying some kind of essence."
 - id: 21906
-  examine: "That makes my stomach churn."
 - id: 21907
-  examine: "Doesn't look that comfortable."
 - id: 21908
-  examine: "Reminds me of a lucky dip."
 - id: 21909
-  examine: "Reminds me of a lucky dip."
 - id: 21910
-  examine: "Reminds me of a lucky dip."
 - id: 21911
-  examine: "Reminds me of a lucky dip."
 - id: 21912
-  examine: "Reminds me of a lucky dip."
 - id: 21913
-  examine: "Reminds me of a lucky dip."
 - id: 21914
-  examine: "Reminds me of a lucky dip."
 - id: 21915
-  examine: "Reminds me of a lucky dip."
 - id: 21916
-  examine: "Reminds me of a lucky dip."
 - id: 21917
-  examine: "Reminds me of a lucky dip."
 - id: 21918
-  examine: "Oh, oh, oh, it's magic!"
 - id: 21919
 - id: 21920
-  examine: "Now that's the most random thing I've ever seen."
 - id: 21921
-  examine: "I wonder what's under it?"
 - id: 21922
-  examine: "I wonder what's down there."
 - id: 21923
-  examine: "How sad..."
 - id: 21924
-  examine: "A leafy shrub."
 - id: 21925
-  examine: "A water pipe. Plain and simple."
 - id: 21926
-  examine: "A water pipe. Plain and simple."
 - id: 21927
 - id: 21928
 - id: 21929
-  examine: "This door is closed."
 - id: 21930
-  examine: "I wonder what was in it."
 - id: 21931
-  examine: "So sad... what a waste of life."
 - id: 21932
-  examine: "A table with shackles, one size fits all!"
 - id: 21933
-  examine: "Cascading retorts, function unknown."
 - id: 21934
-  examine: "Reminds me of the dentist."
 - id: 21935
-  examine: "Reminds me of the dentist."
 - id: 21936
-  examine: "Reminds me of the dentist."
 - id: 21937
-  examine: "More strange liquids and tools."
 - id: 21938
-  examine: "For storage."
 - id: 21939
-  examine: "For storage."
 - id: 21940
-  examine: "For storage."
 - id: 21941
 - id: 21942
 - id: 21943
 - id: 21944
 - id: 21945
-  examine: "Part of the lighthouse Light mechanism."
 - id: 21946
 - id: 21947
 - id: 21948
@@ -34464,7 +31460,6 @@
 - id: 22005
 - id: 22006
 - id: 22007
-  examine: "Looks like a door to me."
 - id: 22008
 - id: 22009
 - id: 22010
@@ -34549,143 +31544,79 @@
 - id: 22089
 - id: 22090
 - id: 22091
-  examine: "A wall."
 - id: 22092
-  examine: "A wall."
 - id: 22093
-  examine: "A wall."
 - id: 22094
-  examine: "A wall."
 - id: 22095
-  examine: "A wall."
 - id: 22096
-  examine: "A wall."
 - id: 22097
-  examine: "Sneaky little peephole..."
 - id: 22098
-  examine: "Hard rock."
 - id: 22099
-  examine: "Hard rock."
 - id: 22100
 - id: 22101
 - id: 22102
 - id: 22103
 - id: 22104
 - id: 22105
-  examine: "A wall."
 - id: 22106
-  examine: "A wall."
 - id: 22107
-  examine: "A wall."
 - id: 22108
-  examine: "A wall."
 - id: 22109
-  examine: "A collapsed wall."
 - id: 22110
-  examine: "A collapsed wall."
 - id: 22111
 - id: 22112
 - id: 22113
-  examine: "A door."
 - id: 22114
-  examine: "A door."
 - id: 22115
-  examine: "A door."
 - id: 22116
-  examine: "A door."
 - id: 22117
-  examine: "A door."
 - id: 22118
-  examine: "A door."
 - id: 22119
 - id: 22120
-  examine: "A bench."
 - id: 22121
-  examine: "Allows access to above level."
 - id: 22122
-  examine: "Allows access to level below."
 - id: 22123
-  examine: "A stand with lit candles and hymns written on paper."
 - id: 22124
-  examine: "A stand with lit candles."
 - id: 22125
-  examine: "A candle stand."
 - id: 22126
-  examine: "A bookcase."
 - id: 22127
-  examine: "A bookcase."
 - id: 22128
-  examine: "A bookcase."
 - id: 22129
-  examine: "A bookcase."
 - id: 22130
 - id: 22131
-  examine: "A bookcase."
 - id: 22132
-  examine: "A bed."
 - id: 22133
-  examine: "A bed."
 - id: 22134
-  examine: "A chest of drawers."
 - id: 22135
-  examine: "A chest of drawers."
 - id: 22136
-  examine: "A chest of drawers."
 - id: 22137
-  examine: "A chest of drawers."
 - id: 22138
-  examine: "A chest of drawers."
 - id: 22139
-  examine: "A chest of drawers."
 - id: 22140
-  examine: "A chest of drawers."
 - id: 22141
-  examine: "A chest of drawers."
 - id: 22142
-  examine: "A chest of drawers."
 - id: 22143
-  examine: "A chest of drawers."
 - id: 22144
-  examine: "A nice-looking wardrobe."
 - id: 22145
-  examine: "A nice-looking wardrobe."
 - id: 22146
-  examine: "A nice-looking wardrobe."
 - id: 22147
-  examine: "A nice-looking wardrobe."
 - id: 22148
-  examine: "A nice-looking wardrobe."
 - id: 22149
-  examine: "A nice-looking wardrobe."
 - id: 22150
-  examine: "A nice-looking wardrobe."
 - id: 22151
-  examine: "A nice-looking wardrobe."
 - id: 22152
-  examine: "A nice-looking wardrobe."
 - id: 22153
-  examine: "A nice-looking wardrobe."
 - id: 22154
-  examine: "An appliance used for cooking."
 - id: 22155
-  examine: "A clock."
 - id: 22156
-  examine: "A chair."
 - id: 22157
-  examine: "A chair."
 - id: 22158
-  examine: "A bench."
 - id: 22159
-  examine: "A table."
 - id: 22160
-  examine: "A table."
 - id: 22161
-  examine: "A potted plant."
 - id: 22162
-  examine: "A larder."
 - id: 22163
 - id: 22164
-  examine: "Allows access to level below."
 - id: 22165
 - id: 22166
 - id: 22167
@@ -34694,9 +31625,7 @@
 - id: 22170
 - id: 22171
 - id: 22172
-  examine: "Allows access to above level."
 - id: 22173
-  examine: "Allows access to the basement."
 - id: 22174
 - id: 22175
 - id: 22176
@@ -34771,19 +31700,13 @@
 - id: 22245
 - id: 22246
 - id: 22247
-  examine: "Stairs leading up."
 - id: 22248
-  examine: "Stairs leading up."
 - id: 22249
 - id: 22250
-  examine: "Stairs leading up."
 - id: 22251
 - id: 22252
-  examine: "Stairs leading down."
 - id: 22253
-  examine: "Stairs leading down."
 - id: 22254
-  examine: "Stairs leading down."
 - id: 22255
 - id: 22256
 - id: 22257
@@ -34800,32 +31723,19 @@
 - id: 22268
 - id: 22269
 - id: 22270
-  examine: "The steering wheel was probably here once."
 - id: 22271
-  examine: "A cannon."
 - id: 22272
-  examine: "A cannon."
 - id: 22273
-  examine: "A broken cannon."
 - id: 22274
-  examine: "A ladder leading up to the deck of the ship."
 - id: 22275
-  examine: "A ladder leading down to the hull of the ship."
 - id: 22276
 - id: 22277
-  examine: "A wooden crate."
 - id: 22278
-  examine: "A wooden barrel for storage."
 - id: 22279
-  examine: "A wooden barrel for storage."
 - id: 22280
-  examine: "A wooden barrel for storage."
 - id: 22281
-  examine: "There is no way in."
 - id: 22282
-  examine: "There is no way in."
 - id: 22283
-  examine: "There is no way in."
 - id: 22284
 - id: 22285
 - id: 22286
@@ -34841,15 +31751,10 @@
 - id: 22296
 - id: 22297
 - id: 22298
-  examine: "Stores items."
 - id: 22299
-  examine: "Stores items."
 - id: 22300
-  examine: "Baby bread."
 - id: 22301
-  examine: "Cabbage...yuck!"
 - id: 22302
-  examine: "I can climb over the fence with this."
 - id: 22303
 - id: 22304
 - id: 22305
@@ -34900,11 +31805,8 @@
 - id: 22350
 - id: 22351
 - id: 22352
-  examine: "A statue."
 - id: 22353
-  examine: "A statue."
 - id: 22354
-  examine: "A statue."
 - id: 22355
 - id: 22356
 - id: 22357
@@ -34916,182 +31818,98 @@
 - id: 22363
 - id: 22364
 - id: 22365
-  examine: "These look a little waterlogged."
 - id: 22366
-  examine: "Nice handiwork there."
 - id: 22367
-  examine: "I hope these haven't been tampered with..."
 - id: 22368
-  examine: "More than a little rickety."
 - id: 22369
-  examine: "Seem a lot sturdier now."
 - id: 22370
 - id: 22371
-  examine: "A ladder leading up."
 - id: 22372
-  examine: "A ladder leading up."
 - id: 22373
-  examine: "Well built granary."
 - id: 22374
-  examine: "Well built granary."
 - id: 22375
-  examine: "Well built granary."
 - id: 22376
-  examine: "Well built granary."
 - id: 22377
-  examine: "Well built granary."
 - id: 22378
-  examine: "Well built granary."
 - id: 22379
-  examine: "Well built granary."
 - id: 22380
-  examine: "Well built granary."
 - id: 22381
 - id: 22382
 - id: 22383
 - id: 22384
 - id: 22385
-  examine: "Well built granary."
 - id: 22386
-  examine: "Well built granary."
 - id: 22387
-  examine: "Well built granary."
 - id: 22388
-  examine: "Well built granary."
 - id: 22389
-  examine: "Well built granary."
 - id: 22390
-  examine: "Well built granary."
 - id: 22391
-  examine: "Well built granary."
 - id: 22392
-  examine: "Well built granary."
 - id: 22393
-  examine: "Well built granary."
 - id: 22394
-  examine: "Well built granary."
 - id: 22395
-  examine: "Well built granary."
 - id: 22396
-  examine: "Well built granary."
 - id: 22397
-  examine: "Well built granary."
 - id: 22398
-  examine: "Well built granary."
 - id: 22399
-  examine: "Well built granary."
 - id: 22400
-  examine: "Well built granary."
 - id: 22401
-  examine: "Well built granary."
 - id: 22402
-  examine: "Well built granary."
 - id: 22403
-  examine: "Well built granary."
 - id: 22404
-  examine: "Well built granary."
 - id: 22405
-  examine: "Well built granary."
 - id: 22406
-  examine: "Well built granary."
 - id: 22407
-  examine: "Well built granary."
 - id: 22408
-  examine: "Well built granary."
 - id: 22409
-  examine: "Well built granary."
 - id: 22410
-  examine: "Well built granary."
 - id: 22411
-  examine: "Well built granary."
 - id: 22412
-  examine: "Well built granary."
 - id: 22413
-  examine: "Well built granary."
 - id: 22414
-  examine: "Well built granary."
 - id: 22415
-  examine: "Well built granary."
 - id: 22416
-  examine: "Well built granary."
 - id: 22417
-  examine: "Well built granary."
 - id: 22418
-  examine: "These sails use the wind to drive the windmill."
 - id: 22419
-  examine: "These huge stone discs grind grain to make flour."
 - id: 22420
-  examine: "When I've ground some flour, I'll be able to collect it here."
 - id: 22421
-  examine: "I'll need an empty pot so I can collect my flour."
 - id: 22422
-  examine: "Grain can be put in here for milling."
 - id: 22423
 - id: 22424
-  examine: "This lever will dump the hopper's contents into the mill works."
 - id: 22425
 - id: 22426
-  examine: "A wooden crate."
 - id: 22427
-  examine: "A wooden crate."
 - id: 22428
 - id: 22429
 - id: 22430
-  examine: "Full of animal feed."
 - id: 22431
-  examine: "A table."
 - id: 22432
-  examine: "I can climb this."
 - id: 22433
-  examine: "I can climb this."
 - id: 22434
-  examine: "I can climb this."
 - id: 22435
-  examine: "A large double door."
 - id: 22436
-  examine: "A large double door."
 - id: 22437
-  examine: "A large double door."
 - id: 22438
-  examine: "A large double door."
 - id: 22439
-  examine: "A black rock wall with some more recent repairs."
 - id: 22440
-  examine: "A black rock wall with some more recent repairs."
 - id: 22441
-  examine: "A black rock wall with some more recent repairs."
 - id: 22442
-  examine: "A black rock wall with some more recent repairs."
 - id: 22443
-  examine: "A black rock wall with some more recent repairs."
 - id: 22444
-  examine: "A black rock wall with some more recent repairs."
 - id: 22445
-  examine: "A black rock wall with some more recent repairs."
 - id: 22446
-  examine: "A black rock wall with some more recent repairs."
 - id: 22447
-  examine: "A black rock wall with some more recent repairs."
 - id: 22448
-  examine: "A black rock wall with some more recent repairs."
 - id: 22449
-  examine: "A black rock wall with some more recent repairs."
 - id: 22450
-  examine: "A black rock wall with some more recent repairs."
 - id: 22451
-  examine: "A black rock wall with some more recent repairs."
 - id: 22452
-  examine: "A black rock wall with some more recent repairs."
 - id: 22453
-  examine: "A crate with the top off."
 - id: 22454
-  examine: "A crate with the top off."
 - id: 22455
-  examine: "A crate with the top off."
 - id: 22456
-  examine: "You are not worthy... yet."
 - id: 22457
-  examine: "A wooden crate."
 - id: 22458
 - id: 22459
 - id: 22460
@@ -35107,31 +31925,18 @@
 - id: 22470
 - id: 22471
 - id: 22472
-  examine: "A lectern."
 - id: 22473
-  examine: "Baby bread."
 - id: 22474
-  examine: "Baby bread."
 - id: 22475
-  examine: "Baby bread."
 - id: 22476
-  examine: "Baby bread."
 - id: 22477
-  examine: "A collapsed door."
 - id: 22478
-  examine: "A collapsed wall."
 - id: 22479
-  examine: "A collapsed wall."
 - id: 22480
-  examine: "A collapsed wall."
 - id: 22481
-  examine: "A collapsed wall."
 - id: 22482
-  examine: "A collapsed wall."
 - id: 22483
-  examine: "Can be lit."
 - id: 22484
-  examine: "Can be lit."
 - id: 22485
 - id: 22486
 - id: 22487
@@ -35144,146 +31949,86 @@
 - id: 22494
 - id: 22495
 - id: 22496
-  examine: "A path leading out of this swampy dead end."
 - id: 22497
-  examine: "Marv - he looks sick."
 - id: 22498
-  examine: "Marv - He looks very sick - scary!"
 - id: 22499
-  examine: "Marv - He'd look sick, if he resembled a human!"
 - id: 22500
-  examine: "Marv - he looks sick."
 - id: 22501
-  examine: "Marv - He looks very sick - scary!"
 - id: 22502
-  examine: "Marv - He'd look sick, if he resembled a human!"
 - id: 22503
-  examine: "Marv - He looks much better now."
 - id: 22504
-  examine: "Hank - he looks sick."
 - id: 22505
-  examine: "Hank - He looks very sick - scary!"
 - id: 22506
-  examine: "Hank - He'd look sick, if he resembled a human!"
 - id: 22507
-  examine: "Hank - he looks sick."
 - id: 22508
-  examine: "Hank - He looks very sick - scary!"
 - id: 22509
-  examine: "Hank - He'd look sick, if he resembled a human!"
 - id: 22510
-  examine: "Hank - He looks much better now."
 - id: 22511
-  examine: "Wilf - he looks sick."
 - id: 22512
-  examine: "Wilf - He looks very sick - scary!"
 - id: 22513
-  examine: "Wilf - He'd look sick, if he resembled a human!"
 - id: 22514
-  examine: "Wilf - he looks sick."
 - id: 22515
-  examine: "Wilf - He looks very sick - scary!"
 - id: 22516
-  examine: "Wilf - He'd look sick, if he resembled a human!"
 - id: 22517
-  examine: "Wilf - He looks much better now."
 - id: 22518
-  examine: "Sarah - she looks sick."
 - id: 22519
-  examine: "Sarah - She looks very sick - scary!"
 - id: 22520
-  examine: "Sarah - She'd look sick, if she resembled a human!"
 - id: 22521
-  examine: "Sarah - she looks sick."
 - id: 22522
-  examine: "Sarah - She looks very sick - scary!"
 - id: 22523
-  examine: "Sarah - She'd look sick, if she resembled a human!"
 - id: 22524
-  examine: "She seems to be all better."
 - id: 22525
-  examine: "Rachel - she looks sick."
 - id: 22526
-  examine: "Rachel - She looks very sick - scary!"
 - id: 22527
-  examine: "Rachel - She'd look sick, if she resembled a human!"
 - id: 22528
-  examine: "Rachel - she looks sick."
 - id: 22529
-  examine: "Rachel - She looks very sick - scary!"
 - id: 22530
-  examine: "Rachel - She'd look sick, if she resembled a human!"
 - id: 22531
-  examine: "Rachel - She looks much better now."
 - id: 22532
-  examine: "The body has totally disappeared."
 - id: 22533
-  examine: "This bridge is partially broken."
 - id: 22534
-  examine: "This bridge is slightly broken."
 - id: 22535
-  examine: "This bridge can be traversed safely."
 - id: 22536
 - id: 22537
 - id: 22538
 - id: 22539
 - id: 22540
 - id: 22541
-  examine: "A stalagmite protrudes from the floor."
 - id: 22542
-  examine: "A larger stalagmite."
 - id: 22543
-  examine: "Conjoined stalagmites."
 - id: 22544
 - id: 22545
-  examine: "That white dot looks like an eye!"
 - id: 22546
 - id: 22547
 - id: 22548
 - id: 22549
-  examine: "A big, slimy lump of rock."
 - id: 22550
-  examine: "A slimy lump of rock."
 - id: 22551
-  examine: "A slippery-looking rock."
 - id: 22552
-  examine: "A wall jutting out into the path."
 - id: 22553
 - id: 22554
 - id: 22555
 - id: 22556
-  examine: "A pipe I can squeeze through."
 - id: 22557
-  examine: "A tunnel I can squeeze through."
 - id: 22558
 - id: 22559
 - id: 22560
 - id: 22561
 - id: 22562
 - id: 22563
-  examine: "I could swing across this like monkey bars."
 - id: 22564
-  examine: "I could swing across this like monkey bars."
 - id: 22565
 - id: 22566
-  examine: "I could swing across this like monkey bars."
 - id: 22567
-  examine: "I could swing across this like monkey bars."
 - id: 22568
-  examine: "I can balance on this cable."
 - id: 22569
-  examine: "Maybe I could balance on this cable."
 - id: 22570
-  examine: "A broken lamppost with the cable leading to the other side."
 - id: 22571
-  examine: "A lamppost with a cable hanging down."
 - id: 22572
-  examine: "Maybe I could swing on this hanging cable."
 - id: 22573
 - id: 22574
 - id: 22575
 - id: 22576
-  examine: "Thick wire."
 - id: 22577
 - id: 22578
 - id: 22579
@@ -35297,11 +32042,8 @@
 - id: 22587
 - id: 22588
 - id: 22589
-  examine: "A pylon with a cable hanging down."
 - id: 22590
-  examine: "A pylon with a cable hanging down."
 - id: 22591
-  examine: "A very tall pylon."
 - id: 22592
 - id: 22593
 - id: 22594
@@ -35311,21 +32053,15 @@
 - id: 22598
 - id: 22599
 - id: 22600
-  examine: "A slimy, stone ladder back up to Dorgesh-Kaan."
 - id: 22601
-  examine: "A slimy, stone ladder back up to Dorgesh-Kaan."
 - id: 22602
-  examine: "A slimy, stone ladder down to the cave floor."
 - id: 22603
 - id: 22604
 - id: 22605
 - id: 22606
 - id: 22607
-  examine: "Hot, metal stairs."
 - id: 22608
-  examine: "Hot, metal stairs."
 - id: 22609
-  examine: "Hot, metal stairs."
 - id: 22610
 - id: 22611
 - id: 22612
@@ -35341,9 +32077,7 @@
 - id: 22622
 - id: 22623
 - id: 22624
-  examine: "A large, dirty boiler."
 - id: 22625
-  examine: "What do they do?"
 - id: 22626
 - id: 22627
 - id: 22628
@@ -35353,9 +32087,7 @@
 - id: 22632
 - id: 22633
 - id: 22634
-  examine: "Looks like it hasn't been used for years."
 - id: 22635
-  examine: "Looks like it hasn't been used for years."
 - id: 22636
 - id: 22637
 - id: 22638
@@ -35370,414 +32102,222 @@
 - id: 22647
 - id: 22648
 - id: 22649
-  examine: "They're old, but I think they're safe."
 - id: 22650
-  examine: "They're old, but I think they're safe."
 - id: 22651
-  examine: "They're old, but I think they're safe."
 - id: 22652
 - id: 22653
 - id: 22654
 - id: 22655
 - id: 22656
-  examine: "Blocked up by huge bones and reinforced with metal!"
 - id: 22657
-  examine: "Blocked up by huge bones and reinforced with metal!"
 - id: 22658
-  examine: "Blocked up by huge bones and reinforced with metal!"
 - id: 22659
-  examine: "Blocked up by huge bones and reinforced with metal!"
 - id: 22660
 - id: 22661
 - id: 22662
 - id: 22663
-  examine: "I could fire a grapple at that..."
 - id: 22664
-  examine: "A buckled pylon leans over the middle of the chasm."
 - id: 22665
-  examine: "I could climb down but not back up."
 - id: 22666
-  examine: "I can climb down."
 - id: 22667
-  examine: "I could climb down here but not back up."
 - id: 22668
-  examine: "Kalphite Lair - mostly harmless."
 - id: 22669
-  examine: "A well-made bench."
 - id: 22670
-  examine: "A well-made stone stool."
 - id: 22671
-  examine: "A shelf with stuff on it."
 - id: 22672
-  examine: "A well-made stone table."
 - id: 22673
 - id: 22674
 - id: 22675
 - id: 22676
-  examine: "Looks comfy...for a goblin."
 - id: 22677
-  examine: "A well-made stone table."
 - id: 22678
-  examine: "A large ornate table."
 - id: 22679
-  examine: "An ornamented goblin bed."
 - id: 22680
-  examine: "A double-sized goblin bed. Looks comfy."
 - id: 22681
-  examine: "A metal bound stone chest."
 - id: 22682
-  examine: "A metal bound stone chest."
 - id: 22683
-  examine: "An open metal bound stone chest."
 - id: 22684
-  examine: "A solid stone ladder."
 - id: 22685
-  examine: "A shelf with various things on it."
 - id: 22686
-  examine: "A shelf with various things on it."
 - id: 22687
 - id: 22688
 - id: 22689
 - id: 22690
-  examine: "A standard stone table."
 - id: 22691
-  examine: "A standard stone stool."
 - id: 22692
-  examine: "A stone chair."
 - id: 22693
-  examine: "A standard stone table."
 - id: 22694
-  examine: "A large stone table."
 - id: 22695
-  examine: "A small single bed... Sleepy time!"
 - id: 22696
-  examine: "A large double bed... Double sleepy time!"
 - id: 22697
-  examine: "A stone chest."
 - id: 22698
-  examine: "A stone chest."
 - id: 22699
-  examine: "An open stone chest."
 - id: 22700
-  examine: "A makeshift bone ladder."
 - id: 22701
-  examine: "A shelf with various things on it."
 - id: 22702
-  examine: "A shelf with various things on it."
 - id: 22703
-  examine: "A chair for members of the Dorgeshuun Council."
 - id: 22704
-  examine: "A chair for the head of the Dorgeshuun Council."
 - id: 22705
-  examine: "The councillors of Dorgeshuun use this huge stone table."
 - id: 22706
-  examine: "Dorgeshuun symbols are carved into the wall."
 - id: 22707
-  examine: "Dorgeshuun symbols are carved into the wall."
 - id: 22708
-  examine: "Dorgeshuun symbols are carved into the wall."
 - id: 22709
-  examine: "A revered member of the Council, carved in stone."
 - id: 22710
-  examine: "A revered member of the Council, carved in stone."
 - id: 22711
-  examine: "A former head of the Council, carved in stone."
 - id: 22712
-  examine: "A former head of the Council, carved in stone."
 - id: 22713
-  examine: "Be careful; it's hot!"
 - id: 22714
-  examine: "Be careful; it's hot!"
 - id: 22715
-  examine: "A busy goblin has left the sink running."
 - id: 22716
-  examine: "For the preparation of scrummy food."
 - id: 22717
-  examine: "They are suspended from the wall."
 - id: 22718
-  examine: "Cluttered stone shelves."
 - id: 22719
-  examine: "Messy!"
 - id: 22720
-  examine: "The bowl on the shelf has been inverted."
 - id: 22721
-  examine: "A very hot furnace."
 - id: 22722
-  examine: "Used to fan the flames."
 - id: 22723
-  examine: "Carries the smoke to the roof of the cavern."
 - id: 22724
-  examine: "It keeps the room warm."
 - id: 22725
-  examine: "Three anvils in one."
 - id: 22726
-  examine: "A sandpit used for glassmaking."
 - id: 22727
-  examine: "Smmmokin'!"
 - id: 22728
-  examine: "Noisy and dangerous; don't get too close."
 - id: 22729
-  examine: "Noisy and dangerous; don't get too close."
 - id: 22730
-  examine: "The wire is collected here."
 - id: 22731
-  examine: "The wire is collected here."
 - id: 22732
-  examine: "The guard is there for a reason."
 - id: 22733
-  examine: "Bad for your health, kids!"
 - id: 22734
-  examine: "They'll eat your clothes."
 - id: 22735
-  examine: "A light that will zap those pesky flies."
 - id: 22736
-  examine: "A light that will zap those pesky flies."
 - id: 22737
-  examine: "A light that will zap those pesky flies."
 - id: 22738
-  examine: "A large metal lamppost."
 - id: 22739
-  examine: "A large metal lamppost."
 - id: 22740
-  examine: "A large metal lamppost."
 - id: 22741
-  examine: "A large metal lamppost."
 - id: 22742
-  examine: "A large metal lamppost."
 - id: 22743
-  examine: "A large metal lamppost."
 - id: 22744
-  examine: "A large metal lamppost."
 - id: 22745
-  examine: "A large metal lamppost."
 - id: 22746
-  examine: "A large metal lamppost."
 - id: 22747
-  examine: "A large metal lamppost."
 - id: 22748
-  examine: "A large metal lamppost."
 - id: 22749
-  examine: "A large metal lamppost."
 - id: 22750
-  examine: "The cable connects the lampposts."
 - id: 22751
-  examine: "The cable connects the lampposts."
 - id: 22752
-  examine: "The cable connects the lampposts."
 - id: 22753
-  examine: "The cable connects the lampposts."
 - id: 22754
-  examine: "The cable connects the lampposts."
 - id: 22755
-  examine: "The cable connects the lampposts."
 - id: 22756
-  examine: "The cable terminates here."
 - id: 22757
-  examine: "The cable goes into the wall here."
 - id: 22758
-  examine: "The cable goes into the wall here."
 - id: 22759
-  examine: "The cable goes into the wall here."
 - id: 22760
-  examine: "A bright light."
 - id: 22761
-  examine: "Powered by Dorgeshuun magic."
 - id: 22762
-  examine: "Powered by Dorgeshuun magic."
 - id: 22763
-  examine: "The magic orb has been removed."
 - id: 22764
-  examine: "Powered by Dorgeshuun magic."
 - id: 22765
-  examine: "Selling cave goblin fast food."
 - id: 22766
-  examine: "Selling cave goblin fast food."
 - id: 22767
-  examine: "Selling cave goblin fast food."
 - id: 22768
-  examine: "Selling cave goblin fast food."
 - id: 22769
-  examine: "Selling cave goblin fast food."
 - id: 22770
-  examine: "Selling cave goblin fast food."
 - id: 22771
-  examine: "An empty market stall."
 - id: 22772
-  examine: "Get your lamps here!"
 - id: 22773
-  examine: "A still for oil."
 - id: 22774
-  examine: "Get your armour here!"
 - id: 22775
-  examine: "To control the masses."
 - id: 22776
-  examine: "To control the masses."
 - id: 22777
 - id: 22778
-  examine: "Lets the littlest goblins out of their enclosure."
 - id: 22779
-  examine: "Keeps the littlest goblins in their enclosure."
 - id: 22780
 - id: 22781
-  examine: "You would need mini fillets to use it."
 - id: 22782
-  examine: "Looks like the real thing."
 - id: 22783
-  examine: "Looks like the real thing."
 - id: 22784
-  examine: "The runes look familiar."
 - id: 22785
-  examine: "The runes look familiar."
 - id: 22786
-  examine: "The runes look familiar."
 - id: 22787
-  examine: "It has been carved from stone."
 - id: 22788
-  examine: "It must mean something."
 - id: 22789
-  examine: "Strange symbols."
 - id: 22790
-  examine: "What does it mean?"
 - id: 22791
-  examine: "They have been chalked onto the floor."
 - id: 22792
-  examine: "Maybe it means something."
 - id: 22793
-  examine: "It looks as though it has been scuffed."
 - id: 22794
-  examine: "Each shape fits into a corresponding hole."
 - id: 22795
-  examine: "Each shape fits into a corresponding hole."
 - id: 22796
-  examine: "Not the kind you can eat."
 - id: 22797
-  examine: "Not the kind you can eat."
 - id: 22798
-  examine: "Not the kind you can eat."
 - id: 22799
-  examine: "Not the kind you can eat."
 - id: 22800
-  examine: "Not the kind you can eat."
 - id: 22801
-  examine: "Not the kind you can eat."
 - id: 22802
-  examine: "Not the kind you can eat."
 - id: 22803
-  examine: "Not the kind you can eat."
 - id: 22804
-  examine: "An albino fern."
 - id: 22805
-  examine: "A subterranean fern."
 - id: 22806
-  examine: "How does this plant photosynthesise?"
 - id: 22807
-  examine: "How does this plant photosynthesise?"
 - id: 22808
-  examine: "This plant is flowering."
 - id: 22809
-  examine: "It has a seed pod."
 - id: 22810
-  examine: "It contains lots of bones."
 - id: 22811
-  examine: "It has carved bone supports."
 - id: 22812
-  examine: "Quality bones are lined up on the rack."
 - id: 22813
-  examine: "These will be clubs one day."
 - id: 22814
-  examine: "Get your weapons here."
 - id: 22815
-  examine: "Get your weapons here."
 - id: 22816
-  examine: "Get your weapons here."
 - id: 22817
-  examine: "Get your weapons here."
 - id: 22818
-  examine: "Get your weapons here."
 - id: 22819
-  examine: "Deposit your monies here."
 - id: 22820
-  examine: "Banking business can be conducted here."
 - id: 22821
-  examine: "Banking business can be conducted here."
 - id: 22822
-  examine: "Looks very safe."
 - id: 22823
-  examine: "Looks dangerous."
 - id: 22824
-  examine: "Hair-raising."
 - id: 22825
-  examine: "It holds up the strange magic ball."
 - id: 22826
-  examine: "It looks really cool."
 - id: 22827
-  examine: "Fragile glass globes, a hammer and a vice?"
 - id: 22828
-  examine: "An interesting beetle that Zanik caught in the caves."
 - id: 22829
-  examine: "A trophy from Zanik's early frog-hunting days."
 - id: 22830
-  examine: "An ordinary table."
 - id: 22831
-  examine: "An ordinary table."
 - id: 22832
-  examine: "An ordinary table."
 - id: 22833
-  examine: "A shelf with some things that Zanik has collected."
 - id: 22834
-  examine: "A shelf with some things that Zanik has collected."
 - id: 22835
-  examine: "A large piece of fungus used as a seat."
 - id: 22836
-  examine: "This moth grew to giant size and Zanik hunted it down."
 - id: 22837
 - id: 22838
 - id: 22839
 - id: 22840
 - id: 22841
-  examine: "A bust of an important person."
 - id: 22842
-  examine: "A bust of an important person."
 - id: 22843
-  examine: "A very well-made chair."
 - id: 22844
-  examine: "A very well-made table."
 - id: 22845
-  examine: "A very well-made table."
 - id: 22846
-  examine: "A very well-made table."
 - id: 22847
-  examine: "The scribe has been writing here."
 - id: 22848
-  examine: "The scribe's notes are scattered across the table."
 - id: 22849
-  examine: "A table covered in scrolls and a pen."
 - id: 22850
 - id: 22851
 - id: 22852
 - id: 22853
 - id: 22854
 - id: 22855
-  examine: "A shelf of Dorgeshuun history books."
 - id: 22856
-  examine: "A squelchy fungus doormat."
 - id: 22857
-  examine: "Another squelchy fungus doormat."
 - id: 22858
-  examine: "Yet another squelchy fungus doormat."
 - id: 22859
-  examine: "A stack of storage crates."
 - id: 22860
-  examine: "A storage crate."
 - id: 22861
 - id: 22862
-  examine: "Water drips down this wall."
 - id: 22863
-  examine: "Water drips down this wall."
 - id: 22864
-  examine: "Water drips down this wall."
 - id: 22865
-  examine: "Water drips down this wall."
 - id: 22866
 - id: 22867
 - id: 22868
@@ -35826,18 +32366,14 @@
 - id: 22911
 - id: 22912
 - id: 22913
-  examine: "The door is open."
 - id: 22914
-  examine: "The door is closed."
 - id: 22915
 - id: 22916
 - id: 22917
 - id: 22918
 - id: 22919
 - id: 22920
-  examine: "The door is open."
 - id: 22921
-  examine: "The door is closed."
 - id: 22922
 - id: 22923
 - id: 22924
@@ -35848,34 +32384,20 @@
 - id: 22929
 - id: 22930
 - id: 22931
-  examine: "I wonder where they go."
 - id: 22932
-  examine: "I wonder where they go."
 - id: 22933
-  examine: "I wonder where they go."
 - id: 22934
-  examine: "Allows access to level above."
 - id: 22935
-  examine: "Allows access to level below."
 - id: 22936
-  examine: "Allows access to level below."
 - id: 22937
-  examine: "I wonder where they go."
 - id: 22938
-  examine: "I wonder where they go."
 - id: 22939
-  examine: "I wonder where they go."
 - id: 22940
-  examine: "I wonder where they go."
 - id: 22941
-  examine: "I wonder where they go."
 - id: 22942
-  examine: "I wonder where they go."
 - id: 22943
-  examine: "I wonder where they go."
 - id: 22944
 - id: 22945
-  examine: "Leads to the goblin caves."
 - id: 22946
 - id: 22947
 - id: 22948
@@ -35904,15 +32426,10 @@
 - id: 22971
 - id: 22972
 - id: 22973
-  examine: "A pretty water feature."
 - id: 22974
-  examine: "Mmmm...tasty frog roast?"
 - id: 22975
-  examine: "Bad for your health, kids."
 - id: 22976
-  examine: "Powered by Dorgeshuun magic."
 - id: 22977
-  examine: "The magic orb seems to be broken."
 - id: 22978
 - id: 22979
 - id: 22980
@@ -35978,51 +32495,31 @@
 - id: 23040
 - id: 23041
 - id: 23042
-  examine: "A blacksmith's hammer and tongs."
 - id: 23043
-  examine: "Some blacksmith tools hanging on the wall."
 - id: 23044
-  examine: "Stacked, ready to be forged."
 - id: 23045
-  examine: "These tools are well-used."
 - id: 23046
-  examine: "Not just made by man..."
 - id: 23047
 - id: 23048
 - id: 23049
 - id: 23050
 - id: 23051
 - id: 23052
-  examine: "Leads down to another part of the city."
 - id: 23053
 - id: 23054
-  examine: "This tree has been cut down."
 - id: 23055
-  examine: "A broken cart with nothing much in it."
 - id: 23056
-  examine: "The door is closed."
 - id: 23057
-  examine: "A statue of Saradomin."
 - id: 23058
-  examine: "A statue of Saradomin."
 - id: 23059
-  examine: "A statue."
 - id: 23060
-  examine: "A statue."
 - id: 23061
-  examine: "A tent."
 - id: 23062
-  examine: "A tent."
 - id: 23063
-  examine: "Looks like the fire has gone out."
 - id: 23064
-  examine: "Stores items."
 - id: 23065
-  examine: "A wooden stool."
 - id: 23066
-  examine: "A small wooden table."
 - id: 23067
-  examine: "A bed."
 - id: 23068
 - id: 23069
 - id: 23070
@@ -36030,7 +32527,6 @@
 - id: 23072
 - id: 23073
 - id: 23074
-  examine: "Stairs leading upwards out of the tunnel."
 - id: 23075
 - id: 23076
 - id: 23077
@@ -36048,28 +32544,20 @@
 - id: 23089
 - id: 23090
 - id: 23091
-  examine: "A mountain of knowledge."
 - id: 23092
-  examine: "A mountain of knowledge."
 - id: 23093
-  examine: "A portal from this mystical place."
 - id: 23094
-  examine: "The floor."
 - id: 23095
-  examine: "A portal from this mystical place."
 - id: 23096
 - id: 23097
 - id: 23098
 - id: 23099
 - id: 23100
 - id: 23101
-  examine: "Helping lost souls complete their journey."
 - id: 23102
 - id: 23103
 - id: 23104
-  examine: "Turn to open the gate."
 - id: 23105
-  examine: "A wall of fire. Crossable... but painful."
 - id: 23106
 - id: 23107
 - id: 23108
@@ -36078,64 +32566,38 @@
 - id: 23111
 - id: 23112
 - id: 23113
-  examine: "Steam seems to be condensing into the pot. Neat trick!"
 - id: 23114
-  examine: "I can see fish swimming in the water. Well, they sort of look like fish..."
 - id: 23115
-  examine: "A portal that leads... somewhere?"
 - id: 23116
-  examine: "Part of Glough's advanced apparatus."
 - id: 23117
-  examine: "Looks like it's powering the incubation chambers around the room."
 - id: 23118
 - id: 23119
 - id: 23120
 - id: 23121
 - id: 23122
-  examine: "An odd-looking rock with a rope tied to it."
 - id: 23123
-  examine: "An odd-looking rock with a rope tied to it."
 - id: 23124
-  examine: "An odd-looking rock formation."
 - id: 23125
-  examine: "An odd-looking rock formation."
 - id: 23126
-  examine: "An odd-looking rock formation."
 - id: 23127
-  examine: "An odd-looking rock formation."
 - id: 23128
-  examine: "Holds the rope up. Hopefully."
 - id: 23129
-  examine: "Holds the rope up. Hopefully."
 - id: 23130
-  examine: "Holds the rope up. Hopefully."
 - id: 23131
-  examine: "Use this to swing over crevices."
 - id: 23132
-  examine: "Use this to swing over crevices."
 - id: 23133
-  examine: "This must be climbed over."
 - id: 23134
-  examine: "This must be climbed over."
 - id: 23135
-  examine: "This must be climbed over."
 - id: 23136
-  examine: "A pipe I can squeeze through."
 - id: 23137
-  examine: "A pipe I can squeeze through."
 - id: 23138
-  examine: "A pipe I can squeeze through."
 - id: 23139
-  examine: "A pipe I can squeeze through."
 - id: 23140
-  examine: "A pipe I can squeeze through."
 - id: 23141
 - id: 23142
 - id: 23143
 - id: 23144
-  examine: "A slippery log I can walk across."
 - id: 23145
-  examine: "A slippery log I can walk across."
 - id: 23146
 - id: 23147
 - id: 23148
@@ -36146,71 +32608,40 @@
 - id: 23153
 - id: 23154
 - id: 23155
-  examine: "A rock-locking wall."
 - id: 23156
-  examine: "There seem to be some levers here..."
 - id: 23157
-  examine: "Cave exit."
 - id: 23158
-  examine: "Cave exit."
 - id: 23159
 - id: 23160
 - id: 23161
 - id: 23162
 - id: 23163
-  examine: "A pile of large rocks."
 - id: 23164
-  examine: "A pile of large rocks."
 - id: 23165
-  examine: "A rock."
 - id: 23166
-  examine: "A cave."
 - id: 23167
-  examine: "A cave."
 - id: 23168
-  examine: "A cave."
 - id: 23169
-  examine: "A cave."
 - id: 23170
-  examine: "A cave."
 - id: 23171
-  examine: "A cave."
 - id: 23172
-  examine: "Dripping water seeping through the rocks above."
 - id: 23173
-  examine: "Dripping water seeping through the rocks above."
 - id: 23174
-  examine: "Old and rotten camping equipment."
 - id: 23175
-  examine: "Old and dead camp fire."
 - id: 23176
-  examine: "Old and rotten."
 - id: 23177
-  examine: "A broken and rotten table."
 - id: 23178
-  examine: "An old stool."
 - id: 23179
-  examine: "A broken stool."
 - id: 23180
-  examine: "A rotten barrel."
 - id: 23181
-  examine: "A rotten barrel."
 - id: 23182
-  examine: "A rotten barrel."
 - id: 23183
-  examine: "A rotten barrel."
 - id: 23184
-  examine: "A rotten barrel."
 - id: 23185
-  examine: "A wrecked longboat."
 - id: 23186
-  examine: "A wrecked longboat."
 - id: 23187
-  examine: "A wrecked longboat."
 - id: 23188
-  examine: "A wrecked longboat."
 - id: 23189
-  examine: "A wrecked longboat."
 - id: 23190
 - id: 23191
 - id: 23192
@@ -36219,7 +32650,6 @@
 - id: 23195
 - id: 23196
 - id: 23197
-  examine: "A very old gravestone."
 - id: 23198
 - id: 23199
 - id: 23200
@@ -36236,14 +32666,10 @@
 - id: 23211
 - id: 23212
 - id: 23213
-  examine: "A slippery walkway."
 - id: 23214
-  examine: "A slippery walkway."
 - id: 23215
 - id: 23216
-  examine: "A rusty gate."
 - id: 23217
-  examine: "A rusty gate."
 - id: 23218
 - id: 23219
 - id: 23220
@@ -36257,59 +32683,32 @@
 - id: 23228
 - id: 23229
 - id: 23230
-  examine: "A spooky, rotting longboat wreck."
 - id: 23231
-  examine: "A spooky, rotting longboat wreck."
 - id: 23232
-  examine: "A spooky, rotting longboat wreck."
 - id: 23233
-  examine: "A spooky, rotting longboat wreck."
 - id: 23234
-  examine: "A spooky, rotting longboat wreck."
 - id: 23235
-  examine: "A spooky, rotting longboat wreck."
 - id: 23236
-  examine: "A spooky, rotting longboat wreck."
 - id: 23237
-  examine: "A spooky, rotting longboat wreck."
 - id: 23238
-  examine: "A spooky, rotting longboat wreck."
 - id: 23239
-  examine: "A spooky, rotting longboat wreck."
 - id: 23240
-  examine: "A spooky, rotting longboat wreck."
 - id: 23241
-  examine: "A spooky, rotting longboat wreck."
 - id: 23242
-  examine: "A spooky, rotting longboat wreck."
 - id: 23243
-  examine: "A spooky, rotting longboat wreck."
 - id: 23244
-  examine: "A spooky, rotting longboat wreck."
 - id: 23245
-  examine: "A spooky, rotting longboat wreck."
 - id: 23246
-  examine: "A spooky, rotting longboat wreck."
 - id: 23247
-  examine: "A spooky, rotting longboat wreck."
 - id: 23248
-  examine: "A spooky, rotting longboat wreck."
 - id: 23249
-  examine: "A spooky, rotting longboat wreck."
 - id: 23250
-  examine: "A spooky, rotting longboat wreck."
 - id: 23251
-  examine: "A spooky, rotting longboat wreck."
 - id: 23252
-  examine: "A spooky, rotting longboat wreck."
 - id: 23253
-  examine: "A spooky, rotting longboat wreck."
 - id: 23254
-  examine: "A spooky, rotting longboat wreck."
 - id: 23255
-  examine: "A spooky, rotting longboat wreck."
 - id: 23256
-  examine: "A spooky, rotting longboat wreck."
 - id: 23257
 - id: 23258
 - id: 23259
@@ -36325,93 +32724,54 @@
 - id: 23269
 - id: 23270
 - id: 23271
-  examine: "Jump here."
 - id: 23272
 - id: 23273
 - id: 23274
-  examine: "A slippery log I can walk across."
 - id: 23275
-  examine: "A sign which seems to give a count of people who've left Burgh de Rott."
 - id: 23276
-  examine: "A sign which seems to give a count of Mercenaries taken to Burgh de Rott."
 - id: 23277
 - id: 23278
 - id: 23279
-  examine: "I can climb down this."
 - id: 23280
-  examine: "Some rocks."
 - id: 23281
-  examine: "The passageway has been blocked."
 - id: 23282
 - id: 23283
-  examine: "A wooden crate."
 - id: 23284
-  examine: "Zanik is tied up on the train tracks."
 - id: 23285
-  examine: "An exit leading to Dorgesh-Kaan."
 - id: 23286
-  examine: "An exit leading to Keldagrim."
 - id: 23287
-  examine: "Leads down to another part of the city."
 - id: 23288
-  examine: "Something is buried in the ground here."
 - id: 23289
-  examine: "You dug something up here."
 - id: 23290
 - id: 23291
-  examine: "Something is buried in the ground here."
 - id: 23292
-  examine: "You dug something up here."
 - id: 23293
 - id: 23294
-  examine: "Something is buried in the ground here."
 - id: 23295
-  examine: "You dug something up here."
 - id: 23296
 - id: 23297
-  examine: "Something is buried in the ground here."
 - id: 23298
-  examine: "You dug something up here."
 - id: 23299
-  examine: "Something is buried in the ground here."
 - id: 23300
-  examine: "You dug something up here."
 - id: 23301
 - id: 23302
-  examine: "Something is buried in the ground here."
 - id: 23303
-  examine: "You dug something up here."
 - id: 23304
 - id: 23305
-  examine: "A table used for cleaning artefacts."
 - id: 23306
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 23307
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 23308
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 23309
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 23310
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 23311
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 23312
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 23313
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 23314
-  examine: "A rowdy rabble of goblins. Boo hiss!"
 - id: 23315
-  examine: "Elated dwarves."
 - id: 23316
-  examine: "Elated dwarves."
 - id: 23317
-  examine: "Elated dwarves."
 - id: 23318
-  examine: "Important cave goblins."
 - id: 23319
-  examine: "Various cave goblins."
 - id: 23320
 - id: 23321
 - id: 23322
@@ -36431,38 +32791,26 @@
 - id: 23336
 - id: 23337
 - id: 23338
-  examine: "The door is closed."
 - id: 23339
-  examine: "The door is open."
 - id: 23340
-  examine: "A large double door."
 - id: 23341
-  examine: "A large double door."
 - id: 23342
-  examine: "A large double door."
 - id: 23343
-  examine: "A large double door."
 - id: 23344
 - id: 23345
 - id: 23346
 - id: 23347
 - id: 23348
-  examine: "A wall."
 - id: 23349
-  examine: "A wall."
 - id: 23350
-  examine: "A wall."
 - id: 23351
 - id: 23352
 - id: 23353
 - id: 23354
 - id: 23355
 - id: 23356
-  examine: "A wooden crate."
 - id: 23357
-  examine: "A wooden crate."
 - id: 23358
-  examine: "A wooden crate."
 - id: 23359
 - id: 23360
 - id: 23361
@@ -36471,7 +32819,6 @@
 - id: 23364
 - id: 23365
 - id: 23366
-  examine: "A wooden barrel for storage."
 - id: 23367
 - id: 23368
 - id: 23369
@@ -36482,16 +32829,11 @@
 - id: 23374
 - id: 23375
 - id: 23376
-  examine: "I can climb down this."
 - id: 23377
-  examine: "I can climb this."
 - id: 23378
-  examine: "The door is closed."
 - id: 23379
-  examine: "The door is open."
 - id: 23380
 - id: 23381
-  examine: "It's only useful for firewood now."
 - id: 23382
 - id: 23383
 - id: 23384
@@ -36610,14 +32952,11 @@
 - id: 23497
 - id: 23498
 - id: 23499
-  examine: "Leads back to the station."
 - id: 23500
-  examine: "The station is too far to walk."
 - id: 23501
 - id: 23502
 - id: 23503
 - id: 23504
-  examine: "I can climb this."
 - id: 23505
 - id: 23506
 - id: 23507
@@ -36640,21 +32979,13 @@
 - id: 23524
 - id: 23525
 - id: 23526
-  examine: "A couple of goblins brushing up samples."
 - id: 23527
-  examine: "A couple of goblins brushing up samples."
 - id: 23528
-  examine: "Something is buried in the ground here."
 - id: 23529
-  examine: "Something was buried in the ground here.."
 - id: 23530
-  examine: "A neatly stacked pair of crates."
 - id: 23531
-  examine: "It's the ladder up."
 - id: 23532
-  examine: "It's the ladder down."
 - id: 23533
-  examine: "A neatly stacked pair of crates."
 - id: 23534
 - id: 23535
 - id: 23536
@@ -36664,63 +32995,35 @@
 - id: 23540
 - id: 23541
 - id: 23542
-  examine: "A slippery log I can walk across."
 - id: 23543
-  examine: "The irregular surface can be climbed."
 - id: 23544
-  examine: "The irregular surface can be climbed."
 - id: 23545
-  examine: "The irregular surface can be climbed."
 - id: 23546
-  examine: "Tread carefully!"
 - id: 23547
-  examine: "Tread carefully!"
 - id: 23548
-  examine: "I can just about edge across here."
 - id: 23549
-  examine: "Pointy!"
 - id: 23550
-  examine: "Pointy!"
 - id: 23551
 - id: 23552
-  examine: "A wrought iron gate."
 - id: 23553
 - id: 23554
-  examine: "A wrought iron gate."
 - id: 23555
-  examine: "Solid bars of iron."
 - id: 23556
-  examine: "Hop, hop, hoppity hop, and then you fall in molten lava."
 - id: 23557
-  examine: "I can balance on this rope."
 - id: 23558
-  examine: "I can balance on this rope."
 - id: 23559
-  examine: "I can climb up this."
 - id: 23560
-  examine: "I can climb down here."
 - id: 23561
-  examine: "I can climb down here."
 - id: 23562
-  examine: "I can climb up these stairs."
 - id: 23563
-  examine: "I can climb up these rocks to another cave."
 - id: 23564
-  examine: "I can climb down these rocks to another cave."
 - id: 23565
-  examine: "I can traverse these."
 - id: 23566
-  examine: "I can traverse these."
 - id: 23567
-  examine: "I can traverse these."
 - id: 23568
-  examine: "Use this to swing across gaps."
 - id: 23569
-  examine: "Use this to swing across gaps."
 - id: 23570
-  examine: "Use this to swing across gaps."
 - id: 23571
-  examine: "I can swing on this tree."
 - id: 23572
 - id: 23573
 - id: 23574
@@ -36734,22 +33037,18 @@
 - id: 23582
 - id: 23583
 - id: 23584
-  examine: "I can climb this."
 - id: 23585
-  examine: "I can climb this."
 - id: 23586
 - id: 23587
 - id: 23588
 - id: 23589
 - id: 23590
 - id: 23591
-  examine: "The kalphite queen's old legs."
 - id: 23592
 - id: 23593
 - id: 23594
 - id: 23595
 - id: 23596
-  examine: "Looks like I could squeeze through here."
 - id: 23597
 - id: 23598
 - id: 23599
@@ -36760,20 +33059,16 @@
 - id: 23604
 - id: 23605
 - id: 23606
-  examine: "They might eventually reach the ceiling."
 - id: 23607
-  examine: "They might eventually reach the ceiling."
 - id: 23608
 - id: 23609
 - id: 23610
 - id: 23611
-  examine: "It's moving..."
 - id: 23612
 - id: 23613
 - id: 23614
 - id: 23615
 - id: 23616
-  examine: "A perfectly appointed rosebush."
 - id: 23617
 - id: 23618
 - id: 23619
@@ -36782,62 +33077,38 @@
 - id: 23622
 - id: 23623
 - id: 23624
-  examine: "A comfortable seat."
 - id: 23625
-  examine: "Wild cadava berries are growing here."
 - id: 23626
-  examine: "Wild cadava berries are growing here."
 - id: 23627
-  examine: "Wild cadava berries grow here."
 - id: 23628
-  examine: "Wild redberries are growing here."
 - id: 23629
-  examine: "Wild redberries are growing here."
 - id: 23630
-  examine: "Wild redberries grow here."
 - id: 23631
-  examine: "A solid looking door."
 - id: 23632
-  examine: "Many newspapers."
 - id: 23633
-  examine: "A wheelbarrow filled with the latest news."
 - id: 23634
-  examine: "The Shield of Arrav."
 - id: 23635
-  examine: "The Shield of Arrav."
 - id: 23636
-  examine: "A plaque with some engraved lettering."
 - id: 23637
-  examine: "The door to the Champions' Guild."
 - id: 23638
-  examine: "A branch protrudes here."
 - id: 23639
-  examine: "This tree has an unusually long branch on it."
 - id: 23640
-  examine: "A rocky outcrop."
 - id: 23641
 - id: 23642
 - id: 23643
 - id: 23644
-  examine: "A nearly rotten wooden log that crosses the river."
 - id: 23645
-  examine: "A rocky outcrop from the running water."
 - id: 23646
-  examine: "A rocky outcrop from the running water."
 - id: 23647
-  examine: "A rocky outcrop from the running water."
 - id: 23648
 - id: 23649
 - id: 23650
 - id: 23651
 - id: 23652
 - id: 23653
-  examine: "Are you sure you want to touch that? It seems to be alive and looking at you."
 - id: 23654
-  examine: "Are you sure you want to touch that? It seems to be alive and looking at you."
 - id: 23655
 - id: 23656
-  examine: "Are you sure you want to touch that? It seems to be alive and looking at you."
 - id: 23657
 - id: 23658
 - id: 23659
@@ -36849,87 +33120,48 @@
 - id: 23665
 - id: 23666
 - id: 23667
-  examine: "He should have run a virus checker more often."
 - id: 23668
-  examine: "They seem to have mould growing from them... ick!"
 - id: 23669
-  examine: "I'm sure he died of natural causes.  Like the plague..."
 - id: 23670
 - id: 23671
 - id: 23672
 - id: 23673
-  examine: "A teleport to the Telekinetic Theatre."
 - id: 23674
-  examine: "A teleport to the Enchanting Chamber."
 - id: 23675
-  examine: "A teleport to the Alchemists' Playground."
 - id: 23676
-  examine: "A teleport to the Creature Graveyard."
 - id: 23677
-  examine: "A teleport to the Entrance hall."
 - id: 23678
-  examine: "This may be worth opening."
 - id: 23679
-  examine: "This may be worth opening."
 - id: 23680
-  examine: "This may be worth opening."
 - id: 23681
-  examine: "This may be worth opening."
 - id: 23682
-  examine: "This may be worth opening."
 - id: 23683
-  examine: "This may be worth opening."
 - id: 23684
-  examine: "This may be worth opening."
 - id: 23685
-  examine: "This may be worth opening."
 - id: 23686
-  examine: "This may be worth opening."
 - id: 23687
-  examine: "This may be worth opening."
 - id: 23688
-  examine: "This may be worth opening."
 - id: 23689
-  examine: "This may be worth opening."
 - id: 23690
-  examine: "This may be worth opening."
 - id: 23691
-  examine: "This may be worth opening."
 - id: 23692
-  examine: "This may be worth opening."
 - id: 23693
-  examine: "This may be worth opening."
 - id: 23694
-  examine: "Some simple cubes."
 - id: 23695
-  examine: "A pile of cylindrical shapes."
 - id: 23696
-  examine: "A pile of Icosahedrons."
 - id: 23697
-  examine: "A pile of pentamids."
 - id: 23698
-  examine: "A hole the perfect shape for spheres"
 - id: 23699
 - id: 23700
-  examine: "A terrible stench arises from these tendrils, better keep your distance."
 - id: 23701
-  examine: "Goo drips from these wiggling horrors."
 - id: 23702
-  examine: "Not what you'd call inviting!"
 - id: 23703
-  examine: "You'll be lucky to keep a grip on this! Climb to go back to the start of this level."
 - id: 23704
-  examine: "You'll be lucky to keep a grip on this, if you'd even want to!"
 - id: 23705
-  examine: "Goo oozes from this vine."
 - id: 23706
-  examine: "Goo oozes from this vine."
 - id: 23707
-  examine: "If you are of sufficient experience, you may take a shortcut through this level."
 - id: 23708
-  examine: "Danger - Extremely deadly creatures below!"
 - id: 23709
-  examine: "A shiny box of medicine treasure away from the stinking ooze."
 - id: 23710
 - id: 23711
 - id: 23712
@@ -36946,20 +33178,13 @@
 - id: 23723
 - id: 23724
 - id: 23725
-  examine: "Hot enough to cook your breakfast on."
 - id: 23726
 - id: 23727
-  examine: "Elaborate portal crafted from bones of the long dead."
 - id: 23728
-  examine: "Elaborate portal crafted from bones of the long dead."
 - id: 23729
-  examine: "Elaborate portal crafted from bones of the long dead."
 - id: 23730
-  examine: "Elaborate portal crafted from bones of the long dead."
 - id: 23731
-  examine: "Life in the midst of death."
 - id: 23732
-  examine: "A chain of bones leading up."
 - id: 23733
 - id: 23734
 - id: 23735
@@ -37145,148 +33370,82 @@
 - id: 23915
 - id: 23916
 - id: 23917
-  examine: "A wooden gate."
 - id: 23918
-  examine: "A wooden gate."
 - id: 23919
-  examine: "A wooden gate."
 - id: 23920
-  examine: "A chain of bones leading down."
 - id: 23921
-  examine: "Bones of the dead lashed together."
 - id: 23922
-  examine: "If you've completed this level before, you may use this portal."
 - id: 23923
 - id: 23924
 - id: 23925
 - id: 23926
 - id: 23927
-  examine: "I don't think she read the security tips on the website."
 - id: 23928
-  examine: "One less adventurer..."
 - id: 23929
-  examine: "I don't think he expected that."
 - id: 23930
 - id: 23931
-  examine: "This vat is empty."
 - id: 23932
-  examine: "This vat is filled with water."
 - id: 23933
-  examine: "This vat is filled with bad ale."
 - id: 23934
-  examine: "This vat is filled with bad cider."
 - id: 23935
-  examine: "This vat contains a mixture of water and barley malt."
 - id: 23936
-  examine: "This controls the flow of ale to the barrel."
 - id: 23937
-  examine: "This controls the flow of ale to the barrel."
 - id: 23938
-  examine: "This vat contains a mixture of water, barley malt, and Hammerstone hops."
 - id: 23939
-  examine: "Dwarven Stout is fermenting in this vat."
 - id: 23940
-  examine: "Dwarven Stout is fermenting in this vat."
 - id: 23941
-  examine: "This vat is filled with Dwarven Stout."
 - id: 23942
-  examine: "This person was of great importance."
 - id: 23943
-  examine: "This person was of great importance."
 - id: 23944
-  examine: "King Roald of Misthalin."
 - id: 23945
-  examine: "Queen Ellamaria of Misthalin."
 - id: 23946
-  examine: "A depiction of a famous gnome warrior."
 - id: 23947
-  examine: "A depiction of King Healthorg the Great."
 - id: 23948
 - id: 23949
 - id: 23950
-  examine: "It throws stuff."
 - id: 23951
-  examine: "It throws stuff."
 - id: 23952
-  examine: "It throws stuff."
 - id: 23953
-  examine: "It throws stuff."
 - id: 23954
-  examine: "It throws stuff."
 - id: 23955
-  examine: "Brings armour to life."
 - id: 23956
 - id: 23957
 - id: 23958
-  examine: "It's a Dummy."
 - id: 23959
-  examine: "It's a Dummy."
 - id: 23960
-  examine: "It's a Dummy."
 - id: 23961
-  examine: "It's a Dummy."
 - id: 23962
-  examine: "It's a Dummy."
 - id: 23963
-  examine: "It's a Dummy."
 - id: 23964
-  examine: "It's a Dummy."
 - id: 23965
-  examine: "It's a hole."
 - id: 23966
-  examine: "For keeping things in."
 - id: 23967
-  examine: "For keeping things in."
 - id: 23968
-  examine: "They go down."
 - id: 23969
-  examine: "I can climb these stairs."
 - id: 23970
-  examine: "South to Falador :"
 - id: 23971
-  examine: "South to Falador :"
 - id: 23972
-  examine: "The door is closed."
 - id: 23973
-  examine: "The door is open."
 - id: 23974
 - id: 23975
 - id: 23976
-  examine: "A rock."
 - id: 23977
-  examine: "A rock."
 - id: 23978
-  examine: "A rock."
 - id: 23979
-  examine: "A rock."
 - id: 23980
-  examine: "A rock."
 - id: 23981
-  examine: "A rock."
 - id: 23982
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23983
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23984
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23985
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23986
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23987
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23988
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23989
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23990
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23991
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23992
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23993
-  examine: "Keeps unwelcome folk out of Falador."
 - id: 23994
 - id: 23995
 - id: 23996
@@ -37294,23 +33453,15 @@
 - id: 23998
 - id: 23999
 - id: 24000
-  examine: "A rack for displaying fine maces."
 - id: 24001
-  examine: "Shelves for maces."
 - id: 24002
-  examine: "A barrel of maces."
 - id: 24003
-  examine: "A table bearing a fine selection of maces."
 - id: 24004
-  examine: "A handy source of water."
 - id: 24005
-  examine: "Fine gems for sale!"
 - id: 24006
-  examine: "Precious stones for sale."
 - id: 24007
 - id: 24008
 - id: 24009
-  examine: "A hot furnace."
 - id: 24010
 - id: 24011
 - id: 24012
@@ -37319,19 +33470,14 @@
 - id: 24015
 - id: 24016
 - id: 24017
-  examine: "Rising Sun Tavern."
 - id: 24018
-  examine: "Rising Sun Tavern, Falador."
 - id: 24019
 - id: 24020
-  examine: "Powers the spinning pole outside."
 - id: 24021
-  examine: "The traditional sign of a barber."
 - id: 24022
 - id: 24023
 - id: 24024
 - id: 24025
-  examine: "A small wooden table."
 - id: 24026
 - id: 24027
 - id: 24028
@@ -37343,153 +33489,84 @@
 - id: 24034
 - id: 24035
 - id: 24036
-  examine: "A statue of a famous White Knight."
 - id: 24037
-  examine: "A statue of a famous White Knight."
 - id: 24038
-  examine: "A statue of a famous White Knight."
 - id: 24039
-  examine: "A statue of a famous White Knight."
 - id: 24040
-  examine: "A statue of a famous White Knight."
 - id: 24041
-  examine: "Filled to the brim with knowledge."
 - id: 24042
-  examine: "The flag of Asgarnia."
 - id: 24043
-  examine: "I thought he'd be bigger than that."
 - id: 24044
-  examine: "Big beard, robes. Yeah, that's Saradomin."
 - id: 24045
 - id: 24046
 - id: 24047
 - id: 24048
 - id: 24049
-  examine: "Nicely planted."
 - id: 24050
-  examine: "The door is closed."
 - id: 24051
-  examine: "The door is open."
 - id: 24052
-  examine: "The door is closed."
 - id: 24053
-  examine: "The door is open."
 - id: 24054
-  examine: "The door is closed."
 - id: 24055
-  examine: "The door is open."
 - id: 24056
-  examine: "The door is closed."
 - id: 24057
-  examine: "The door is closed."
 - id: 24058
-  examine: "The door is open."
 - id: 24059
-  examine: "A grand door."
 - id: 24060
-  examine: "A grand door."
 - id: 24061
-  examine: "A grand door."
 - id: 24062
-  examine: "A grand door."
 - id: 24063
-  examine: "A grand door."
 - id: 24064
-  examine: "A grand door."
 - id: 24065
-  examine: "A grand door."
 - id: 24066
-  examine: "A grand door."
 - id: 24067
-  examine: "I can climb up these stairs."
 - id: 24068
-  examine: "I can climb down these stairs."
 - id: 24069
 - id: 24070
-  examine: "I can climb this."
 - id: 24071
-  examine: "I can climb down this."
 - id: 24072
-  examine: "I can climb up these stairs."
 - id: 24073
 - id: 24074
-  examine: "I can climb down these stairs."
 - id: 24075
-  examine: "I can climb up these stairs."
 - id: 24076
-  examine: "I can climb down these stairs."
 - id: 24077
-  examine: "I can climb these stairs."
 - id: 24078
-  examine: "They go down."
 - id: 24079
-  examine: "I can climb these stairs."
 - id: 24080
-  examine: "They go down."
 - id: 24081
-  examine: "A nice sturdy-looking table."
 - id: 24082
-  examine: "Allows access to above level."
 - id: 24083
-  examine: "Allows access to above level."
 - id: 24084
-  examine: "Allows access to level below."
 - id: 24085
-  examine: "Allows access to level below."
 - id: 24086
-  examine: "A nice sturdy looking table."
 - id: 24087
-  examine: "Small wooden boxes."
 - id: 24088
-  examine: "Wooden crates."
 - id: 24089
-  examine: "A wooden stool."
 - id: 24090
-  examine: "A basic bed."
 - id: 24091
-  examine: "Nice banquet table."
 - id: 24092
-  examine: "A sturdy-looking round table."
 - id: 24093
 - id: 24094
 - id: 24095
 - id: 24096
-  examine: "Armour of a White Knight. Decorative, but still effective."
 - id: 24097
 - id: 24098
-  examine: "'Concerned about theft? Set a Bank PIN today!'"
 - id: 24099
-  examine: "'Customers are reminded NEVER to tell ANYONE their password.'"
 - id: 24100
-  examine: "This chest contains an impressive amount of Gold!!"
 - id: 24101
-  examine: "The bank teller will serve you from here."
 - id: 24102
-  examine: "Hope springs eternal."
 - id: 24103
-  examine: "A comfortable seat."
 - id: 24104
-  examine: "A carving of a figure from the history of RuneScape."
 - id: 24105
-  examine: "A source of foamy neurotoxin."
 - id: 24106
-  examine: "Where drunkards may be found."
 - id: 24107
-  examine: "So clean you could eat your dinner off it."
 - id: 24108
-  examine: "I'd really hate to drink anything that had been in here."
 - id: 24109
-  examine: "Smells alcoholic."
 - id: 24110
-  examine: "Dusty old books."
 - id: 24111
-  examine: "Storage for all needs."
 - id: 24112
-  examine: "Storage for all needs."
 - id: 24113
-  examine: "Storage for all needs."
 - id: 24114
-  examine: "Storage for all needs."
 - id: 24115
 - id: 24116
 - id: 24117
@@ -37515,35 +33592,23 @@
 - id: 24137
 - id: 24138
 - id: 24139
-  examine: "What ancient rites were performed here?"
 - id: 24140
-  examine: "What ancient rites were performed here?"
 - id: 24141
-  examine: "What ancient rites were performed here?"
 - id: 24142
-  examine: "What ancient rites were performed here?"
 - id: 24143
 - id: 24144
 - id: 24145
 - id: 24146
-  examine: "Weathered rocks."
 - id: 24147
-  examine: "Weathered rocks."
 - id: 24148
-  examine: "Weathered rocks."
 - id: 24149
 - id: 24150
-  examine: "Best used with a bucket."
 - id: 24151
-  examine: "Ready for a quick snip?"
 - id: 24152
-  examine: "Put your head in my hands..."
 - id: 24153
-  examine: "Ooh - pretty!"
 - id: 24154
 - id: 24155
 - id: 24156
-  examine: "Makes your hair stay curly."
 - id: 24157
 - id: 24158
 - id: 24159
@@ -37558,11 +33623,8 @@
 - id: 24168
   depleted: 24169
 - id: 24169
-  examine: "Running water - very nice!"
 - id: 24170
-  examine: "Might be handy for a workman."
 - id: 24171
-  examine: "Might be handy for a workman."
 - id: 24172
 - id: 24173
 - id: 24174
@@ -37610,13 +33672,10 @@
 - id: 24216
 - id: 24217
 - id: 24218
-  examine: "A pile of bricks."
 - id: 24219
-  examine: "A pile of bricks."
 - id: 24220
 - id: 24221
 - id: 24222
-  examine: "It looks like I might be able to climb over this piece of the wall..."
 - id: 24223
 - id: 24224
 - id: 24225
@@ -37624,9 +33683,7 @@
 - id: 24227
 - id: 24228
 - id: 24229
-  examine: "An attractively laid out collection of ranging weapons."
 - id: 24230
-  examine: "Contains washing items."
 - id: 24231
 - id: 24232
 - id: 24233
@@ -37645,21 +33702,13 @@
 - id: 24246
 - id: 24247
 - id: 24248
-  examine: "I can climb up and down these stairs."
 - id: 24249
-  examine: "I can climb up and down these stairs."
 - id: 24250
-  examine: "I can climb up these stairs."
 - id: 24251
-  examine: "I can climb up these stairs."
 - id: 24252
-  examine: "I can climb down these stairs."
 - id: 24253
-  examine: "I can climb down these stairs."
 - id: 24254
-  examine: "I can climb down these stairs."
 - id: 24255
-  examine: "I can climb down these stairs."
 - id: 24256
 - id: 24257
 - id: 24258
@@ -37698,79 +33747,46 @@
 - id: 24291
 - id: 24292
 - id: 24293
-  examine: "It doesn't look like the way out."
 - id: 24294
-  examine: "It doesn't look like the way out."
 - id: 24295
 - id: 24296
-  examine: "Pull me!"
 - id: 24297
-  examine: "It's a hole."
 - id: 24298
-  examine: "It's a hole."
 - id: 24299
-  examine: "It's a hole."
 - id: 24300
-  examine: "It's a hole."
 - id: 24301
-  examine: "It's a hole."
 - id: 24302
-  examine: "It's a hole."
 - id: 24303
-  examine: "I can climb down these stairs."
 - id: 24304
 - id: 24305
 - id: 24306
-  examine: "A door."
 - id: 24307
-  examine: "A door."
 - id: 24308
 - id: 24309
-  examine: "A door."
 - id: 24310
-  examine: "A door."
 - id: 24311
 - id: 24312
-  examine: "A door."
 - id: 24313
-  examine: "A door."
 - id: 24314
 - id: 24315
-  examine: "A door."
 - id: 24316
-  examine: "A door."
 - id: 24317
 - id: 24318
-  examine: "A door."
 - id: 24319
-  examine: "A door."
 - id: 24320
 - id: 24321
-  examine: "A coal scuttle for storing coal."
 - id: 24322
-  examine: "A barstool."
 - id: 24323
-  examine: "A barstool."
 - id: 24324
-  examine: "Never drink and drive. Of course, what could you possibly drive?"
 - id: 24325
-  examine: "Excessive consumption of alcohol is bad for you."
 - id: 24326
-  examine: "Do you know what 'cirrhosis of the liver' means?"
 - id: 24327
-  examine: "Drinks for sale here."
 - id: 24328
-  examine: "Where everybody knows your username."
 - id: 24329
-  examine: "Have a drop a-fore ye go..."
 - id: 24330
-  examine: "Always drink responsibly."
 - id: 24331
-  examine: "Wine and whisky don't mix."
 - id: 24332
-  examine: "Eat, drink and be merry, for tomorrow we die."
 - id: 24333
-  examine: "Generally used for putting things on."
 - id: 24334
 - id: 24335
 - id: 24336
@@ -37778,60 +33794,35 @@
 - id: 24338
 - id: 24339
 - id: 24340
-  examine: "Filled to the brim with knowledge."
 - id: 24341
-  examine: "Filled to the brim with knowledge."
 - id: 24342
-  examine: "Filled to the brim with knowledge."
 - id: 24343
-  examine: "Filled to the brim with knowledge."
 - id: 24344
-  examine: "An old crate for storage."
 - id: 24345
 - id: 24346
-  examine: "A well slept in bed."
 - id: 24347
-  examine: "The bank teller will serve you from here."
 - id: 24348
 - id: 24349
-  examine: "Pots and pans."
 - id: 24350
-  examine: "These can be useful."
 - id: 24351
-  examine: "It leads up."
 - id: 24352
-  examine: "I can climb down this."
 - id: 24353
-  examine: "Used to squeeze moisture from the hide."
 - id: 24354
-  examine: "Used to squeeze moisture from the hide."
 - id: 24355
-  examine: "Odd bits of fabric lie on this table."
 - id: 24356
 - id: 24357
 - id: 24358
-  examine: "I can climb up these stairs."
 - id: 24359
-  examine: "I can climb down these stairs."
 - id: 24360
-  examine: "A table."
 - id: 24361
 - id: 24362
-  examine: "Prepared hides hang here drying."
 - id: 24363
-  examine: "The door is open."
 - id: 24364
-  examine: "The door is closed."
 - id: 24365
-  examine: "The door is open."
 - id: 24366
-  examine: "The door is closed."
 - id: 24367
-  examine: "The door is open."
 - id: 24368
-  examine: "The door is open."
 - id: 24369
-  examine: "The door is closed."
 - id: 24370
 - id: 24371
 - id: 24372
@@ -37853,11 +33844,8 @@
 - id: 24388
 - id: 24389
 - id: 24390
-  examine: "A map of the Museum."
 - id: 24391
-  examine: "A map of the Museum."
 - id: 24392
-  examine: "A map of the Museum."
 - id: 24393
 - id: 24394
 - id: 24395
@@ -37893,9 +33881,7 @@
 - id: 24425
 - id: 24426
 - id: 24427
-  examine: "Stairs leading to the upper levels."
 - id: 24428
-  examine: "Stairs leading to the lower levels."
 - id: 24429
 - id: 24430
 - id: 24431
@@ -37920,77 +33906,42 @@
 - id: 24450
 - id: 24451
 - id: 24452
-  examine: "An information booth."
 - id: 24453
 - id: 24454
 - id: 24455
-  examine: "A barge under construction."
 - id: 24456
-  examine: "A barge under construction."
 - id: 24457
-  examine: "A barge under construction."
 - id: 24458
-  examine: "A barge under construction."
 - id: 24459
-  examine: "A barge under construction."
 - id: 24460
-  examine: "A barge under construction."
 - id: 24461
-  examine: "A barge under construction."
 - id: 24462
-  examine: "A barge under construction."
 - id: 24463
-  examine: "A barge under construction."
 - id: 24464
-  examine: "A barge under construction."
 - id: 24465
-  examine: "A barge under construction."
 - id: 24466
-  examine: "A barge under construction."
 - id: 24467
-  examine: "A barge under construction."
 - id: 24468
-  examine: "A barge under construction."
 - id: 24469
-  examine: "A barge under construction."
 - id: 24470
-  examine: "A barge under construction."
 - id: 24471
-  examine: "A barge under construction."
 - id: 24472
-  examine: "A barge under construction."
 - id: 24473
-  examine: "A barge under construction."
 - id: 24474
-  examine: "A barge under construction."
 - id: 24475
-  examine: "A barge under construction."
 - id: 24476
-  examine: "A barge under construction."
 - id: 24477
-  examine: "A barge under construction."
 - id: 24478
-  examine: "A barge under construction."
 - id: 24479
-  examine: "A barge under construction."
 - id: 24480
-  examine: "A barge under construction."
 - id: 24481
-  examine: "A barge under construction."
 - id: 24482
-  examine: "A barge under construction."
 - id: 24483
-  examine: "A barge under construction."
 - id: 24484
-  examine: "A barge under construction."
 - id: 24485
-  examine: "A barge under construction."
 - id: 24486
-  examine: "A barge under construction."
 - id: 24487
-  examine: "Wall of the canal."
 - id: 24488
-  examine: "Wall of the canal."
 - id: 24489
 - id: 24490
 - id: 24491
@@ -38003,457 +33954,246 @@
 - id: 24498
 - id: 24499
 - id: 24500
-  examine: "Buckets of tar."
 - id: 24501
-  examine: "Planks of wood."
 - id: 24502
-  examine: "Planks of wood."
 - id: 24503
-  examine: "A barge under construction."
 - id: 24504
-  examine: "A barge under construction."
 - id: 24505
-  examine: "A barge under construction."
 - id: 24506
-  examine: "A barge under construction."
 - id: 24507
-  examine: "A barge under construction."
 - id: 24508
-  examine: "A barge under construction."
 - id: 24509
-  examine: "A barge under construction."
 - id: 24510
-  examine: "A barge under construction."
 - id: 24511
-  examine: "A barge under construction."
 - id: 24512
-  examine: "A barge under construction."
 - id: 24513
-  examine: "A barge under construction."
 - id: 24514
-  examine: "A barge under construction."
 - id: 24515
-  examine: "A barge under construction."
 - id: 24516
-  examine: "A barge under construction."
 - id: 24517
-  examine: "A barge under construction."
 - id: 24518
-  examine: "A barge under construction."
 - id: 24519
-  examine: "A barge under construction."
 - id: 24520
-  examine: "A barge under construction."
 - id: 24521
-  examine: "A barge under construction."
 - id: 24522
-  examine: "A barge under construction."
 - id: 24523
-  examine: "A barge under construction."
 - id: 24524
-  examine: "A barge under construction."
 - id: 24525
-  examine: "A barge under construction."
 - id: 24526
-  examine: "A barge under construction."
 - id: 24527
-  examine: "A barge under construction."
 - id: 24528
-  examine: "A barge under construction."
 - id: 24529
-  examine: "A barge under construction."
 - id: 24530
-  examine: "A barge under construction."
 - id: 24531
-  examine: "Wall of the canal."
 - id: 24532
-  examine: "Wall of the canal."
 - id: 24533
 - id: 24534
-  examine: "Filled with all sorts of old stuff."
 - id: 24535
-  examine: "Some tools to work with."
 - id: 24536
-  examine: "A beautifully-worked golden gate."
 - id: 24537
 - id: 24538
 - id: 24539
-  examine: "A Saradomin symbol from the 4th Age."
 - id: 24540
-  examine: "An ancient Saradomin symbol from the 4th Age."
 - id: 24541
-  examine: "An old vase with Saradominist markings."
 - id: 24542
-  examine: "Pottery from the 3rd or 4th Ages."
 - id: 24543
-  examine: "Pottery from the 3rd or 4th Ages."
 - id: 24544
-  examine: "Ancient gold jewelry."
 - id: 24545
-  examine: "Rusty arrowheads, dating back to the early 4th Age."
 - id: 24546
-  examine: "A Zarosian talisman found at the Dig Site."
 - id: 24547
-  examine: "Stone tablet found at the Dig Site."
 - id: 24548
-  examine: "An ancient coin from Senntisten."
 - id: 24549
-  examine: "An old coin, accurately dating the city of Saranthium."
 - id: 24550
-  examine: "An empty display case."
 - id: 24551
-  examine: "An empty display case."
 - id: 24552
 - id: 24553
 - id: 24554
 - id: 24555
-  examine: "A table for cleaning specimens."
 - id: 24556
-  examine: "A table for cleaning specimens."
 - id: 24557
-  examine: "Looks like a pile of rocks."
 - id: 24558
-  examine: "It's a Dig Site specimen rocks"
 - id: 24559
-  examine: "Contains Dig Site finds."
 - id: 24560
-  examine: "A wooden gate."
 - id: 24561
-  examine: "A wooden gate."
 - id: 24562
-  examine: "Gap where a gate goes."
 - id: 24563
-  examine: "An opening in the wall, with flappy bits called doors."
 - id: 24564
-  examine: "A beautifully-worked golden gate."
 - id: 24565
-  examine: "A thick wooden door."
 - id: 24566
-  examine: "A thick wooden door."
 - id: 24567
-  examine: "A thick wooden door."
 - id: 24568
-  examine: "A thick wooden door."
 - id: 24569
-  examine: "It's a snake!"
 - id: 24570
 - id: 24571
-  examine: "A machine that powers the display."
 - id: 24572
-  examine: "A machine that powers the display."
 - id: 24573
-  examine: "A machine that powers the display."
 - id: 24574
-  examine: "A machine that powers the display."
 - id: 24575
-  examine: "A machine that powers the display."
 - id: 24576
-  examine: "A machine that powers the display."
 - id: 24577
-  examine: "A machine that powers the display."
 - id: 24578
-  examine: "A machine that powers the display."
 - id: 24579
-  examine: "A machine that powers the display."
 - id: 24580
-  examine: "A machine that powers the display."
 - id: 24581
-  examine: "A machine that powers the display."
 - id: 24582
-  examine: "A machine that powers the display."
 - id: 24583
-  examine: "A machine that powers the display."
 - id: 24584
-  examine: "A machine that powers the display."
 - id: 24585
-  examine: "A machine that powers the display."
 - id: 24586
-  examine: "A machine that powers the display."
 - id: 24587
-  examine: "A machine that powers the display."
 - id: 24588
-  examine: "Push me."
 - id: 24589
-  examine: "Push me."
 - id: 24590
-  examine: "Push me."
 - id: 24591
-  examine: "Push me."
 - id: 24592
-  examine: "Push me."
 - id: 24593
-  examine: "Push me."
 - id: 24594
-  examine: "Push me."
 - id: 24595
-  examine: "Push me."
 - id: 24596
-  examine: "Push me."
 - id: 24597
-  examine: "Push me."
 - id: 24598
-  examine: "Push me."
 - id: 24599
-  examine: "Push me."
 - id: 24600
-  examine: "Push me."
 - id: 24601
-  examine: "Push me."
 - id: 24602
-  examine: "Push me."
 - id: 24603
-  examine: "Push me."
 - id: 24604
 - id: 24605
-  examine: "Plaque."
 - id: 24606
-  examine: "Plaque."
 - id: 24607
-  examine: "Plaque."
 - id: 24608
-  examine: "Plaque."
 - id: 24609
-  examine: "Plaque."
 - id: 24610
-  examine: "Plaque."
 - id: 24611
-  examine: "Plaque."
 - id: 24612
-  examine: "Plaque."
 - id: 24613
-  examine: "Plaque."
 - id: 24614
-  examine: "Plaque."
 - id: 24615
-  examine: "Plaque."
 - id: 24616
-  examine: "Plaque."
 - id: 24617
-  examine: "Plaque."
 - id: 24618
-  examine: "Plaque."
 - id: 24619
-  examine: "A display case."
 - id: 24620
-  examine: "A painting of King Lathas."
 - id: 24621
-  examine: "A display of the different layers of soil."
 - id: 24622
-  examine: "An early map of RuneScape."
 - id: 24623
 - id: 24624
-  examine: "The staff of Armadyl."
 - id: 24625
-  examine: "A display of three god symbols."
 - id: 24626
 - id: 24627
-  examine: "A terracotta statue."
 - id: 24628
-  examine: "Ancient archaeological finds."
 - id: 24629
-  examine: "A display model of the druid stone circle."
 - id: 24630
-  examine: "A display of different runes."
 - id: 24631
-  examine: "A display model of the runestone essence rocks."
 - id: 24632
-  examine: "A map of the world."
 - id: 24633
 - id: 24634
-  examine: "A display of Robert the Strong in battle with Dragonkin."
 - id: 24635
-  examine: "A star chart."
 - id: 24636
 - id: 24637
-  examine: "A display of seven knights' helms."
 - id: 24638
 - id: 24639
-  examine: "The Shield of Arrav."
 - id: 24640
-  examine: "A map of Morytania."
 - id: 24641
-  examine: "A model of a bridge over the River Lum."
 - id: 24642
 - id: 24643
-  examine: "A model of the Observatory near Ardougne."
 - id: 24644
-  examine: "Fangs for the memory."
 - id: 24645
-  examine: "A map of the Barbarian Village."
 - id: 24646
-  examine: "A map of Edgeville."
 - id: 24647
-  examine: "Black Knight armour."
 - id: 24648
-  examine: "Infinity equipment."
 - id: 24649
-  examine: "Silverlight, the demon slayer."
 - id: 24650
-  examine: "A display of weapons used by barbarians."
 - id: 24651
-  examine: "Some weapons and runes."
 - id: 24652
-  examine: "A display of Zamorakian symbols."
 - id: 24653
 - id: 24654
-  examine: "Excalibur, de-stoned."
 - id: 24655
-  examine: "Broken arrows."
 - id: 24656
-  examine: "The Phoenix crossbow and Blackarm bands."
 - id: 24657
-  examine: "A human skeleton - un-undead."
 - id: 24658
-  examine: "Armour worn by White Knights."
 - id: 24659
-  examine: "A mage arena guardian."
 - id: 24660
-  examine: "A Gnome glider model."
 - id: 24661
-  examine: "A map of Ardougne."
 - id: 24662
 - id: 24663
-  examine: "A display of an ancient tome."
 - id: 24664
 - id: 24665
 - id: 24666
-  examine: "Scary lighting apparatus."
 - id: 24667
-  examine: "A creepy looking table."
 - id: 24668
-  examine: "I wonder what this spooky item contains."
 - id: 24669
-  examine: "It smells funny in there."
 - id: 24670
-  examine: "I wonder what this spooky item contains."
 - id: 24671
-  examine: "It smells funny in there."
 - id: 24672
-  examine: "Dare I go up?"
 - id: 24673
-  examine: "These stairs look spooky!"
 - id: 24674
-  examine: "Looking good!"
 - id: 24675
-  examine: "Esoteric artefacts."
 - id: 24676
-  examine: "I don't want to know what's in those little urns."
 - id: 24677
-  examine: "Trinkets and stuff."
 - id: 24678
 - id: 24679
-  examine: "Distinctly feminine."
 - id: 24680
-  examine: "To help you do your hair."
 - id: 24681
-  examine: "For keeping things in."
 - id: 24682
-  examine: "For keeping things in."
 - id: 24683
-  examine: "An elegant chair."
 - id: 24684
-  examine: "An ordinary looking table."
 - id: 24685
-  examine: "The door is open."
 - id: 24686
-  examine: "The door is closed."
 - id: 24687
-  examine: "I can climb up these stairs."
 - id: 24688
-  examine: "A broken lab tube."
 - id: 24689
-  examine: "A lab tube."
 - id: 24690
-  examine: "A box."
 - id: 24691
-  examine: "A stack of boxes."
 - id: 24692
-  examine: "Some boxes."
 - id: 24693
-  examine: "Large rocks."
 - id: 24694
-  examine: "Large rocks."
 - id: 24695
-  examine: "Large rocks."
 - id: 24696
-  examine: "Large rocks."
 - id: 24697
-  examine: "Large rocks."
 - id: 24698
-  examine: "Large rocks."
 - id: 24699
-  examine: "Large rocks."
 - id: 24700
-  examine: "Large rocks."
 - id: 24701
-  examine: "Large rocks."
 - id: 24702
 - id: 24703
 - id: 24704
 - id: 24705
 - id: 24706
-  examine: "Looks like he could do with a drink and a mop."
 - id: 24707
-  examine: "These bones have been picked clean... Something around here is hungry!"
 - id: 24708
-  examine: "He looks hungry!"
 - id: 24709
-  examine: "A wooden barrel."
 - id: 24710
-  examine: "A mucky sack."
 - id: 24711
-  examine: "Not so good for sitting on."
 - id: 24712
-  examine: "The remains of a bad driver."
 - id: 24713
 - id: 24714
 - id: 24715
 - id: 24716
-  examine: "Its eyes stare off into the distance..."
 - id: 24717
-  examine: "This leads to the Witch's House."
 - id: 24718
-  examine: "This leads downwards."
 - id: 24719
 - id: 24720
 - id: 24721
-  examine: "A piano with some sort of compartment."
 - id: 24722
-  examine: "A piano with some sort of compartment."
 - id: 24723
-  examine: "It's a rickety old drain pipe."
 - id: 24724
-  examine: "A musical device."
 - id: 24725
-  examine: "A musical box?"
 - id: 24726
-  examine: "A musical box?"
 - id: 24727
-  examine: "A musical box?"
 - id: 24728
-  examine: "A stand with a music sheet on it."
 - id: 24729
-  examine: "A music stand."
 - id: 24730
-  examine: "A glowing mound of earth."
 - id: 24731
-  examine: "A dry earth mound with beans in."
 - id: 24732
-  examine: "It's huge."
 - id: 24733
   depleted: 24734
-  examine: "It's huge."
 - id: 24734
-  examine: "It's huge."
 - id: 24735
   depleted: 24736
-  examine: "It's huge."
 - id: 24736
-  examine: "It's huge."
 - id: 24737
-  examine: "It's huge."
 - id: 24738
-  examine: "The stump from a large beanstalk."
 - id: 24739
 - id: 24740
 - id: 24741
@@ -38465,7 +34205,6 @@
 - id: 24747
 - id: 24748
 - id: 24749
-  examine: "Maybe I can climb this."
 - id: 24750
 - id: 24751
 - id: 24752
@@ -38476,41 +34215,28 @@
 - id: 24757
 - id: 24758
 - id: 24759
-  examine: "A secure looking door."
 - id: 24760
 - id: 24761
 - id: 24762
 - id: 24763
 - id: 24764
 - id: 24765
-  examine: "A window."
 - id: 24766
-  examine: "A window."
 - id: 24767
-  examine: "The dwarf's beard."
 - id: 24768
-  examine: "A window."
 - id: 24769
-  examine: "A dwarf. He seems to be in his underwear!"
 - id: 24770
-  examine: "A dwarf. He seems to be in his underwear!"
 - id: 24771
-  examine: "A dwarf. He seems to be in his underwear!"
 - id: 24772
-  examine: "A dwarf. He seems to be in his underwear!"
 - id: 24773
 - id: 24774
 - id: 24775
 - id: 24776
 - id: 24777
 - id: 24778
-  examine: "A window in a tower. How fortuitous!"
 - id: 24779
-  examine: "Rupert's Beard"
 - id: 24780
-  examine: "The princess's pendant."
 - id: 24781
-  examine: "A rock."
 - id: 24782
 - id: 24783
 - id: 24784
@@ -38525,42 +34251,30 @@
 - id: 24793
 - id: 24794
 - id: 24795
-  examine: "I could climb up these."
 - id: 24796
-  examine: "I could climb down these."
 - id: 24797
 - id: 24798
 - id: 24799
-  examine: "This leads back to the witch's house."
 - id: 24800
 - id: 24801
 - id: 24802
-  examine: "I wonder where this leads?"
 - id: 24803
-  examine: "The lock for the door."
 - id: 24804
-  examine: "Some blunt looking nails."
 - id: 24805
-  examine: "A witch's charm."
 - id: 24806
 - id: 24807
 - id: 24808
-  examine: "The mouse hole is in there."
 - id: 24809
 - id: 24810
 - id: 24811
 - id: 24812
 - id: 24813
 - id: 24814
-  examine: "Do I dare sit on this?"
 - id: 24815
-  examine: "The door is open."
 - id: 24816
-  examine: "The door is closed."
 - id: 24817
 - id: 24818
 - id: 24819
-  examine: "The top of the beanstalk."
 - id: 24820
 - id: 24821
 - id: 24822
@@ -38581,22 +34295,14 @@
 - id: 24837
 - id: 24838
 - id: 24839
-  examine: "An evil looking griffin."
 - id: 24840
 - id: 24841
-  examine: "A pile of Grimgnash's feathers."
 - id: 24842
-  examine: "Wonder where this leads to."
 - id: 24843
-  examine: "Glowing magic aura."
 - id: 24844
-  examine: "Glowing magic aura."
 - id: 24845
-  examine: "Glowing magic aura."
 - id: 24846
-  examine: "Glowing magic aura."
 - id: 24847
-  examine: "Glowing magic aura."
 - id: 24848
 - id: 24849
 - id: 24850
@@ -38624,18 +34330,12 @@
 - id: 24872
 - id: 24873
 - id: 24874
-  examine: "It's got holes in it."
 - id: 24875
-  examine: "Lovely money!"
 - id: 24876
-  examine: "Bones are for burying!"
 - id: 24877
-  examine: "A strange symbol."
 - id: 24878
-  examine: "A strange symbol."
 - id: 24879
 - id: 24880
-  examine: "Maybe I can climb this."
 - id: 24881
 - id: 24882
 - id: 24883
@@ -38643,7 +34343,6 @@
 - id: 24885
 - id: 24886
 - id: 24887
-  examine: "An empty cage."
 - id: 24888
 - id: 24889
 - id: 24890
@@ -38664,142 +34363,75 @@
 - id: 24905
 - id: 24906
 - id: 24907
-  examine: "Essentials for a seamstress."
 - id: 24908
-  examine: "This scroll has information about the dummy game."
 - id: 24909
-  examine: "This scroll has information about the catapult game."
 - id: 24910
-  examine: "This vat is filled with mature Dwarven Stout."
 - id: 24911
-  examine: "This vat contains a mixture of water, barley malt, and Asgarnian hops."
 - id: 24912
-  examine: "Asgarnian Ale is fermenting in this vat."
 - id: 24913
-  examine: "Asgarnian Ale is fermenting in this vat."
 - id: 24914
-  examine: "This vat is filled with Asgarnian Ale."
 - id: 24915
-  examine: "This vat is filled with mature Asgarnian Ale."
 - id: 24916
-  examine: "This vat contains a mixture of water, barley malt, and Harralander."
 - id: 24917
-  examine: "Greenmans Ale is fermenting in this vat."
 - id: 24918
-  examine: "Greenmans Ale is fermenting in this vat."
 - id: 24919
-  examine: "This vat is filled with Greenmans Ale."
 - id: 24920
-  examine: "This vat is filled with mature Greenmans Ale."
 - id: 24921
-  examine: "This vat contains a mixture of water, barley malt, and Yanillian hops."
 - id: 24922
-  examine: "Wizards Mind Bomb is fermenting in this vat."
 - id: 24923
-  examine: "Wizards Mind Bomb is fermenting in this vat."
 - id: 24924
-  examine: "This vat is filled with Wizards Mind Bomb."
 - id: 24925
-  examine: "This vat is filled with mature Wizards Mind Bomb."
 - id: 24926
-  examine: "This vat contains a mixture of water, barley malt, and Krandorian hops."
 - id: 24927
-  examine: "Dragon Bitter is fermenting in this vat."
 - id: 24928
-  examine: "Dragon Bitter is fermenting in this vat."
 - id: 24929
-  examine: "This vat is filled with Dragon Bitter."
 - id: 24930
-  examine: "This vat is filled with mature Dragon Bitter."
 - id: 24931
-  examine: "This vat contains a mixture of water, barley malt, and Bittercap mushrooms."
 - id: 24932
-  examine: "Moonlight Mead is fermenting in this vat."
 - id: 24933
-  examine: "Moonlight Mead is fermenting in this vat."
 - id: 24934
-  examine: "This vat is filled with Moonlight Mead."
 - id: 24935
-  examine: "This vat is filled with mature Moonlight Mead."
 - id: 24936
-  examine: "This vat contains a mixture of water, barley malt, and oak roots."
 - id: 24937
-  examine: "Axeman's Folly is fermenting in this vat."
 - id: 24938
-  examine: "Axeman's Folly is fermenting in this vat."
 - id: 24939
-  examine: "This vat is filled with Axeman's Folly."
 - id: 24940
-  examine: "This vat is filled with mature Axeman's Folly."
 - id: 24941
-  examine: "This vat contains a mixture of water, barley malt, and chocolate dust."
 - id: 24942
-  examine: "Chef's Delight is fermenting in this vat."
 - id: 24943
-  examine: "Chef's Delight is fermenting in this vat."
 - id: 24944
-  examine: "This vat is filled with Chef's Delight."
 - id: 24945
-  examine: "This vat is filled with mature Chef's Delight."
 - id: 24946
-  examine: "This vat contains a mixture of water, barley malt, and Wildblood hops."
 - id: 24947
-  examine: "Slayer's Respite is fermenting in this vat."
 - id: 24948
-  examine: "Slayer's Respite is fermenting in this vat."
 - id: 24949
-  examine: "This vat is filled with Slayer's Respite."
 - id: 24950
-  examine: "This vat is filled with mature Slayer's Respite."
 - id: 24951
-  examine: "This vat contains some apple mush."
 - id: 24952
-  examine: "Cider is fermenting in this vat."
 - id: 24953
-  examine: "Cider is fermenting in this vat."
 - id: 24954
-  examine: "This vat is filled with cider."
 - id: 24955
-  examine: "This vat is filled with mature cider."
 - id: 24956
 - id: 24957
 - id: 24958
-  examine: "The entrance to the Cooking Guild."
 - id: 24959
 - id: 24960
-  examine: "Grain goes in here."
 - id: 24961
-  examine: "Grain goes in here."
 - id: 24962
-  examine: "Grain goes in here."
 - id: 24963
-  examine: "Grain goes in here."
 - id: 24964
-  examine: "These control the flow of grain from the hopper to the millstones."
 - id: 24965
-  examine: "These control the flow of grain from the hopper to the millstones."
 - id: 24966
-  examine: "These control the flow of grain from the hopper to the millstones."
 - id: 24967
-  examine: "These control the flow of grain from the hopper to the millstones."
 - id: 24968
-  examine: "A spicy meat kebab is cooking here."
 - id: 24969
-  examine: "A fire burns brightly here."
 - id: 24970
-  examine: "A grand old fireplace."
 - id: 24971
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 24972
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 24973
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 24974
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 24975
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 24976
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 24977
 - id: 24978
 - id: 24979
@@ -38808,21 +34440,13 @@
 - id: 24982
 - id: 24983
 - id: 24984
-  examine: "Mysteriously flattened wheat."
 - id: 24985
-  examine: "Suspiciously flattened wheat."
 - id: 24986
-  examine: "Mysteriously flattened wheat."
 - id: 24987
-  examine: "Mysteriously flattened wheat."
 - id: 24988
-  examine: "The mysterious centre of a crop circle."
 - id: 24989
-  examine: "Something unusual is happening to the wheat."
 - id: 24990
-  examine: "Something unusual is happening to the wheat."
 - id: 24991
-  examine: "The mysterious centre of a crop circle."
 - id: 24992
 - id: 24993
 - id: 24994
@@ -38846,70 +34470,40 @@
 - id: 25012
 - id: 25013
 - id: 25014
-  examine: "Use this to leave Puro-Puro."
 - id: 25015
 - id: 25016
-  examine: "100% wholegrain."
 - id: 25017
-  examine: "100% wholegrain."
 - id: 25018
-  examine: "100% wholegrain."
 - id: 25019
-  examine: "100% wholegrain."
 - id: 25020
-  examine: "100% wholegrain."
 - id: 25021
-  examine: "100% wholegrain."
 - id: 25022
-  examine: "Kids grow up fast these days."
 - id: 25023
-  examine: "Life is short and then we die."
 - id: 25024
-  examine: "100% wholegrain."
 - id: 25025
-  examine: "100% wholegrain."
 - id: 25026
-  examine: "100% wholegrain."
 - id: 25027
-  examine: "100% wholegrain."
 - id: 25028
-  examine: "100% wholegrain."
 - id: 25029
-  examine: "The way into the maze."
 - id: 25030
 - id: 25031
 - id: 25032
 - id: 25033
-  examine: "Not what I would pick as wall decoration."
 - id: 25034
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 25035
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 25036
 - id: 25037
-  examine: "You have patched the hole in the ship's hull."
 - id: 25038
-  examine: "I can climb this."
 - id: 25039
-  examine: "There is something strange about this wall."
 - id: 25040
-  examine: "What could Melzar be keeping in this spooky wardrobe?"
 - id: 25041
-  examine: "It smells funny in there."
 - id: 25042
-  examine: "It smells funny in there."
 - id: 25043
-  examine: "It smells funny in there."
 - id: 25044
-  examine: "It smells funny in there."
 - id: 25045
-  examine: "I can climb down this."
 - id: 25046
-  examine: "This, no doubt, contains arcane knowledge."
 - id: 25047
-  examine: "An old spooky table."
 - id: 25048
-  examine: "Do I dare sit on this?"
 - id: 25049
 - id: 25050
 - id: 25051
@@ -38942,28 +34536,17 @@
 - id: 25078
 - id: 25079
 - id: 25080
-  examine: "Formed over many years of dripping limestone."
 - id: 25081
-  examine: "Formed over many years of dripping limestone."
 - id: 25082
-  examine: "Formed over many years of dripping limestone."
 - id: 25083
-  examine: "A tooth-shaped rock formation, protruding from the floor."
 - id: 25084
-  examine: "They look a bit brittle."
 - id: 25085
-  examine: "They look a bit brittle."
 - id: 25086
 - id: 25087
-  examine: "Looks like he's been dead a while now."
 - id: 25088
-  examine: "I don't think he'd mind us checking for his wallet now."
 - id: 25089
-  examine: "I'm sure he died of natural causes. Like a massive dragon or something."
 - id: 25090
-  examine: "All that remains of the original adventurer that woke Elvarg."
 - id: 25091
-  examine: "Looks like the shield took a lot of damage."
 - id: 25092
 - id: 25093
 - id: 25094
@@ -38988,44 +34571,30 @@
 - id: 25113
 - id: 25114
 - id: 25115
-  examine: "There is something in this door for me to put objects in."
 - id: 25116
-  examine: "There is something in this door for me to put objects in."
 - id: 25117
-  examine: "There is something in this door for me to put objects in."
 - id: 25118
-  examine: "There is something in this door for me to put objects in."
 - id: 25119
 - id: 25120
 - id: 25121
 - id: 25122
-  examine: "A burning candle on an interesting stand."
 - id: 25123
-  examine: "A burning candle on an interesting stand."
 - id: 25124
 - id: 25125
 - id: 25126
 - id: 25127
 - id: 25128
 - id: 25129
-  examine: "Some weird vines."
 - id: 25130
-  examine: "Some weird vines."
 - id: 25131
-  examine: "Some weird vines."
 - id: 25132
-  examine: "Some weird vines."
 - id: 25133
 - id: 25134
 - id: 25135
 - id: 25136
-  examine: "Some weird vines."
 - id: 25137
-  examine: "Some sort of plant."
 - id: 25138
-  examine: "I doubt that's edible."
 - id: 25139
-  examine: "I doubt that's edible."
 - id: 25140
 - id: 25141
 - id: 25142
@@ -39035,33 +34604,19 @@
 - id: 25146
 - id: 25147
 - id: 25148
-  examine: "Remains of a wall."
 - id: 25149
-  examine: "Remains of a wall."
 - id: 25150
-  examine: "Remains of a wall."
 - id: 25151
-  examine: "Remains of a wall."
 - id: 25152
-  examine: "A tall pillar."
 - id: 25153
-  examine: "A tall pillar."
 - id: 25154
-  examine: "A mysterious hole at the top of the volcano."
 - id: 25155
-  examine: "Burn me!"
 - id: 25156
-  examine: "Burn me!"
 - id: 25157
-  examine: "Arrggh!"
 - id: 25158
-  examine: "A big, slimy lump of rock."
 - id: 25159
-  examine: "A slimy lump of rock."
 - id: 25160
-  examine: "A slippery-looking rock."
 - id: 25161
-  examine: "I think I could climb over this."
 - id: 25162
 - id: 25163
 - id: 25164
@@ -39070,92 +34625,53 @@
 - id: 25167
 - id: 25168
 - id: 25169
-  examine: "Maybe it caught fire?"
 - id: 25170
-  examine: "This tree is as white as ash."
 - id: 25171
-  examine: "It doesn't look healthy."
 - id: 25172
-  examine: "It doesn't look healthy."
 - id: 25173
 - id: 25174
-  examine: "This tree was the victim of an enraged dragon."
 - id: 25175
-  examine: "A fern."
 - id: 25176
-  examine: "A fern."
 - id: 25177
-  examine: "A dry plant."
 - id: 25178
-  examine: "How does the plant photosynthesise?"
 - id: 25179
-  examine: "The plant is flowering."
 - id: 25180
-  examine: "It has a seed pod."
 - id: 25181
-  examine: "This tree is dead."
 - id: 25182
-  examine: "This tree is not healthy."
 - id: 25183
-  examine: "It doesn't look healthy."
 - id: 25184
-  examine: "It doesn't look healthy."
 - id: 25185
-  examine: "It doesn't look healthy."
 - id: 25186
-  examine: "A twisted tree stump."
 - id: 25187
-  examine: "A burnt tree. What could have done this?"
 - id: 25188
-  examine: "A burnt tree. What could have done this?"
 - id: 25189
-  examine: "A tree found in tropical areas."
 - id: 25190
-  examine: "A tree found in tropical areas. This one is scorched."
 - id: 25191
-  examine: "A tree found in tropical areas. This one is scorched."
 - id: 25192
-  examine: "Some weeds."
 - id: 25193
 - id: 25194
-  examine: "Maybe this statue is a warning."
 - id: 25195
 - id: 25196
 - id: 25197
 - id: 25198
 - id: 25199
-  examine: "A mystical stone circle."
 - id: 25200
-  examine: "A warning beacon."
 - id: 25201
-  examine: "These flames will never go out."
 - id: 25202
-  examine: "The body of a mighty dragon."
 - id: 25203
-  examine: "The headless body of a mighty dragon."
 - id: 25204
-  examine: "This tent looks like it has been here for some time."
 - id: 25205
-  examine: "It's very windy!"
 - id: 25206
-  examine: "I always wonder if someone's hiding inside when I see these."
 - id: 25207
-  examine: "A conveniently rolled sail."
 - id: 25208
-  examine: "A conveniently rolled sail."
 - id: 25209
 - id: 25210
-  examine: "There is something in this door for me to put objects in."
 - id: 25211
-  examine: "There is something in this door for me to put objects in."
 - id: 25212
 - id: 25213
-  examine: "A rope hangs here."
 - id: 25214
-  examine: "The trapdoor can only be opened from below."
 - id: 25215
 - id: 25216
-  examine: "A log jammed by the current, perhaps rideable."
 - id: 25217
 - id: 25218
 - id: 25219
@@ -39192,7 +34708,6 @@
 - id: 25250
 - id: 25251
 - id: 25252
-  examine: "I'm sure the animal is glad its fur was put to good use."
 - id: 25253
 - id: 25254
 - id: 25255
@@ -39204,36 +34719,22 @@
 - id: 25261
 - id: 25262
 - id: 25263
-  examine: "A barbarian funeral pyre."
 - id: 25264
-  examine: "A barbarian funeral pyre."
 - id: 25265
-  examine: "A barbarian funeral pyre."
 - id: 25266
-  examine: "A barbarian funeral pyre."
 - id: 25267
-  examine: "A barbarian funeral pyre."
 - id: 25268
-  examine: "A barbarian bed."
 - id: 25269
-  examine: "A barbarian table."
 - id: 25270
-  examine: "A barbarian chair."
 - id: 25271
 - id: 25272
 - id: 25273
 - id: 25274
-  examine: "Crazy-looking whirlpool."
 - id: 25275
-  examine: "Crazy-looking whirlpool."
 - id: 25276
-  examine: "The thundering water exerts a tangible suction upon you."
 - id: 25277
-  examine: "The thundering water exerts a tangible suction upon you."
 - id: 25278
-  examine: "The thundering water exerts a tangible suction upon you."
 - id: 25279
-  examine: "The thundering water exerts a tangible suction upon you."
 - id: 25280
 - id: 25281
 - id: 25282
@@ -39241,25 +34742,15 @@
 - id: 25284
 - id: 25285
 - id: 25286
-  examine: "A patch of ash-strewn ground."
 - id: 25287
-  examine: "The ground looks burned here."
 - id: 25288
-  examine: "A carved log."
 - id: 25289
-  examine: "A carved log."
 - id: 25290
-  examine: "Fit for a barbarian burial."
 - id: 25291
-  examine: "Fit for a barbarian burial."
 - id: 25292
-  examine: "Fit for a barbarian burial."
 - id: 25293
-  examine: "Fit for a barbarian burial."
 - id: 25294
-  examine: "Fit for a barbarian burial."
 - id: 25295
-  examine: "Fit for a barbarian burial."
 - id: 25296
 - id: 25297
 - id: 25298
@@ -39301,16 +34792,11 @@
 - id: 25334
 - id: 25335
 - id: 25336
-  examine: "Some steps, for stepping up."
 - id: 25337
 - id: 25338
-  examine: "Some steps, for stepping down."
 - id: 25339
-  examine: "Small steps upwards."
 - id: 25340
-  examine: "Small steps downwards."
 - id: 25341
-  examine: "An old, sealed mithril door."
 - id: 25342
 - id: 25343
 - id: 25344
@@ -39319,7 +34805,6 @@
 - id: 25347
 - id: 25348
 - id: 25349
-  examine: "A barbarian's anvil."
 - id: 25350
 - id: 25351
 - id: 25352
@@ -39333,7 +34818,6 @@
 - id: 25360
 - id: 25361
 - id: 25362
-  examine: "A pile of old barbarian bones."
 - id: 25363
 - id: 25364
 - id: 25365
@@ -39341,135 +34825,83 @@
 - id: 25367
 - id: 25368
   depleted: 25371
-  examine: "Part of Glough's advanced apparatus."
 - id: 25369
   depleted: 25372
-  examine: "An area to hold one of Glough's smaller twisted creations."
 - id: 25370
   depleted: 25373
 - id: 25371
 - id: 25372
 - id: 25373
 - id: 25374
-  examine: "A campfire. You can cook things on this."
 - id: 25375
 - id: 25376
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 25377
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 25378
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 25379
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 25380
-  examine: "A tear in the dimensional weave of the Abyss."
 - id: 25381
-  examine: "A tunnel through the abyss."
 - id: 25382
 - id: 25383
-  examine: "This seems to be blocking the exit..."
 - id: 25384
 - id: 25385
-  examine: "I wonder what could be inside."
 - id: 25386
-  examine: "Perhaps I should search it."
 - id: 25387
-  examine: "I wonder what could be inside."
 - id: 25388
-  examine: "Perhaps I should search it."
 - id: 25389
-  examine: "I wonder what could be inside."
 - id: 25390
-  examine: "Perhaps I should search it."
 - id: 25391
-  examine: "I wonder what could be inside."
 - id: 25392
-  examine: "Perhaps I should search it."
 - id: 25393
-  examine: "Used for observing heavenly bodies."
 - id: 25394
 - id: 25395
 - id: 25396
 - id: 25397
-  examine: "Tells you where places are."
 - id: 25398
 - id: 25399
 - id: 25400
 - id: 25401
-  examine: "An impressive display of the planets."
 - id: 25402
-  examine: "A bookcase with various books."
 - id: 25403
-  examine: "A bookcase with various books."
 - id: 25404
-  examine: "A bookcase somewhat lacking in reading material."
 - id: 25405
-  examine: "A bookcase with various books."
 - id: 25406
-  examine: "A bookcase with various books."
 - id: 25407
-  examine: "Filled to the brim with knowledge."
 - id: 25408
-  examine: "Filled to the brim with knowledge."
 - id: 25409
 - id: 25410
 - id: 25411
-  examine: "A cluttered work area."
 - id: 25412
 - id: 25413
 - id: 25414
 - id: 25415
-  examine: "They might eventually reach the ceiling."
 - id: 25416
 - id: 25417
-  examine: "The door is open."
 - id: 25418
-  examine: "The door is closed."
 - id: 25419
-  examine: "The bluebells are coming!"
 - id: 25420
-  examine: "A great, big, sunny flower."
 - id: 25421
-  examine: "Great, big, sunny flowers."
 - id: 25422
-  examine: "I could probably break this up with a pickaxe."
 - id: 25423
-  examine: "I could probably break this up with a pickaxe. Oh wait, I just did."
 - id: 25424
-  examine: "Pickaxe power!"
 - id: 25425
-  examine: "They don't look that solid, an axe could help me chop them down."
 - id: 25426
-  examine: "They don't look that solid, an axe could help me chop them down."
 - id: 25427
-  examine: "I cannot tell a lie. I chopped them down."
 - id: 25428
-  examine: "If I'm agile enough I might be able to squeeze through..."
 - id: 25429
-  examine: "I wonder where they will take me."
 - id: 25430
 - id: 25431
-  examine: "I wonder where they will take me."
 - id: 25432
-  examine: "I wonder where they will take me."
 - id: 25433
 - id: 25434
-  examine: "I wonder where they will take me."
 - id: 25435
 - id: 25436
 - id: 25437
-  examine: "I wonder where they will take me."
 - id: 25438
-  examine: "Remember to look up at the stars and not down at your feet."
 - id: 25439
-  examine: "Remember to look up at the stars and not down at your feet."
 - id: 25440
-  examine: "A crude, stone goblin stove."
 - id: 25441
-  examine: "A crude, stone goblin stove."
 - id: 25442
 - id: 25443
-  examine: "Where is the spider hiding?"
 - id: 25444
 - id: 25445
 - id: 25446
@@ -39491,9 +34923,7 @@
 - id: 25462
 - id: 25463
 - id: 25464
-  examine: "Potentially hot!"
 - id: 25465
-  examine: "A goblin fire. Looks fierce."
 - id: 25466
 - id: 25467
 - id: 25468
@@ -39555,9 +34985,7 @@
 - id: 25524
 - id: 25525
 - id: 25526
-  examine: "Probably no longer used."
 - id: 25527
-  examine: "Probably no longer used."
 - id: 25528
 - id: 25529
 - id: 25530
@@ -39609,314 +35037,178 @@
 - id: 25576
 - id: 25577
 - id: 25578
-  examine: "Shows one of the different constellations."
 - id: 25579
-  examine: "Shows one of the different constellations."
 - id: 25580
-  examine: "Shows one of the different constellations."
 - id: 25581
-  examine: "Shows one of the different constellations."
 - id: 25582
-  examine: "Shows one of the different constellations."
 - id: 25583
-  examine: "Shows one of the different constellations."
 - id: 25584
 - id: 25585
 - id: 25586
 - id: 25587
 - id: 25588
-  examine: "A stone archway."
 - id: 25589
 - id: 25590
-  examine: "I could probably burn this away with a tinderbox."
 - id: 25591
 - id: 25592
-  examine: "I wonder what's inside."
 - id: 25593
-  examine: "Perhaps I should search it."
 - id: 25594
-  examine: "A large double door."
 - id: 25595
-  examine: "A large double door."
 - id: 25596
 - id: 25597
 - id: 25598
 - id: 25599
-  examine: "Looks kind of like a man made of metal."
 - id: 25600
-  examine: "It's got ale in it."
 - id: 25601
-  examine: "Sit back and relax..."
 - id: 25602
-  examine: "An attractively laid-out collection of ranging weapons."
 - id: 25603
-  examine: "A nice sturdy-looking table."
 - id: 25604
-  examine: "I can climb down this."
 - id: 25605
-  examine: "A kingly seat for a royal behind."
 - id: 25606
-  examine: "I can climb down this."
 - id: 25607
-  examine: "A good source of books."
 - id: 25608
-  examine: "The perfect place to store things."
 - id: 25609
-  examine: "The perfect place to store things."
 - id: 25610
-  examine: "I wonder what this spooky item contains."
 - id: 25611
-  examine: "Storage for all needs."
 - id: 25612
-  examine: "Storage for all needs."
 - id: 25613
 - id: 25614
-  examine: "The scrying glass of a seer."
 - id: 25615
-  examine: "A creepy-looking table."
 - id: 25616
-  examine: "Do I dare sit on this?"
 - id: 25617
 - id: 25618
 - id: 25619
 - id: 25620
-  examine: "Only people of a lower combat level can use this lander."
 - id: 25621
-  examine: "Only people of a high combat level can use this lander."
 - id: 25622
-  examine: "Only ultimate fighters can use this lander."
 - id: 25623
-  examine: "Only people of a lower combat level can use this lander."
 - id: 25624
-  examine: "Only people of a high combat level can use this lander."
 - id: 25625
-  examine: "Only ultimate fighters can use this lander."
 - id: 25626
 - id: 25627
 - id: 25628
 - id: 25629
-  examine: "A ladder out of the lander craft."
 - id: 25630
-  examine: "A ladder out of the lander craft."
 - id: 25631
-  examine: "Handy for boarding the ship."
 - id: 25632
-  examine: "Handy for boarding the ship."
 - id: 25633
 - id: 25634
 - id: 25635
 - id: 25636
-  examine: "It's almost totally destroyed."
 - id: 25637
 - id: 25638
-  examine: "A large double door."
 - id: 25639
-  examine: "A large double door."
 - id: 25640
-  examine: "A large double door."
 - id: 25641
-  examine: "A large double door."
 - id: 25642
-  examine: "A nicely-fitted door."
 - id: 25643
-  examine: "A nicely-fitted door."
 - id: 25644
-  examine: "An old crate for storage."
 - id: 25645
-  examine: "An old crate for storage."
 - id: 25646
-  examine: "Not suitable for children. Aim away from face."
 - id: 25647
-  examine: "I wonder what's inside."
 - id: 25648
-  examine: "The easiest opponent I'll ever fight."
 - id: 25649
-  examine: "Makes you taller."
 - id: 25650
 - id: 25651
-  examine: "Useful Ranged equipment."
 - id: 25652
-  examine: "What kind of sick person keeps a skull on their wall?"
 - id: 25653
-  examine: "Esoteric artefacts."
 - id: 25654
-  examine: "Trinkets and stuff."
 - id: 25655
-  examine: "Used for storage."
 - id: 25656
 - id: 25657
 - id: 25658
 - id: 25659
 - id: 25660
-  examine: "A wooden crate."
 - id: 25661
-  examine: "A wooden crate."
 - id: 25662
-  examine: "I can climb down this."
 - id: 25663
-  examine: "I can climb this."
 - id: 25664
-  examine: "One of the Knights of the Round Table."
 - id: 25665
-  examine: "One of the Knights of the Round Table."
 - id: 25666
-  examine: "One of the Knights of the Round Table."
 - id: 25667
-  examine: "One of the Knights of the Round Table."
 - id: 25668
-  examine: "Keeps the neighbours out!"
 - id: 25669
-  examine: "Keeps the neighbours out!"
 - id: 25670
-  examine: "Keeps the neighbours out!"
 - id: 25671
 - id: 25672
 - id: 25673
 - id: 25674
 - id: 25675
-  examine: "Animals have no table manners."
 - id: 25676
-  examine: "For sitting on."
 - id: 25677
 - id: 25678
 - id: 25679
 - id: 25680
 - id: 25681
-  examine: "A drab-looking bed."
 - id: 25682
-  examine: "I can climb up these stairs."
 - id: 25683
-  examine: "I can climb down these stairs."
 - id: 25684
-  examine: "Shelves filled with Carol's interesting books."
 - id: 25685
-  examine: "Elizabeth's chest."
 - id: 25686
-  examine: "Elizabeth's chest."
 - id: 25687
-  examine: "I can climb this."
 - id: 25688
-  examine: "I can climb down this."
 - id: 25689
-  examine: "A good source of books!"
 - id: 25690
-  examine: "A good source of books!"
 - id: 25691
-  examine: "A good source of books!"
 - id: 25692
-  examine: "A good source of books!"
 - id: 25693
-  examine: "A good source of books!"
 - id: 25694
-  examine: "A good source of books!"
 - id: 25695
-  examine: "A good source of books!"
 - id: 25696
-  examine: "A good source of books!"
 - id: 25697
-  examine: "A good source of books!"
 - id: 25698
-  examine: "A good source of books!"
 - id: 25699
-  examine: "The perfect place to store things."
 - id: 25700
-  examine: "The perfect place to store things."
 - id: 25701
-  examine: "These open and close!"
 - id: 25702
-  examine: "These may be worth searching."
 - id: 25703
-  examine: "These open and close!"
 - id: 25704
-  examine: "These may be worth searching."
 - id: 25705
-  examine: "These open and close!"
 - id: 25706
-  examine: "These may be worth searching."
 - id: 25707
-  examine: "These open and close!"
 - id: 25708
-  examine: "These open and close!"
 - id: 25709
-  examine: "These may be worth searching."
 - id: 25710
-  examine: "These open and close!"
 - id: 25711
-  examine: "These may be worth searching."
 - id: 25712
-  examine: "These open and close!"
 - id: 25713
-  examine: "These may be worth searching."
 - id: 25714
-  examine: "These open and close!"
 - id: 25715
-  examine: "These may be worth searching."
 - id: 25716
-  examine: "The door is closed."
 - id: 25717
-  examine: "The door is open."
 - id: 25718
-  examine: "A nicely-fitted door."
 - id: 25719
-  examine: "A nicely-fitted door."
 - id: 25720
-  examine: "Turns milk into other dairy products."
 - id: 25721
-  examine: "A wooden barrel for storage."
 - id: 25722
-  examine: "Looks like this is where the cook stores flour."
 - id: 25723
-  examine: "Looks like this is where Anna keeps her stuff."
 - id: 25724
-  examine: "Looks like this is where Bob keeps his stuff."
 - id: 25725
-  examine: "Looks like this is where Carol keeps her stuff."
 - id: 25726
-  examine: "Looks like this is where David keeps his stuff."
 - id: 25727
-  examine: "Looks like this is where Elizabeth keeps her stuff."
 - id: 25728
-  examine: "Looks like this is where Frank keeps his stuff."
 - id: 25729
-  examine: "Ideal for washing things in."
 - id: 25730
-  examine: "Ideal for cooking on."
 - id: 25731
-  examine: "Tick-tock, it's a clock."
 - id: 25732
-  examine: "An interesting choice of wall decoration."
 - id: 25733
-  examine: "Useful for putting things on."
 - id: 25734
-  examine: "Useful for putting things on."
 - id: 25735
-  examine: "A drab-looking bed."
 - id: 25736
-  examine: "Esoteric artefacts."
 - id: 25737
-  examine: "I don't want to know what's in those little urns."
 - id: 25738
-  examine: "A beautiful landscape."
 - id: 25739
-  examine: "Hail to the King!"
 - id: 25740
-  examine: "I don't know much about art, but I like this."
 - id: 25741
-  examine: "A painting of some guy standing around somewhere."
 - id: 25742
-  examine: "A really bad portrait of the King."
 - id: 25743
-  examine: "Fine brushwork adds to the realism of this serene landscape."
 - id: 25744
-  examine: "Pretty good painting."
 - id: 25745
 - id: 25746
 - id: 25747
 - id: 25748
-  examine: "A large double door."
 - id: 25749
 - id: 25750
-  examine: "A large double door."
 - id: 25751
 - id: 25752
 - id: 25753
@@ -39928,153 +35220,89 @@
 - id: 25759
 - id: 25760
 - id: 25761
-  examine: "Various implements for working with metal."
 - id: 25762
-  examine: "Bank of RuneScape."
 - id: 25763
-  examine: "No little mouse to be seen."
 - id: 25764
-  examine: "I was always forced to play this as a child."
 - id: 25765
-  examine: "Time for a recital?"
 - id: 25766
-  examine: "These open and close."
 - id: 25767
-  examine: "These may be worth searching."
 - id: 25768
-  examine: "Sit back and relax..."
 - id: 25769
-  examine: "The perfect place to store things."
 - id: 25770
-  examine: "The perfect place to store things."
 - id: 25771
-  examine: "The ideal thing to sit on."
 - id: 25772
-  examine: "Not so good for sitting on."
 - id: 25773
-  examine: "Good for sitting on."
 - id: 25774
-  examine: "Empty...so sad..."
 - id: 25775
-  examine: "An old crate for storage."
 - id: 25776
-  examine: "An old crate for storage."
 - id: 25777
 - id: 25778
-  examine: "Useful for putting things on."
 - id: 25779
-  examine: "A statue of a famous White Knight."
 - id: 25780
-  examine: "A barrel."
 - id: 25781
-  examine: "Storage for cookery items."
 - id: 25782
-  examine: "Filled to the brim with knowledge."
 - id: 25783
-  examine: "Good for rocking in."
 - id: 25784
-  examine: "A comfortable seat."
 - id: 25785
-  examine: "Makes you taller."
 - id: 25786
-  examine: "I can climb these stairs."
 - id: 25787
-  examine: "They go down."
 - id: 25788
-  examine: "A large double door."
 - id: 25789
-  examine: "A large double door."
 - id: 25790
-  examine: "A large double door."
 - id: 25791
-  examine: "A large double door."
 - id: 25792
-  examine: "Looks kind of like a man made of metal."
 - id: 25793
-  examine: "I wonder what's inside."
 - id: 25794
-  examine: "Perhaps I should search it."
 - id: 25795
 - id: 25796
 - id: 25797
 - id: 25798
-  examine: "Not suitable for children. Aim away from face."
 - id: 25799
-  examine: "A nicely-fitted door."
 - id: 25800
-  examine: "A nicely-fitted door."
 - id: 25801
-  examine: "I can climb down these stairs."
 - id: 25802
 - id: 25803
 - id: 25804
-  examine: "A sturdy wooden door."
 - id: 25805
-  examine: "A sturdy wooden door."
 - id: 25806
-  examine: "A sturdy wooden door."
 - id: 25807
-  examine: "A sturdy wooden door."
 - id: 25808
-  examine: "The bank teller will serve you from here."
 - id: 25809
-  examine: "Closed for business."
 - id: 25810
 - id: 25811
 - id: 25812
 - id: 25813
-  examine: "A sturdy wooden door."
 - id: 25814
-  examine: "A sturdy wooden door."
 - id: 25815
-  examine: "A sturdy wooden door."
 - id: 25816
-  examine: "A sturdy wooden door."
 - id: 25817
-  examine: "The ideal place to study."
 - id: 25818
-  examine: "With skill, I can play this."
 - id: 25819
-  examine: "The door is closed."
 - id: 25820
-  examine: "The door is open."
 - id: 25821
-  examine: "An attractively laid out collection of ranging weapons."
 - id: 25822
-  examine: "Lovely comfy-looking big bed."
 - id: 25823
-  examine: "Looking good."
 - id: 25824
-  examine: "Used for spinning thread."
 - id: 25825
-  examine: "A door."
 - id: 25826
-  examine: "A door."
 - id: 25827
-  examine: "A door."
 - id: 25828
-  examine: "A door."
 - id: 25829
 - id: 25830
 - id: 25831
 - id: 25832
-  examine: "A comfortable seat."
 - id: 25833
 - id: 25834
 - id: 25835
 - id: 25836
-  examine: "A wooden crate."
 - id: 25837
-  examine: "A wooden crate."
 - id: 25838
 - id: 25839
 - id: 25840
 - id: 25841
 - id: 25842
 - id: 25843
-  examine: "I can climb down this."
 - id: 25844
-  examine: "I can climb this."
 - id: 25845
 - id: 25846
 - id: 25847
@@ -40107,26 +35335,19 @@
 - id: 25874
 - id: 25875
 - id: 25876
-  examine: "A metal door."
 - id: 25877
-  examine: "A metal door."
 - id: 25878
 - id: 25879
-  examine: "For letting air in."
 - id: 25880
-  examine: "For letting air in."
 - id: 25881
 - id: 25882
 - id: 25883
 - id: 25884
 - id: 25885
-  examine: "The sheets are dirty."
 - id: 25886
-  examine: "The sheets are dirty."
 - id: 25887
 - id: 25888
 - id: 25889
-  examine: "One of the Knights of the Round Table."
 - id: 25890
 - id: 25891
 - id: 25892
@@ -40165,61 +35386,35 @@
 - id: 25925
 - id: 25926
 - id: 25927
-  examine: "A good source of books."
 - id: 25928
-  examine: "A good place to eat."
 - id: 25929
-  examine: "Ideal for washing things in."
 - id: 25930
-  examine: "A nice sturdy-looking table."
 - id: 25931
-  examine: "Useful for putting things on."
 - id: 25932
-  examine: "If only I had one of those at home..."
 - id: 25933
-  examine: "Full of lovely drinks."
 - id: 25934
-  examine: "Full of lovely drinks."
 - id: 25935
-  examine: "I can climb up these stairs."
 - id: 25936
 - id: 25937
-  examine: "Lets you put items into your bank."
 - id: 25938
-  examine: "I can climb this."
 - id: 25939
-  examine: "I can climb down this."
 - id: 25940
-  examine: "I can climb down this."
 - id: 25941
-  examine: "I can climb this."
 - id: 25942
-  examine: "He has been turned to stone."
 - id: 25943
 - id: 25944
-  examine: "Twelve bored men and women."
 - id: 25945
-  examine: "Twelve bored men and women."
 - id: 25946
-  examine: "Twelve bored men and women."
 - id: 25947
-  examine: "Twelve bored men and women."
 - id: 25948
-  examine: "Twelve bored men and women."
 - id: 25949
-  examine: "Twelve bored men and women."
 - id: 25950
-  examine: "Twelve bored men and women."
 - id: 25951
-  examine: "Twelve bored men and women."
 - id: 25952
-  examine: "Twelve bored men and women."
 - id: 25953
 - id: 25954
 - id: 25955
-  examine: "He is fast asleep."
 - id: 25956
-  examine: "Don't fancy your chances."
 - id: 25957
 - id: 25958
 - id: 25959
@@ -40245,7 +35440,6 @@
 - id: 25979
 - id: 25980
 - id: 25981
-  examine: "The gate is locked."
 - id: 25982
 - id: 25983
 - id: 25984
@@ -40282,11 +35476,9 @@
 - id: 26015
 - id: 26016
 - id: 26017
-  examine: "Stairs leading to the courtroom."
 - id: 26018
 - id: 26019
 - id: 26020
-  examine: "A table."
 - id: 26021
 - id: 26022
 - id: 26023
@@ -40309,28 +35501,17 @@
 - id: 26040
 - id: 26041
 - id: 26042
-  examine: "The gate to exit the courtroom."
 - id: 26043
-  examine: "Antique desk."
 - id: 26044
-  examine: "Antique desk."
 - id: 26045
-  examine: "A citizen of Seers' Village."
 - id: 26046
-  examine: "A citizen of Seers' Village."
 - id: 26047
-  examine: "A citizen of the Seers village."
 - id: 26048
-  examine: "A citizen of Seers' Village."
 - id: 26049
-  examine: "A citizen of Seers' Village."
 - id: 26050
-  examine: "A citizen of Seers' Village."
 - id: 26051
-  examine: "Stairs leading up."
 - id: 26052
 - id: 26053
-  examine: "A good source of books!"
 - id: 26054
 - id: 26055
 - id: 26056
@@ -40351,22 +35532,15 @@
 - id: 26071
 - id: 26072
 - id: 26073
-  examine: "A statue of a Knight of Camelot."
 - id: 26074
-  examine: "A table."
 - id: 26075
-  examine: "A chair."
 - id: 26076
-  examine: "A chair."
 - id: 26077
-  examine: "A chair."
 - id: 26078
 - id: 26079
 - id: 26080
 - id: 26081
-  examine: "A wrought iron gate."
 - id: 26082
-  examine: "A wrought iron gate."
 - id: 26083
 - id: 26084
 - id: 26085
@@ -40391,38 +35565,22 @@
 - id: 26104
 - id: 26105
 - id: 26106
-  examine: "I can climb up this."
 - id: 26107
-  examine: "I can climb this."
 - id: 26108
 - id: 26109
-  examine: "It looks like a spiders' nest to me."
 - id: 26110
-  examine: "Looks like the killer smashed this to leave the mansion."
 - id: 26111
-  examine: "A broken window."
 - id: 26112
-  examine: "Looks like the window has been repaired."
 - id: 26113
-  examine: "A good source of books!"
 - id: 26114
-  examine: "A strange crack cuts into the wall."
 - id: 26115
-  examine: "A strange crack cuts into the wall."
 - id: 26116
-  examine: "A strange crack cuts into the wall."
 - id: 26117
-  examine: "A strange crack cuts into the wall."
 - id: 26118
-  examine: "I can climb this."
 - id: 26119
-  examine: "Don't want to close this, I might not be able to get back down."
 - id: 26120
-  examine: "A pile of smelly rotting waste."
 - id: 26121
-  examine: "A sturdy home for bees."
 - id: 26122
-  examine: "Looks like this is where the cook stores flour."
 - id: 26123
 - id: 26124
 - id: 26125
@@ -40431,40 +35589,25 @@
 - id: 26128
 - id: 26129
 - id: 26130
-  examine: "A wrought iron gate."
 - id: 26131
-  examine: "A wrought iron gate."
 - id: 26132
-  examine: "A wrought iron gate."
 - id: 26133
-  examine: "A wrought iron gate."
 - id: 26134
 - id: 26135
 - id: 26136
 - id: 26137
-  examine: "A strip of fly paper."
 - id: 26138
 - id: 26139
 - id: 26140
-  examine: "A musical device."
 - id: 26141
-  examine: "A musical device."
 - id: 26142
-  examine: "A table for playing cards on."
 - id: 26143
-  examine: "Used for spinning thread."
 - id: 26144
-  examine: "I could probably burn this with fire."
 - id: 26145
-  examine: "Burnt open."
 - id: 26146
-  examine: "I could probably distract these with thievery."
 - id: 26147
-  examine: "I could probably distract these with thievery."
 - id: 26148
-  examine: "I could probably distract these with thievery."
 - id: 26149
-  examine: "An unstable portal across the dimensions..."
 - id: 26150
 - id: 26151
 - id: 26152
@@ -40483,11 +35626,8 @@
 - id: 26165
 - id: 26166
 - id: 26167
-  examine: "Abyssal Tendrils."
 - id: 26168
-  examine: "Abyssal Tendrils."
 - id: 26169
-  examine: "Abyssal Tendrils."
 - id: 26170
 - id: 26171
 - id: 26172
@@ -40498,21 +35638,13 @@
 - id: 26177
 - id: 26178
 - id: 26179
-  examine: "A grand old fireplace."
 - id: 26180
-  examine: "Something is cooking nicely here."
 - id: 26181
-  examine: "Ideal for cooking on."
 - id: 26182
-  examine: "Ideal for cooking on."
 - id: 26183
-  examine: "Ideal for cooking on."
 - id: 26184
-  examine: "Ideal for cooking on."
 - id: 26185
-  examine: "Hot!"
 - id: 26186
-  examine: "Hot!"
 - id: 26187
 - id: 26188
 - id: 26189
@@ -40520,47 +35652,29 @@
 - id: 26191
 - id: 26192
 - id: 26193
-  examine: "Place party drop items in here."
 - id: 26194
-  examine: "Pull me."
 - id: 26195
 - id: 26196
 - id: 26197
 - id: 26198
-  examine: "Happy Birthday!"
 - id: 26199
-  examine: "Happy Birthday!"
 - id: 26200
-  examine: "Happy Birthday!"
 - id: 26201
-  examine: "Suitable for celebrations."
 - id: 26202
-  examine: "Suitable for celebrations."
 - id: 26203
-  examine: "Suitable for celebrations."
 - id: 26204
-  examine: "Someone likes you..."
 - id: 26205
-  examine: "Someone likes you..."
 - id: 26206
 - id: 26207
-  examine: "A sturdy wooden door."
 - id: 26208
 - id: 26209
 - id: 26210
-  examine: "A basic wooden dining bench."
 - id: 26211
-  examine: "A basic oak dining bench."
 - id: 26212
-  examine: "A nice oak dining bench."
 - id: 26213
-  examine: "A teak dining bench."
 - id: 26214
-  examine: "A nice teak dining bench."
 - id: 26215
-  examine: "A mahogany dining bench."
 - id: 26216
-  examine: "A very expensive dining bench."
 - id: 26217
 - id: 26218
 - id: 26219
@@ -40576,286 +35690,158 @@
 - id: 26229
 - id: 26230
 - id: 26231
-  examine: "A wooden stool."
 - id: 26232
-  examine: "An oak stool."
 - id: 26233
-  examine: "Sit here and rule all you survey."
 - id: 26234
-  examine: "Sit here and rule all you survey."
 - id: 26235
-  examine: "Sit here and rule all you survey."
 - id: 26236
-  examine: "Sit here and rule all you survey."
 - id: 26237
-  examine: "Sit here and rule all you survey."
 - id: 26238
-  examine: "Sit here and rule all you survey."
 - id: 26239
-  examine: "Sit here and rule all you survey."
 - id: 26240
-  examine: "A nice teak dining bench."
 - id: 26241
-  examine: "A mahogany bench."
 - id: 26242
-  examine: "A very expensive bench."
 - id: 26243
-  examine: "This leads to somewhere... but where?"
 - id: 26244
-  examine: "It's old and pretty broken."
 - id: 26245
 - id: 26246
 - id: 26247
 - id: 26248
-  examine: "A well used tree."
 - id: 26249
-  examine: "A well used tree."
 - id: 26250
 - id: 26251
 - id: 26252
 - id: 26253
 - id: 26254
-  examine: "Lets you put items into your bank."
 - id: 26255
-  examine: "Information is displayed here."
 - id: 26256
-  examine: "Damages nearby monsters."
 - id: 26257
-  examine: "Shrine to the glory of Saradomin."
 - id: 26258
-  examine: "Shrine to the glory of Zamorak."
 - id: 26259
-  examine: "An ancient sentient tree."
 - id: 26260
-  examine: "An ancient sentient tree."
 - id: 26261
-  examine: "An ancient sentient tree."
 - id: 26262
-  examine: "A young sentient tree."
 - id: 26263
-  examine: "A young sentient tree."
 - id: 26264
-  examine: "Gives you more special attack power."
 - id: 26265
-  examine: "Deals extra damage whenever you hit."
 - id: 26266
-  examine: "Clears the floor."
 - id: 26267
-  examine: "A rough plinth."
 - id: 26268
-  examine: "A special vial."
 - id: 26269
-  examine: "Drink the potion when you're ready to begin your dream."
 - id: 26270
-  examine: "Drink from this vial to observe someone else's dream."
 - id: 26271
-  examine: "You must put money in here to pay for your dreams."
 - id: 26272
-  examine: "You must put money in here to pay for your dreams."
 - id: 26273
-  examine: "Exchange your reward points here."
 - id: 26274
 - id: 26275
 - id: 26276
-  examine: "Drink this when you're ready to wake up."
 - id: 26277
-  examine: "A barrel for storing super ranging potion."
 - id: 26278
-  examine: "A barrel for storing super magic potion."
 - id: 26279
-  examine: "A barrel for storing overload potion."
 - id: 26280
-  examine: "A barrel for storing absorption potion."
 - id: 26281
-  examine: "You might want this for Elvarg."
 - id: 26282
-  examine: "You might want these for a Tanglefoot."
 - id: 26283
-  examine: "Used for low level missile spells."
 - id: 26284
-  examine: "Used for medium level missile spells."
 - id: 26285
-  examine: "Used for high level missile spells."
 - id: 26286
-  examine: "One of the 4 basic elemental Runes."
 - id: 26287
-  examine: "One of the 4 basic elemental Runes."
 - id: 26288
-  examine: "One of the 4 basic elemental Runes."
 - id: 26289
-  examine: "One of the 4 basic elemental Runes."
 - id: 26290
-  examine: "You might want this for a Slagilith."
 - id: 26291
 - id: 26292
 - id: 26293
 - id: 26294
 - id: 26295
-  examine: "Now you know."
 - id: 26296
-  examine: "You can build a pet house here."
 - id: 26297
-  examine: "A house for 3 pets."
 - id: 26298
-  examine: "A house for 5 pets."
 - id: 26299
-  examine: "A house for 7 pets."
 - id: 26300
-  examine: "A hot volcanic furnace."
 - id: 26301
 - id: 26302
 - id: 26303
 - id: 26304
 - id: 26305
 - id: 26306
-  examine: "Used as a vantage point."
 - id: 26307
-  examine: "It no longer works."
 - id: 26308
-  examine: "A broken crossbow."
 - id: 26309
-  examine: "A ball and chain."
 - id: 26310
-  examine: "Used to break down obstacles."
 - id: 26311
-  examine: "A broken arrow."
 - id: 26312
-  examine: "Not useful any more."
 - id: 26313
-  examine: "A buried skeleton."
 - id: 26314
-  examine: "A damaged wheel."
 - id: 26315
-  examine: "A broken hammer."
 - id: 26316
-  examine: "Broken and sullied armour."
 - id: 26317
-  examine: "A broken ladder."
 - id: 26318
-  examine: "A smashed crate."
 - id: 26319
-  examine: "The arm of a warrior."
 - id: 26320
-  examine: "Some storage barrels."
 - id: 26321
 - id: 26322
 - id: 26323
 - id: 26324
-  examine: "This axe is old and blunt."
 - id: 26325
-  examine: "A tall and solid support."
 - id: 26326
-  examine: "A crate and cannonball."
 - id: 26327
-  examine: "They look sharp!"
 - id: 26328
-  examine: "A crate and broken shield."
 - id: 26329
-  examine: "They look sharp!"
 - id: 26330
-  examine: "A set of barrels."
 - id: 26331
-  examine: "A set of barrels and an axe."
 - id: 26332
-  examine: "A pole of some kind."
 - id: 26333
-  examine: "A broken catapult."
 - id: 26334
-  examine: "A set of crates."
 - id: 26335
-  examine: "A set of crates and a broken hammer."
 - id: 26336
-  examine: "A broken crossbow."
 - id: 26337
-  examine: "A set of crates and a wheel."
 - id: 26338
-  examine: "A set of crates."
 - id: 26339
-  examine: "They look sharp!"
 - id: 26340
-  examine: "Some wooden debris."
 - id: 26341
-  examine: "They look sharp!"
 - id: 26342
-  examine: "A strong battering ram."
 - id: 26343
-  examine: "A broken skullshield."
 - id: 26344
-  examine: "A set of barrels."
 - id: 26345
-  examine: "A set of boards."
 - id: 26346
-  examine: "A broken crane."
 - id: 26347
-  examine: "A broken handle."
 - id: 26348
-  examine: "I wonder what happened to them."
 - id: 26349
-  examine: "I wonder what happened to them."
 - id: 26350
-  examine: "I wonder what happened to them."
 - id: 26351
-  examine: "I wonder what happened to them."
 - id: 26352
-  examine: "I wonder what happened to them."
 - id: 26353
-  examine: "I wonder what happened to them."
 - id: 26354
-  examine: "I wonder what happened to them."
 - id: 26355
-  examine: "I wonder what happened to them."
 - id: 26356
-  examine: "I wonder what happened to them."
 - id: 26357
-  examine: "I wonder what happened to them."
 - id: 26358
-  examine: "I wonder what happened to them."
 - id: 26359
-  examine: "I wonder what happened to them."
 - id: 26360
-  examine: "Did I see him move?"
 - id: 26361
-  examine: "Did I see him move?"
 - id: 26362
-  examine: "Did I see him move?"
 - id: 26363
-  examine: "An altar to Zamorak."
 - id: 26364
-  examine: "An altar to Saradomin."
 - id: 26365
-  examine: "The last remaining holy place of the aviantese."
 - id: 26366
-  examine: "Altar to the goblin god."
 - id: 26367
 - id: 26368
-  examine: "A big hole that lets the light shine in."
 - id: 26369
-  examine: "No rope here."
 - id: 26370
-  examine: "Good for climbing."
 - id: 26371
 - id: 26372
-  examine: "There's a rope attached."
 - id: 26373
-  examine: "A place to attach a rope."
 - id: 26374
-  examine: "I can climb it."
 - id: 26375
 - id: 26376
-  examine: "There's a rope attached."
 - id: 26377
-  examine: "A place to attach a rope."
 - id: 26378
-  examine: "I can climb it."
 - id: 26379
-  examine: "I could fire a grapple to that."
 - id: 26380
-  examine: "A pillar leans over the chasm."
 - id: 26381
 - id: 26382
-  examine: "Maybe I can crawl through here."
 - id: 26383
-  examine: "He's dead."
 - id: 26384
 - id: 26385
 - id: 26386
@@ -40873,18 +35859,12 @@
 - id: 26398
 - id: 26399
 - id: 26400
-  examine: "They're rather icy, but it might be possible to climb them anyway."
 - id: 26401
-  examine: "They're rather icy, but it might be possible to climb them anyway."
 - id: 26402
-  examine: "They're rather icy, but it might be possible to climb them anyway."
 - id: 26403
 - id: 26404
-  examine: "They're rather icy, but it might be possible to climb them anyway."
 - id: 26405
-  examine: "They're rather icy, but it might be possible to climb them anyway."
 - id: 26406
-  examine: "They're rather icy, but it might be possible to climb them anyway."
 - id: 26407
 - id: 26408
 - id: 26409
@@ -40894,20 +35874,13 @@
 - id: 26413
 - id: 26414
 - id: 26415
-  examine: "Looks like it might be moveable, if I am strong enough."
 - id: 26416
-  examine: "Looks like it might be moveable, if I am strong enough."
 - id: 26417
-  examine: "Looks deep."
 - id: 26418
-  examine: "Looks deep."
 - id: 26419
 - id: 26420
-  examine: "Looks like I can tie something to this."
 - id: 26421
-  examine: "There's a rope tied to it."
 - id: 26422
-  examine: "I can climb it."
 - id: 26423
 - id: 26424
 - id: 26425
@@ -40943,15 +35916,11 @@
 - id: 26455
 - id: 26456
 - id: 26457
-  examine: "It's frozen shut; I can't open it."
 - id: 26458
-  examine: "It's frozen shut; I can't open it."
 - id: 26459
 - id: 26460
 - id: 26461
-  examine: "What's this?"
 - id: 26462
-  examine: "Staves in a barrel."
 - id: 26463
 - id: 26464
 - id: 26465
@@ -40981,32 +35950,20 @@
 - id: 26489
 - id: 26490
 - id: 26491
-  examine: "Warm water spouts from the ground."
 - id: 26492
-  examine: "Cast your votes here."
 - id: 26493
 - id: 26494
-  examine: "Falling flakes from the open crevasse above."
 - id: 26495
-  examine: "A descent of water."
 - id: 26496
-  examine: "A descent of water."
 - id: 26497
-  examine: "A descent of water."
 - id: 26498
-  examine: "A descent of water."
 - id: 26499
-  examine: "A descent of water."
 - id: 26500
 - id: 26501
 - id: 26502
-  examine: "Looks foreboding!"
 - id: 26503
-  examine: "Looks foreboding!"
 - id: 26504
-  examine: "Looks foreboding!"
 - id: 26505
-  examine: "Looks foreboding!"
 - id: 26506
 - id: 26507
 - id: 26508
@@ -41020,9 +35977,7 @@
 - id: 26516
 - id: 26517
 - id: 26518
-  examine: "Looks like I'll have to swim for it."
 - id: 26519
-  examine: "A wooden box."
 - id: 26520
 - id: 26521
 - id: 26522
@@ -41068,31 +36023,20 @@
 - id: 26562
 - id: 26563
 - id: 26564
-  examine: "Many brave adventurers have crawled through here, battered and bruised."
 - id: 26565
-  examine: "Many brave adventurers have crawled through here, battered and bruised."
 - id: 26566
-  examine: "Many brave adventurers have crawled through here, battered and bruised."
 - id: 26567
-  examine: "Many brave adventurers have entered, yet none have returned."
 - id: 26568
-  examine: "Many brave adventurers have entered, yet none have returned."
 - id: 26569
-  examine: "Many brave adventurers have entered, yet none have returned."
 - id: 26570
 - id: 26571
 - id: 26572
-  examine: "It almost looks like some supernatural force has blighted this plant."
 - id: 26573
 - id: 26574
 - id: 26575
-  examine: "Hot!"
 - id: 26576
-  examine: "Hot!"
 - id: 26577
-  examine: "Glowing embers."
 - id: 26578
-  examine: "Glowing embers."
 - id: 26579
 - id: 26580
 - id: 26581
@@ -41109,11 +36053,8 @@
 - id: 26592
 - id: 26593
 - id: 26594
-  examine: "These dyed fabrics are drying off."
 - id: 26595
-  examine: "These dyed fabrics are drying off."
 - id: 26596
-  examine: "These dyed fabrics are drying off."
 - id: 26597
 - id: 26598
 - id: 26599
@@ -41150,13 +36091,9 @@
 - id: 26630
 - id: 26631
 - id: 26632
-  examine: "A case. With books."
 - id: 26633
-  examine: "Some small stones, nothing interesting about them... really."
 - id: 26634
-  examine: "ALL of the numbers."
 - id: 26635
-  examine: "It's not doing anything wrong... Stop bullying it!"
 - id: 26636
 - id: 26637
 - id: 26638
@@ -41164,15 +36101,10 @@
 - id: 26640
 - id: 26641
 - id: 26642
-  examine: "When your clan has been challenged to a battle, step through here."
 - id: 26643
-  examine: "When your clan has been challenged to a battle, step through here."
 - id: 26644
-  examine: "When your clan has been challenged to a battle, step through here."
 - id: 26645
-  examine: "Step through here to bash people around in safety."
 - id: 26646
-  examine: "The way out."
 - id: 26647
 - id: 26648
 - id: 26649
@@ -41181,51 +36113,32 @@
 - id: 26652
 - id: 26653
 - id: 26654
-  examine: "Leads to a deeper part of the mine."
 - id: 26655
-  examine: "Leads to the mines under Falador."
 - id: 26656
 - id: 26657
 - id: 26658
 - id: 26659
 - id: 26660
 - id: 26661
-  examine: "A mineral vein."
 - id: 26662
-  examine: "A mineral vein."
 - id: 26663
-  examine: "A mineral vein."
 - id: 26664
-  examine: "A mineral vein."
 - id: 26665
-  examine: "A mineral vein that has been mined to depletion."
 - id: 26666
-  examine: "A mineral vein that has been mined to depletion."
 - id: 26667
-  examine: "A mineral vein that has been mined to depletion."
 - id: 26668
-  examine: "A mineral vein that has been mined to depletion."
 - id: 26669
-  examine: "It supports the water wheel."
 - id: 26670
-  examine: "It's fallen slightly out of alignment."
 - id: 26671
-  examine: "Keeps the water flowing."
 - id: 26672
-  examine: "It ought to be spinning."
 - id: 26673
 - id: 26674
-  examine: "Pay-dirt can be put in here."
 - id: 26675
 - id: 26676
 - id: 26677
-  examine: "Ore is collected here after it's been washed."
 - id: 26678
-  examine: "Ore is collected here after it's been washed."
 - id: 26679
-  examine: "A lump of rock has fallen from above."
 - id: 26680
-  examine: "A lump of rock has fallen from above."
 - id: 26681
 - id: 26682
 - id: 26683
@@ -41238,220 +36151,126 @@
 - id: 26690
 - id: 26691
 - id: 26692
-  examine: "The symbol glows brightly with energy."
 - id: 26693
-  examine: "The symbol is inert."
 - id: 26694
-  examine: "Can your clan dominate this area?"
 - id: 26695
-  examine: "Wipe the other team off the hill!"
 - id: 26696
-  examine: "Take the area at all costs!"
 - id: 26697
-  examine: "Hold the area!"
 - id: 26698
-  examine: "Take the area at all costs!"
 - id: 26699
 - id: 26700
 - id: 26701
 - id: 26702
 - id: 26703
-  examine: "A small pile of snow."
 - id: 26704
-  examine: "A small pile of snow."
 - id: 26705
-  examine: "It almost looks like some supernatural force has blighted this plant."
 - id: 26706
 - id: 26707
-  examine: "It's open."
 - id: 26708
 - id: 26709
-  examine: "It sounds like there are dangerous creatures in there."
 - id: 26710
 - id: 26711
-  examine: "A convenient bank chest."
 - id: 26712
-  examine: "Leads to another section of the cave."
 - id: 26713
-  examine: "A mounted cape of infernal power."
 - id: 26714
-  examine: "A mounted cape worn by the most experienced players."
 - id: 26715
 - id: 26716
 - id: 26717
-  examine: "Someone's brought in a lot of sand."
 - id: 26718
-  examine: "Someone's brought in a lot of sand."
 - id: 26719
-  examine: "Someone's brought in a lot of sand."
 - id: 26720
-  examine: "A tree root is protruding through the floor."
 - id: 26721
-  examine: "A tree root is protruding through the floor."
 - id: 26722
 - id: 26723
 - id: 26724
 - id: 26725
 - id: 26726
 - id: 26727
-  examine: "This way to become a quitter."
 - id: 26728
-  examine: "This way to become a quitter."
 - id: 26729
-  examine: "A commonly found bush."
 - id: 26730
 - id: 26731
-  examine: "This way to become a quitter."
 - id: 26732
-  examine: "This way to become a quitter."
 - id: 26733
-  examine: "This way to become a quitter."
 - id: 26734
-  examine: "This way to become a quitter."
 - id: 26735
-  examine: "This way to become a quitter."
 - id: 26736
-  examine: "This way to become a quitter."
 - id: 26737
-  examine: "This way to become a quitter."
 - id: 26738
-  examine: "Returns you to the lobby area."
 - id: 26739
-  examine: "Returns you to the lobby area."
 - id: 26740
-  examine: "Returns you to the lobby area."
 - id: 26741
-  examine: "Get a closer look at the battle."
 - id: 26742
 - id: 26743
-  examine: "Get a closer look at the battle."
 - id: 26744
 - id: 26745
-  examine: "Get a closer look at the battle."
 - id: 26746
 - id: 26747
-  examine: "Get a closer look at the battle."
 - id: 26748
 - id: 26749
-  examine: "Get a closer look at the battle."
 - id: 26750
 - id: 26751
 - id: 26752
 - id: 26753
 - id: 26754
-  examine: "It doesn't look healthy."
 - id: 26755
-  examine: "The chambers of fire form the perfect forging location."
 - id: 26756
-  examine: "Let's see how good you REALLY are..."
 - id: 26757
-  examine: "I wonder what's inside it."
 - id: 26758
 - id: 26759
-  examine: "Valuable artefacts Mandrith has collected on his journeys."
 - id: 26760
-  examine: "Stops people walking past."
 - id: 26761
-  examine: "I wonder what this does..."
 - id: 26762
-  examine: "Just in case you aren't getting enough peril out here."
 - id: 26763
-  examine: "You can crawl through here without difficulty."
 - id: 26764
 - id: 26765
-  examine: "Riiiiiight?"
 - id: 26766
-  examine: "It might be dangerous in there, but it's pretty dangerous out here too."
 - id: 26767
-  examine: "You can crawl through here without difficulty."
 - id: 26768
-  examine: "A wall jutting out into the path."
 - id: 26769
-  examine: "You can crawl through here without difficulty."
 - id: 26770
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26771
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26772
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26773
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26774
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26775
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26776
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26777
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26778
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26779
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26780
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26781
-  examine: "It presumably leads to the cave from which these creatures emerged."
 - id: 26782
-  examine: "Magical energy, accumulated under the Wilderness for aeons, gushes forth."
 - id: 26783
 - id: 26784
-  examine: "This will sink into the ground when the battle begins."
 - id: 26785
-  examine: "It's sinking!"
 - id: 26786
-  examine: "This will sink into the ground when the battle begins."
 - id: 26787
-  examine: "It's sinking!"
 - id: 26788
-  examine: "This will sink into the ground when the battle begins."
 - id: 26789
-  examine: "It's sinking!"
 - id: 26790
-  examine: "This will sink into the ground when the battle begins."
 - id: 26791
-  examine: "It's sinking!"
 - id: 26792
-  examine: "This will sink into the ground when the battle begins."
 - id: 26793
-  examine: "It's sinking!"
 - id: 26794
-  examine: "This will be removed when the battle begins."
 - id: 26795
 - id: 26796
-  examine: "Cast your votes here."
 - id: 26797
-  examine: "Cast your votes here."
 - id: 26798
-  examine: "Cast your votes here."
 - id: 26799
-  examine: "Cast your votes here."
 - id: 26800
-  examine: "Cast your votes here."
 - id: 26801
-  examine: "Cast your votes here."
 - id: 26802
-  examine: "Cast your votes here."
 - id: 26803
-  examine: "Cast your votes here."
 - id: 26804
-  examine: "Cast your votes here."
 - id: 26805
-  examine: "Cast your votes here."
 - id: 26806
-  examine: "Cast your votes here."
 - id: 26807
-  examine: "Cast your votes here."
 - id: 26808
-  examine: "Cast your votes here."
 - id: 26809
-  examine: "Cast your votes here."
 - id: 26810
-  examine: "Cast your votes here."
 - id: 26811
-  examine: "Cast your votes here."
 - id: 26812
-  examine: "Cast your votes here."
 - id: 26813
 - id: 26814
 - id: 26815
@@ -41462,121 +36281,65 @@
 - id: 26820
 - id: 26821
 - id: 26822
-  examine: "A comfy home for small creatures."
 - id: 26823
-  examine: "A comfy home for very small creatures."
 - id: 26824
-  examine: "One could keep quite a large bird in here."
 - id: 26825
-  examine: "Champions of the 2014 P2P Clan Cups!"
 - id: 26826
-  examine: "Champions of the 2014 Pure Clan Cups!"
 - id: 26828
-  examine: "Reigning Champions of the F2P & P2P PvP Clan Cups!"
 - id: 26829
-  examine: "Reigning Champions of the PvM Clan Cup!"
 - id: 26830
-  examine: "A house for 9 pets."
 - id: 26831
-  examine: "A house for 12 pets."
 - id: 26832
-  examine: "A house for all one-off pets, plus 12 extras."
 - id: 26833
-  examine: "You can build a habitat here."
 - id: 26834
-  examine: "Stumpy."
 - id: 26835
-  examine: "A tree."
 - id: 26836
-  examine: "Touch me, I dare you!"
 - id: 26837
-  examine: "A little house in your POH - houseception?"
 - id: 26838
-  examine: "Nothing to do with crates."
 - id: 26839
-  examine: "You can build a habitat here."
 - id: 26840
-  examine: "It's the ground."
 - id: 26841
-  examine: "It's the ground."
 - id: 26842
-  examine: "It's the ground."
 - id: 26843
-  examine: "It's the ground."
 - id: 26844
-  examine: "It's the ground."
 - id: 26845
-  examine: "You can build a habitat here."
 - id: 26846
-  examine: "It's the ground."
 - id: 26847
-  examine: "It's the ground."
 - id: 26848
-  examine: "It's the ground."
 - id: 26849
-  examine: "It's the ground."
 - id: 26850
-  examine: "It's the ground."
 - id: 26851
-  examine: "You can build a habitat here."
 - id: 26852
-  examine: "It's the ground."
 - id: 26853
-  examine: "It's the ground."
 - id: 26854
-  examine: "It's the ground."
 - id: 26855
-  examine: "It's the ground."
 - id: 26856
-  examine: "It's the ground."
 - id: 26857
-  examine: "You can build a scratching post here."
 - id: 26858
-  examine: "A rough post where cats may play."
 - id: 26859
-  examine: "A sturdy post where cats may play."
 - id: 26860
-  examine: "A fancy post where cats may play."
 - id: 26861
-  examine: "You can build an arena here."
 - id: 26862
-  examine: "Where your pets can let off a bit of steam."
 - id: 26863
-  examine: "Where your pets can let off a bit of steam."
 - id: 26864
-  examine: "Where your pets can let off a bit of steam."
 - id: 26865
-  examine: "You can build an arena here."
 - id: 26866
-  examine: "Where your pets can let off a bit of steam."
 - id: 26867
-  examine: "You can add a pet list here."
 - id: 26868
-  examine: "A catalogue of one-off pets."
 - id: 26869
-  examine: "You can build a pet feeder here."
 - id: 26870
-  examine: "Automatically feeds any kittens in the house."
 - id: 26871
-  examine: "Automatically feeds any kittens in the house."
 - id: 26872
-  examine: "Automatically feeds any kittens in the house."
 - id: 26873
-  examine: "A rocky outcrop."
 - id: 26874
-  examine: "A rocky outcrop."
 - id: 26875
-  examine: "A sturdy vine."
 - id: 26876
 - id: 26877
-  examine: "A sturdy vine."
 - id: 26878
 - id: 26879
 - id: 26880
-  examine: "It might be sturdy enough to climb."
 - id: 26881
 - id: 26882
-  examine: "It might be sturdy enough to climb."
 - id: 26883
 - id: 26884
 - id: 26885
@@ -41648,9 +36411,7 @@
 - id: 26951
 - id: 26952
 - id: 26953
-  examine: "Noxious gases are being exchanged."
 - id: 26954
-  examine: "The vent is silent."
 - id: 26955
 - id: 26956
 - id: 26957
@@ -41711,11 +36472,8 @@
 - id: 27012
 - id: 27013
 - id: 27014
-  examine: "An eerie glow emanates from these tendrils."
 - id: 27015
-  examine: "An eerie glow emanates from these tendrils."
 - id: 27016
-  examine: "An eerie glow emanates from these tendrils."
 - id: 27017
 - id: 27018
 - id: 27019
@@ -41727,11 +36485,8 @@
 - id: 27025
 - id: 27026
 - id: 27027
-  examine: "An appendage for activating something."
 - id: 27028
-  examine: "An appendage for activating something."
 - id: 27029
-  examine: "A font filled with a viscous corrosive."
 - id: 27030
 - id: 27031
 - id: 27032
@@ -41747,13 +36502,9 @@
 - id: 27042
 - id: 27043
 - id: 27044
-  examine: "A parasitic organism that feeds on the flesh of demons."
 - id: 27045
-  examine: "Various fluids secreted by the Overseer during its long imprisonment."
 - id: 27046
-  examine: "A growth on the flesh of the Abyss."
 - id: 27047
-  examine: "A book left for you by the Overseer."
 - id: 27048
 - id: 27049
 - id: 27050
@@ -41761,102 +36512,62 @@
 - id: 27052
 - id: 27053
 - id: 27054
-  examine: "A tunnel through the abyss."
 - id: 27055
-  examine: "It looks impossible to pass through from this side."
 - id: 27056
 - id: 27057
 - id: 27058
 - id: 27059
 - id: 27060
-  examine: "A hardy evergreen tree."
 - id: 27061
-  examine: "This tree has been cut down."
 - id: 27062
-  examine: "Looks impassable."
 - id: 27063
-  examine: "Looks potentially passable."
 - id: 27064
-  examine: "This old tree is rotting away, but it might float."
 - id: 27065
-  examine: "A primitive looking boat."
 - id: 27066
-  examine: "I hope it doesn't sink."
 - id: 27067
 - id: 27068
-  examine: "You can use this to add or remove rooms."
 - id: 27069
-  examine: "You can use this to add or remove rooms."
 - id: 27070
-  examine: "You can build a chapel window here."
 - id: 27071
-  examine: "You can build various fiendish devices here."
 - id: 27072
-  examine: "What could happen on this spot?"
 - id: 27073
-  examine: "A basic chapel window."
 - id: 27074
-  examine: "What nice shapes you can make out of glass!"
 - id: 27075
-  examine: "It fills the room with coloured light."
 - id: 27076
-  examine: "What nice shapes you can make out of glass!"
 - id: 27077
-  examine: "It fills the room with coloured light."
 - id: 27078
-  examine: "What nice shapes you can make out of glass!"
 - id: 27079
-  examine: "It fills the room with coloured light."
 - id: 27080
-  examine: "What nice shapes you can make out of glass!"
 - id: 27081
-  examine: "It fills the room with coloured light."
 - id: 27082
 - id: 27083
 - id: 27084
-  examine: "An ominous door."
 - id: 27085
-  examine: "An ominous door."
 - id: 27086
-  examine: "An ominous door."
 - id: 27087
-  examine: "An ominous door."
 - id: 27088
 - id: 27089
 - id: 27090
 - id: 27091
 - id: 27092
-  examine: "A market stall."
 - id: 27093
-  examine: "Walk into the..."
 - id: 27094
 - id: 27095
-  examine: "Connects the Challenge area to Edgeville."
 - id: 27096
-  examine: "Lets you give up."
 - id: 27097
-  examine: "He won't be ruining another holiday any time soon."
 - id: 27098
-  examine: "Who could that possibly belong to?"
 - id: 27099
 - id: 27100
-  examine: "For storage."
 - id: 27101
-  examine: "For a little more storage."
 - id: 27102
-  examine: "For even more storage."
 - id: 27103
 - id: 27104
 - id: 27105
 - id: 27106
 - id: 27107
-  examine: "For making juniper charcoal."
 - id: 27108
-  examine: "Some juniper logs have been placed in here."
 - id: 27109
-  examine: "Logs are being reduced to juniper charcoal."
 - id: 27110
-  examine: "Your juniper charcoal is ready."
 - id: 27111
 - id: 27112
 - id: 27113
@@ -41864,18 +36575,13 @@
 - id: 27115
 - id: 27116
 - id: 27117
-  examine: "You really don't see that many of these."
 - id: 27118
-  examine: "I wonder what these are?"
 - id: 27119
 - id: 27120
 - id: 27121
-  examine: "I can see fish swimming in the water."
 - id: 27122
 - id: 27123
-  examine: "It looks grey and dead."
 - id: 27124
-  examine: "It's been reanimated."
 - id: 27125
 - id: 27126
 - id: 27127
@@ -41951,63 +36657,37 @@
 - id: 27197
 - id: 27198
 - id: 27199
-  examine: "Wooden stairs."
 - id: 27200
-  examine: "Wooden stairs."
 - id: 27201
-  examine: "Wooden stairs."
 - id: 27202
-  examine: "Wooden stairs."
 - id: 27203
-  examine: "Wooden stairs."
 - id: 27204
-  examine: "Wooden stairs."
 - id: 27205
-  examine: "It's full of medpacks."
 - id: 27206
 - id: 27207
 - id: 27208
 - id: 27209
-  examine: "Covered in financial paperwork."
 - id: 27210
-  examine: "Covered in financial paperwork."
 - id: 27211
 - id: 27212
 - id: 27213
 - id: 27214
-  examine: "Words of comfort and strength for times when comrades have fallen."
 - id: 27215
-  examine: "A melee training dummy for Shayzien soldiers."
 - id: 27216
-  examine: "A ranged target for Shayzien soldiers."
 - id: 27217
-  examine: "A ranged target for Shayzien soldiers."
 - id: 27218
-  examine: "A ranged target for Shayzien soldiers."
 - id: 27219
-  examine: "A ranged target for Shayzien soldiers."
 - id: 27220
-  examine: "A wooden barrel for storage."
 - id: 27221
-  examine: "A wooden barrel for storage."
 - id: 27222
-  examine: "A wooden barrel containing water."
 - id: 27223
-  examine: "A crate for storing food rations."
 - id: 27224
-  examine: "A crate for storing food rations."
 - id: 27225
-  examine: "A crate for storing food rations."
 - id: 27226
-  examine: "A crate for storing food rations."
 - id: 27227
-  examine: "Wooden barrels for storage."
 - id: 27228
-  examine: "A large barrel for storage."
 - id: 27229
-  examine: "A large barrel for storage."
 - id: 27230
-  examine: "Notifications from informants are listed here."
 - id: 27231
 - id: 27232
 - id: 27233
@@ -42032,64 +36712,44 @@
 - id: 27252
 - id: 27253
 - id: 27254
-  examine: "The bank teller will serve you from here."
 - id: 27255
 - id: 27256
-  examine: "Maybe the contents survived the crash."
 - id: 27257
-  examine: "Smells like there's fresh air up there!"
 - id: 27258
-  examine: "Smells like there's fresh air up there!"
 - id: 27259
 - id: 27260
-  examine: "The bank teller will serve you from here."
 - id: 27261
-  examine: "The remains of one of Glough's experiments."
 - id: 27262
 - id: 27263
-  examine: "The bank teller will serve you from here."
 - id: 27264
 - id: 27265
-  examine: "The bank teller will serve you from here."
 - id: 27266
 - id: 27267
-  examine: "The bank teller will serve you from here."
 - id: 27268
 - id: 27269
-  examine: "You would be hard pressed to fit fifteen people on that!"
 - id: 27270
 - id: 27271
-  examine: "You would be hard pressed to fit fifteen people on that!"
 - id: 27272
 - id: 27273
 - id: 27274
 - id: 27275
-  examine: "You would be hard pressed to fit fifteen people on that!"
 - id: 27276
 - id: 27277
-  examine: "You would be hard pressed to fit fifteen people on that!"
 - id: 27278
 - id: 27279
 - id: 27280
-  examine: "You would be hard pressed to fit fifteen people on that!"
 - id: 27281
 - id: 27282
-  examine: "You would be hard pressed to fit fifteen people on that!"
 - id: 27283
 - id: 27284
-  examine: "You would be hard pressed to fit fifteen people on that!"
 - id: 27285
 - id: 27286
-  examine: "You would be hard pressed to fit fifteen people on that!"
 - id: 27287
 - id: 27288
-  examine: "You would be hard pressed to fit fifteen people on that!"
 - id: 27289
 - id: 27290
-  examine: "You would be hard pressed to fit fifteen people on that!"
 - id: 27291
 - id: 27292
-  examine: "The bank teller will serve you from here."
 - id: 27293
 - id: 27294
 - id: 27295
@@ -42133,200 +36793,107 @@
 - id: 27333
 - id: 27334
 - id: 27335
-  examine: "A big luxurious bed."
 - id: 27336
-  examine: "An even bigger luxurious bed."
 - id: 27337
-  examine: "A table."
 - id: 27338
-  examine: "A comfy lounge sofa-bed."
 - id: 27339
-  examine: "A small comfy lounge sofa-bed."
 - id: 27340
-  examine: "A small Ivory table."
 - id: 27341
-  examine: "A small Ivory table."
 - id: 27342
-  examine: "A small Ivory table."
 - id: 27343
-  examine: "A small Ivory table."
 - id: 27344
-  examine: "A small Ivory table."
 - id: 27345
-  examine: "A small Ivory table."
 - id: 27346
-  examine: "A small Ivory table."
 - id: 27347
-  examine: "A small Ivory table."
 - id: 27348
-  examine: "A small Ivory table."
 - id: 27349
-  examine: "A small Ivory table."
 - id: 27350
-  examine: "A small Ivory table."
 - id: 27351
-  examine: "A small Ivory table."
 - id: 27352
 - id: 27353
-  examine: "A vast table."
 - id: 27354
-  examine: "A vast table."
 - id: 27355
 - id: 27356
-  examine: "A vast table."
 - id: 27357
-  examine: "A vast table."
 - id: 27358
-  examine: "A wooden bookcase used to keep battlement plans."
 - id: 27359
-  examine: "A wooden bookcase used to keep battlement plans."
 - id: 27360
-  examine: "A wooden bookcase used to keep battlement plans."
 - id: 27361
-  examine: "Something's burning here."
 - id: 27362
-  examine: "Sturdy metal handholds."
 - id: 27363
 - id: 27364
-  examine: "Looks abandoned."
 - id: 27365
-  examine: "Shayzien built defences."
 - id: 27366
-  examine: "Shayzien built defences."
 - id: 27367
-  examine: "Sadly this is no place for a fiddly fletching job."
 - id: 27368
-  examine: "Shayzien built defences."
 - id: 27369
-  examine: "Broken crates."
 - id: 27370
-  examine: "Shayzien built defences."
 - id: 27371
-  examine: "Broken Crates"
 - id: 27372
-  examine: "Shayzien built defences."
 - id: 27373
 - id: 27374
 - id: 27375
-  examine: "Ingredients are found in here."
 - id: 27376
-  examine: "Utensils are found in here."
 - id: 27377
-  examine: "Raw meat for cooking."
 - id: 27378
-  examine: "Food is served from here."
 - id: 27379
 - id: 27380
 - id: 27381
 - id: 27382
 - id: 27383
-  examine: "Tithe seeds may be planted here."
 - id: 27384
-  examine: "This patch is dry."
 - id: 27385
-  examine: "This patch has been watered."
 - id: 27386
-  examine: "This patch is blighted."
 - id: 27387
-  examine: "This patch is dry."
 - id: 27388
-  examine: "This patch has been watered."
 - id: 27389
-  examine: "This patch is blighted."
 - id: 27390
-  examine: "This patch is dry."
 - id: 27391
-  examine: "This patch has been watered."
 - id: 27392
-  examine: "This patch is blighted."
 - id: 27393
-  examine: "This patch is fully grown."
 - id: 27394
-  examine: "This patch is blighted."
 - id: 27395
-  examine: "This patch is dry."
 - id: 27396
-  examine: "This patch has been watered."
 - id: 27397
-  examine: "This patch is blighted."
 - id: 27398
-  examine: "This patch is dry."
 - id: 27399
-  examine: "This patch has been watered."
 - id: 27400
-  examine: "This patch is blighted."
 - id: 27401
-  examine: "This patch is dry."
 - id: 27402
-  examine: "This patch has been watered."
 - id: 27403
-  examine: "This patch is blighted."
 - id: 27404
-  examine: "This patch is fully grown."
 - id: 27405
-  examine: "This patch is blighted."
 - id: 27406
-  examine: "This patch is dry."
 - id: 27407
-  examine: "This patch has been watered."
 - id: 27408
-  examine: "This patch is blighted."
 - id: 27409
-  examine: "This patch is dry."
 - id: 27410
-  examine: "This patch has been watered."
 - id: 27411
-  examine: "This patch is blighted."
 - id: 27412
-  examine: "This patch is dry."
 - id: 27413
-  examine: "This patch has been watered."
 - id: 27414
-  examine: "This patch is blighted."
 - id: 27415
-  examine: "This patch is fully grown."
 - id: 27416
-  examine: "This patch is blighted."
 - id: 27417
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27418
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27419
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27420
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27421
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27422
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27423
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27424
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27425
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27426
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27427
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27428
-  examine: "Farmer Gricoller must have been unable to save it."
 - id: 27429
-  examine: "For taking the fruit to market."
 - id: 27430
-  examine: "Grab a seed. Plant away."
 - id: 27431
-  examine: "For putting fruit in."
 - id: 27432
-  examine: "For putting fruit in."
 - id: 27433
-  examine: "A natural deposit of saltpetre."
 - id: 27434
-  examine: "A natural deposit of saltpetre."
 - id: 27435
-  examine: "A natural deposit of saltpetre."
 - id: 27436
-  examine: "A natural deposit of saltpetre."
 - id: 27437
 - id: 27438
 - id: 27439
@@ -42334,11 +36901,8 @@
 - id: 27441
 - id: 27442
 - id: 27443
-  examine: "It looks rough, but effective."
 - id: 27444
-  examine: "It looks rough, but effective."
 - id: 27445
-  examine: "Farmer Gricoller's farm entrance."
 - id: 27446
 - id: 27447
 - id: 27448
@@ -42379,13 +36943,9 @@
 - id: 27483
 - id: 27484
 - id: 27485
-  examine: "Everything looks greener on the other side."
 - id: 27486
-  examine: "Provides much-needed transparency."
 - id: 27487
-  examine: "People who live in glass houses shouldn't stow thrones."
 - id: 27488
-  examine: "Like a window on a big hinge."
 - id: 27489
 - id: 27490
 - id: 27491
@@ -42397,15 +36957,10 @@
 - id: 27497
 - id: 27498
 - id: 27499
-  examine: "An old matured tree."
 - id: 27500
-  examine: "The 'brb' message of trees."
 - id: 27501
-  examine: "A place of veneration."
 - id: 27502
-  examine: "Assistant Le Smith didn't survive the crash."
 - id: 27503
-  examine: "This tree was destroyed in the crash."
 - id: 27504
 - id: 27505
 - id: 27506
@@ -42413,96 +36968,53 @@
 - id: 27508
 - id: 27509
 - id: 27510
-  examine: "An arbor where smaller vines could grow."
 - id: 27511
-  examine: "Sit and admire the view."
 - id: 27512
-  examine: "A chair made to sit on."
 - id: 27513
-  examine: "A chair made to sit on."
 - id: 27514
 - id: 27515
 - id: 27516
-  examine: "Cook some delicious food on here!"
 - id: 27517
-  examine: "Cook some delicious food on here!"
 - id: 27518
-  examine: "It's got an impressive range of ales for a land with no hops patch."
 - id: 27519
-  examine: "It feels sticky."
 - id: 27520
-  examine: "A rack of barrels."
 - id: 27521
-  examine: "An empty basket."
 - id: 27522
-  examine: "A basket filled with apples."
 - id: 27523
-  examine: "A basket filled with fish."
 - id: 27524
-  examine: "A basket filled with onions."
 - id: 27525
-  examine: "A basket filled with potatos."
 - id: 27526
-  examine: "A basket filled with wood."
 - id: 27527
-  examine: "A bed to sleep on."
 - id: 27528
-  examine: "A bed to sleep on."
 - id: 27529
-  examine: "A bed to sleep on."
 - id: 27530
-  examine: "A bench."
 - id: 27531
-  examine: "It's full of beer, a state to which many people aspire."
 - id: 27532
-  examine: "A crate."
 - id: 27533
-  examine: "A crate."
 - id: 27534
-  examine: "A cupboard with bottles of wine."
 - id: 27535
-  examine: "A cupboard with bottles of wine."
 - id: 27536
-  examine: "A water fountain."
 - id: 27537
-  examine: "A fruit stall."
 - id: 27538
-  examine: "A fruit stall."
 - id: 27539
-  examine: "Large drawers."
 - id: 27540
-  examine: "Large drawers."
 - id: 27541
-  examine: "A piano."
 - id: 27542
-  examine: "A cupboard filled with plates."
 - id: 27543
-  examine: "Empty pots."
 - id: 27544
-  examine: "A round table."
 - id: 27545
-  examine: "Drawers."
 - id: 27546
-  examine: "A stool to sit on."
 - id: 27547
-  examine: "A stool to sit on."
 - id: 27548
-  examine: "A stool to sit on."
 - id: 27549
 - id: 27550
 - id: 27551
 - id: 27552
-  examine: "A barrel of fresh fish."
 - id: 27553
-  examine: "An empty barrel."
 - id: 27554
-  examine: "It's an insulated chest full of ice."
 - id: 27555
-  examine: "It looks like the crane is in need of repair."
 - id: 27556
-  examine: "It's used for collecting fish from below the docks."
 - id: 27557
-  examine: "Damp castings left by sandworms."
 - id: 27558
 - id: 27559
 - id: 27560
@@ -42580,11 +37092,8 @@
 - id: 27632
 - id: 27633
 - id: 27634
-  examine: "An extremely solid ladder fashioned from rough wood."
 - id: 27635
-  examine: "An extremely solid ladder fashioned from rough wood."
 - id: 27636
-  examine: "An extremely solid ladder fashioned from rough wood."
 - id: 27637
 - id: 27638
 - id: 27639
@@ -42597,7 +37106,6 @@
 - id: 27646
 - id: 27647
 - id: 27648
-  examine: "Not the mail kind."
 - id: 27649
 - id: 27650
 - id: 27651
@@ -42613,98 +37121,53 @@
 - id: 27661
 - id: 27662
 - id: 27663
-  examine: "I guess I could sleep in it if I was really tired."
 - id: 27664
-  examine: "I guess I could sleep in it if I was really tired."
 - id: 27665
-  examine: "I guess I could sleep in it if I was really tired."
 - id: 27666
-  examine: "I guess I could sleep in it if I was really tired."
 - id: 27667
-  examine: "I guess I could sleep in it if I was really tired."
 - id: 27668
-  examine: "I guess I could sleep in it if I was really tired."
 - id: 27669
-  examine: "I guess I could sleep in it if I was really tired."
 - id: 27670
-  examine: "I guess I could sleep in it if I was really tired."
 - id: 27671
-  examine: "I guess I could sleep in it if I was really tired."
 - id: 27672
-  examine: "I guess I could sleep in it if I was really tired."
 - id: 27673
-  examine: "For storing personal belongings."
 - id: 27674
-  examine: "For storing personal belongings."
 - id: 27675
-  examine: "For storing personal belongings."
 - id: 27676
-  examine: "The water looks cold and unwelcoming."
 - id: 27677
-  examine: "I guess I could wash in it if I was really dirty."
 - id: 27678
-  examine: "A wooden stool."
 - id: 27679
-  examine: "A wooden stool."
 - id: 27680
-  examine: "A wooden stool. Not so suitable for sitting on anymore."
 - id: 27681
-  examine: "A well used chair."
 - id: 27682
-  examine: "A well used chair."
 - id: 27683
-  examine: "A well used chair."
 - id: 27684
-  examine: "A sturdy chair."
 - id: 27685
-  examine: "Generally used for putting things on."
 - id: 27686
-  examine: "Generally used for putting things on."
 - id: 27687
-  examine: "Generally used for putting things on."
 - id: 27688
-  examine: "Generally used for putting things on."
 - id: 27689
-  examine: "Generally used for putting things on."
 - id: 27690
-  examine: "Generally used for putting things on."
 - id: 27691
-  examine: "Generally used for putting things on."
 - id: 27692
-  examine: "Generally used for putting things on."
 - id: 27693
 - id: 27694
 - id: 27695
 - id: 27696
-  examine: "Unfortunately they are roped off."
 - id: 27697
-  examine: "A table with beer barrels on it."
 - id: 27698
-  examine: "I wonder what happened to this."
 - id: 27699
-  examine: "It doesn't look very secure."
 - id: 27700
-  examine: "Shelves for storing stuff."
 - id: 27701
-  examine: "Shelves for storing stuff."
 - id: 27702
-  examine: "Shelves for storing stuff."
 - id: 27703
-  examine: "A cupboard for storing stuff."
 - id: 27704
-  examine: "A cupboard for storing stuff."
 - id: 27705
-  examine: "Generally used for putting things on."
 - id: 27706
-  examine: "Generally used for putting things on."
 - id: 27707
-  examine: "I dread to think what this is in the plughole."
 - id: 27708
-  examine: "Looks far too dirty to use."
 - id: 27709
-  examine: "Some old copper pots."
 - id: 27710
-  examine: "Some old copper pots."
 - id: 27711
 - id: 27712
 - id: 27713
@@ -42713,22 +37176,14 @@
 - id: 27716
 - id: 27717
 - id: 27718
-  examine: "The bank teller will serve you from here."
 - id: 27719
-  examine: "The bank teller will serve you from here."
 - id: 27720
-  examine: "The bank teller will serve you from here."
 - id: 27721
-  examine: "The bank teller will serve you from here."
 - id: 27722
-  examine: "A pile of destroyed furniture."
 - id: 27723
-  examine: "A larger pile of destroyed furniture."
 - id: 27724
-  examine: "Ideal for cooking on."
 - id: 27725
 - id: 27726
-  examine: "These books look water damaged."
 - id: 27727
 - id: 27728
 - id: 27729
@@ -42757,68 +37212,37 @@
 - id: 27752
 - id: 27753
 - id: 27754
-  examine: "A crate for shipping goods."
 - id: 27755
-  examine: "A crate for shipping goods."
 - id: 27756
-  examine: "A crate for shipping goods."
 - id: 27757
-  examine: "A crate for shipping goods."
 - id: 27758
-  examine: "A wooden barrel for storage."
 - id: 27759
-  examine: "A wooden rowboat."
 - id: 27760
-  examine: "This rowboat is in need of repair."
 - id: 27761
-  examine: "This rowboat is beyond repair."
 - id: 27762
-  examine: "This rowboat is beyond repair."
 - id: 27763
-  examine: "This rowboat is beyond repair."
 - id: 27764
-  examine: "This rowboat is beyond repair."
 - id: 27765
-  examine: "This rowboat is beyond repair."
 - id: 27766
-  examine: "This rowboat is beyond repair."
 - id: 27767
 - id: 27768
-  examine: "This barrel is of no use."
 - id: 27769
-  examine: "This lobster trap is of no use."
 - id: 27770
-  examine: "These look damaged beyond repair."
 - id: 27771
-  examine: "For storing personal belongings."
 - id: 27772
-  examine: "For storing personal belongings."
 - id: 27773
-  examine: "For storing personal belongings."
 - id: 27774
-  examine: "For storing personal belongings."
 - id: 27775
-  examine: "For storing personal belongings."
 - id: 27776
-  examine: "For storing personal belongings."
 - id: 27777
-  examine: "Handy for boarding boats."
 - id: 27778
-  examine: "Handy for boarding boats."
 - id: 27779
-  examine: "Handy for boarding boats."
 - id: 27780
-  examine: "Handy for boarding boats."
 - id: 27781
-  examine: "Handy for boarding boats."
 - id: 27782
-  examine: "Handy for boarding boats."
 - id: 27783
-  examine: "Handy for boarding boats."
 - id: 27784
-  examine: "Handy for boarding boats."
 - id: 27785
-  examine: "King Rada I, founder of Great Kourend."
 - id: 27786
 - id: 27787
 - id: 27788
@@ -42885,17 +37309,11 @@
 - id: 27849
 - id: 27850
 - id: 27851
-  examine: "Ornate stairs with an elegant handrail."
 - id: 27852
-  examine: "Ornate stairs with an elegant handrail."
 - id: 27853
-  examine: "Ornate stairs with an elegant handrail."
 - id: 27854
-  examine: "Ornate stairs with an elegant handrail."
 - id: 27855
-  examine: "Ornate stairs with an elegant handrail."
 - id: 27856
-  examine: "Ornate stairs with an elegant handrail."
 - id: 27857
 - id: 27858
 - id: 27859
@@ -42918,24 +37336,16 @@
 - id: 27876
 - id: 27877
 - id: 27878
-  examine: "A large bright crystal."
 - id: 27879
-  examine: "A large dark crystal."
 - id: 27880
-  examine: "A large blood crystal."
 - id: 27881
 - id: 27882
-  examine: "A bright crystal."
 - id: 27883
-  examine: "A dark crystal."
 - id: 27884
-  examine: "A blood crystal."
 - id: 27885
 - id: 27886
-  examine: "A small bright crystal."
 - id: 27887
 - id: 27888
-  examine: "A small blood crystal."
 - id: 27889
 - id: 27890
 - id: 27891
@@ -43026,746 +37436,378 @@
 - id: 27976
 - id: 27977
 - id: 27978
-  examine: "It draws unto itself the blood of countless slain warriors from ancient battles."
 - id: 27979
-  examine: "Site of the darkest rites of the Arceuus house."
 - id: 27980
-  examine: "It leeches power from a myriad of departed souls."
 - id: 27981
 - id: 27982
 - id: 27983
 - id: 27984
-  examine: "With skill, someone could probably cross here."
 - id: 27985
-  examine: "With skill, someone could probably cross here."
 - id: 27986
 - id: 27987
-  examine: "With skill, someone could probably climb down here."
 - id: 27988
-  examine: "With skill, someone could probably climb up here."
 - id: 27989
 - id: 27990
-  examine: "Fortune favours the boulder."
 - id: 27991
-  examine: "A repository of knowledge."
 - id: 27992
-  examine: "A repository of knowledge."
 - id: 27993
-  examine: "A repository of knowledge."
 - id: 27994
-  examine: "A repository of knowledge."
 - id: 27995
-  examine: "A repository of knowledge."
 - id: 27996
-  examine: "A repository of knowledge."
 - id: 27997
-  examine: "A repository of knowledge."
 - id: 27998
-  examine: "A repository of knowledge."
 - id: 27999
-  examine: "A repository of knowledge."
 - id: 28000
-  examine: "A repository of knowledge."
 - id: 28001
-  examine: "A repository of knowledge."
 - id: 28002
-  examine: "A repository of knowledge."
 - id: 28003
-  examine: "A repository of knowledge."
 - id: 28004
-  examine: "A repository of knowledge."
 - id: 28005
-  examine: "A repository of knowledge."
 - id: 28006
-  examine: "A repository of knowledge."
 - id: 28007
-  examine: "A repository of knowledge."
 - id: 28008
-  examine: "A repository of knowledge."
 - id: 28009
-  examine: "A repository of knowledge."
 - id: 28010
-  examine: "A repository of knowledge."
 - id: 28011
-  examine: "A repository of knowledge."
 - id: 28012
-  examine: "A repository of knowledge."
 - id: 28013
-  examine: "A repository of knowledge."
 - id: 28014
-  examine: "A repository of knowledge."
 - id: 28015
-  examine: "A repository of knowledge."
 - id: 28016
-  examine: "A repository of knowledge."
 - id: 28017
-  examine: "A repository of knowledge."
 - id: 28018
-  examine: "A repository of knowledge."
 - id: 28019
-  examine: "A repository of knowledge."
 - id: 28020
-  examine: "A repository of knowledge."
 - id: 28021
-  examine: "A repository of knowledge."
 - id: 28022
-  examine: "A repository of knowledge."
 - id: 28023
-  examine: "A repository of knowledge."
 - id: 28024
-  examine: "A repository of knowledge."
 - id: 28025
-  examine: "A repository of knowledge."
 - id: 28026
-  examine: "A repository of knowledge."
 - id: 28027
-  examine: "A repository of knowledge."
 - id: 28028
-  examine: "A repository of knowledge."
 - id: 28029
-  examine: "A repository of knowledge."
 - id: 28030
-  examine: "A repository of knowledge."
 - id: 28031
-  examine: "A repository of knowledge."
 - id: 28032
-  examine: "A repository of knowledge."
 - id: 28033
-  examine: "A repository of knowledge."
 - id: 28034
-  examine: "A repository of knowledge."
 - id: 28035
-  examine: "A repository of knowledge."
 - id: 28036
-  examine: "A repository of knowledge."
 - id: 28037
-  examine: "A repository of knowledge."
 - id: 28038
-  examine: "A repository of knowledge."
 - id: 28039
-  examine: "A repository of knowledge."
 - id: 28040
-  examine: "A repository of knowledge."
 - id: 28041
-  examine: "A repository of knowledge."
 - id: 28042
-  examine: "A repository of knowledge."
 - id: 28043
-  examine: "A repository of knowledge."
 - id: 28044
-  examine: "A repository of knowledge."
 - id: 28045
-  examine: "A repository of knowledge."
 - id: 28046
-  examine: "A repository of knowledge."
 - id: 28047
-  examine: "A repository of knowledge."
 - id: 28048
-  examine: "A repository of knowledge."
 - id: 28049
-  examine: "A repository of knowledge."
 - id: 28050
-  examine: "A repository of knowledge."
 - id: 28051
-  examine: "A repository of knowledge."
 - id: 28052
-  examine: "A repository of knowledge."
 - id: 28053
-  examine: "A repository of knowledge."
 - id: 28054
-  examine: "A repository of knowledge."
 - id: 28055
-  examine: "A repository of knowledge."
 - id: 28056
-  examine: "A repository of knowledge."
 - id: 28057
-  examine: "A repository of knowledge."
 - id: 28058
-  examine: "A repository of knowledge."
 - id: 28059
-  examine: "A repository of knowledge."
 - id: 28060
-  examine: "A repository of knowledge."
 - id: 28061
-  examine: "A repository of knowledge."
 - id: 28062
-  examine: "A repository of knowledge."
 - id: 28063
-  examine: "A repository of knowledge."
 - id: 28064
-  examine: "A repository of knowledge."
 - id: 28065
-  examine: "A repository of knowledge."
 - id: 28066
-  examine: "A repository of knowledge."
 - id: 28067
-  examine: "A repository of knowledge."
 - id: 28068
-  examine: "A repository of knowledge."
 - id: 28069
-  examine: "A repository of knowledge."
 - id: 28070
-  examine: "A repository of knowledge."
 - id: 28071
-  examine: "A repository of knowledge."
 - id: 28072
-  examine: "A repository of knowledge."
 - id: 28073
-  examine: "A repository of knowledge."
 - id: 28074
-  examine: "A repository of knowledge."
 - id: 28075
-  examine: "A repository of knowledge."
 - id: 28076
-  examine: "A repository of knowledge."
 - id: 28077
-  examine: "A repository of knowledge."
 - id: 28078
-  examine: "A repository of knowledge."
 - id: 28079
-  examine: "A repository of knowledge."
 - id: 28080
-  examine: "A repository of knowledge."
 - id: 28081
-  examine: "A repository of knowledge."
 - id: 28082
-  examine: "A repository of knowledge."
 - id: 28083
-  examine: "A repository of knowledge."
 - id: 28084
-  examine: "A repository of knowledge."
 - id: 28085
-  examine: "A repository of knowledge."
 - id: 28086
-  examine: "A repository of knowledge."
 - id: 28087
-  examine: "A repository of knowledge."
 - id: 28088
-  examine: "A repository of knowledge."
 - id: 28089
-  examine: "A repository of knowledge."
 - id: 28090
-  examine: "A repository of knowledge."
 - id: 28091
-  examine: "A repository of knowledge."
 - id: 28092
-  examine: "A repository of knowledge."
 - id: 28093
-  examine: "A repository of knowledge."
 - id: 28094
-  examine: "A repository of knowledge."
 - id: 28095
-  examine: "A repository of knowledge."
 - id: 28096
-  examine: "A repository of knowledge."
 - id: 28097
-  examine: "A repository of knowledge."
 - id: 28098
-  examine: "A repository of knowledge."
 - id: 28099
-  examine: "A repository of knowledge."
 - id: 28100
-  examine: "A repository of knowledge."
 - id: 28101
-  examine: "A repository of knowledge."
 - id: 28102
-  examine: "A repository of knowledge."
 - id: 28103
-  examine: "A repository of knowledge."
 - id: 28104
-  examine: "A repository of knowledge."
 - id: 28105
-  examine: "A repository of knowledge."
 - id: 28106
-  examine: "A repository of knowledge."
 - id: 28107
-  examine: "A repository of knowledge."
 - id: 28108
-  examine: "A repository of knowledge."
 - id: 28109
-  examine: "A repository of knowledge."
 - id: 28110
-  examine: "A repository of knowledge."
 - id: 28111
-  examine: "A repository of knowledge."
 - id: 28112
-  examine: "A repository of knowledge."
 - id: 28113
-  examine: "A repository of knowledge."
 - id: 28114
-  examine: "A repository of knowledge."
 - id: 28115
-  examine: "A repository of knowledge."
 - id: 28116
-  examine: "A repository of knowledge."
 - id: 28117
-  examine: "A repository of knowledge."
 - id: 28118
-  examine: "A repository of knowledge."
 - id: 28119
-  examine: "A repository of knowledge."
 - id: 28120
-  examine: "A repository of knowledge."
 - id: 28121
-  examine: "A repository of knowledge."
 - id: 28122
-  examine: "A repository of knowledge."
 - id: 28123
-  examine: "A repository of knowledge."
 - id: 28124
-  examine: "A repository of knowledge."
 - id: 28125
-  examine: "A repository of knowledge."
 - id: 28126
-  examine: "A repository of knowledge."
 - id: 28127
-  examine: "A repository of knowledge."
 - id: 28128
-  examine: "A repository of knowledge."
 - id: 28129
-  examine: "A repository of knowledge."
 - id: 28130
-  examine: "A repository of knowledge."
 - id: 28131
-  examine: "A repository of knowledge."
 - id: 28132
-  examine: "A repository of knowledge."
 - id: 28133
-  examine: "A repository of knowledge."
 - id: 28134
-  examine: "A repository of knowledge."
 - id: 28135
-  examine: "A repository of knowledge."
 - id: 28136
-  examine: "A repository of knowledge."
 - id: 28137
-  examine: "A repository of knowledge."
 - id: 28138
-  examine: "A repository of knowledge."
 - id: 28139
-  examine: "A repository of knowledge."
 - id: 28140
-  examine: "A repository of knowledge."
 - id: 28141
-  examine: "A repository of knowledge."
 - id: 28142
-  examine: "A repository of knowledge."
 - id: 28143
-  examine: "A repository of knowledge."
 - id: 28144
-  examine: "A repository of knowledge."
 - id: 28145
-  examine: "A repository of knowledge."
 - id: 28146
-  examine: "A repository of knowledge."
 - id: 28147
-  examine: "A repository of knowledge."
 - id: 28148
-  examine: "A repository of knowledge."
 - id: 28149
-  examine: "A repository of knowledge."
 - id: 28150
-  examine: "A repository of knowledge."
 - id: 28151
-  examine: "A repository of knowledge."
 - id: 28152
-  examine: "A repository of knowledge."
 - id: 28153
-  examine: "A repository of knowledge."
 - id: 28154
-  examine: "A repository of knowledge."
 - id: 28155
-  examine: "A repository of knowledge."
 - id: 28156
-  examine: "A repository of knowledge."
 - id: 28157
-  examine: "A repository of knowledge."
 - id: 28158
-  examine: "A repository of knowledge."
 - id: 28159
-  examine: "A repository of knowledge."
 - id: 28160
-  examine: "A repository of knowledge."
 - id: 28161
-  examine: "A repository of knowledge."
 - id: 28162
-  examine: "A repository of knowledge."
 - id: 28163
-  examine: "A repository of knowledge."
 - id: 28164
-  examine: "A repository of knowledge."
 - id: 28165
-  examine: "A repository of knowledge."
 - id: 28166
-  examine: "A repository of knowledge."
 - id: 28167
-  examine: "A repository of knowledge."
 - id: 28168
-  examine: "A repository of knowledge."
 - id: 28169
-  examine: "A repository of knowledge."
 - id: 28170
-  examine: "A repository of knowledge."
 - id: 28171
-  examine: "A repository of knowledge."
 - id: 28172
-  examine: "A repository of knowledge."
 - id: 28173
-  examine: "A repository of knowledge."
 - id: 28174
-  examine: "A repository of knowledge."
 - id: 28175
-  examine: "A repository of knowledge."
 - id: 28176
-  examine: "A repository of knowledge."
 - id: 28177
-  examine: "A repository of knowledge."
 - id: 28178
-  examine: "A repository of knowledge."
 - id: 28179
-  examine: "A repository of knowledge."
 - id: 28180
-  examine: "A repository of knowledge."
 - id: 28181
-  examine: "A repository of knowledge."
 - id: 28182
-  examine: "A repository of knowledge."
 - id: 28183
-  examine: "A repository of knowledge."
 - id: 28184
-  examine: "A repository of knowledge."
 - id: 28185
-  examine: "A repository of knowledge."
 - id: 28186
-  examine: "A repository of knowledge."
 - id: 28187
-  examine: "A repository of knowledge."
 - id: 28188
-  examine: "A repository of knowledge."
 - id: 28189
-  examine: "A repository of knowledge."
 - id: 28190
-  examine: "A repository of knowledge."
 - id: 28191
-  examine: "A repository of knowledge."
 - id: 28192
-  examine: "A repository of knowledge."
 - id: 28193
-  examine: "A repository of knowledge."
 - id: 28194
-  examine: "A repository of knowledge."
 - id: 28195
-  examine: "A repository of knowledge."
 - id: 28196
-  examine: "A repository of knowledge."
 - id: 28197
-  examine: "A repository of knowledge."
 - id: 28198
-  examine: "A repository of knowledge."
 - id: 28199
-  examine: "A repository of knowledge."
 - id: 28200
-  examine: "A repository of knowledge."
 - id: 28201
-  examine: "A repository of knowledge."
 - id: 28202
-  examine: "A repository of knowledge."
 - id: 28203
-  examine: "A repository of knowledge."
 - id: 28204
-  examine: "A repository of knowledge."
 - id: 28205
-  examine: "A repository of knowledge."
 - id: 28206
-  examine: "A repository of knowledge."
 - id: 28207
-  examine: "A repository of knowledge."
 - id: 28208
-  examine: "A repository of knowledge."
 - id: 28209
-  examine: "A repository of knowledge."
 - id: 28210
-  examine: "A repository of knowledge."
 - id: 28211
-  examine: "A repository of knowledge."
 - id: 28212
-  examine: "A repository of knowledge."
 - id: 28213
-  examine: "A repository of knowledge."
 - id: 28214
-  examine: "A repository of knowledge."
 - id: 28215
-  examine: "A repository of knowledge."
 - id: 28216
-  examine: "A repository of knowledge."
 - id: 28217
-  examine: "A repository of knowledge."
 - id: 28218
-  examine: "A repository of knowledge."
 - id: 28219
-  examine: "A repository of knowledge."
 - id: 28220
-  examine: "A repository of knowledge."
 - id: 28221
-  examine: "A repository of knowledge."
 - id: 28222
-  examine: "A repository of knowledge."
 - id: 28223
-  examine: "A repository of knowledge."
 - id: 28224
-  examine: "A repository of knowledge."
 - id: 28225
-  examine: "A repository of knowledge."
 - id: 28226
-  examine: "A repository of knowledge."
 - id: 28227
-  examine: "A repository of knowledge."
 - id: 28228
-  examine: "A repository of knowledge."
 - id: 28229
-  examine: "A repository of knowledge."
 - id: 28230
-  examine: "A repository of knowledge."
 - id: 28231
-  examine: "A repository of knowledge."
 - id: 28232
-  examine: "A repository of knowledge."
 - id: 28233
-  examine: "A repository of knowledge."
 - id: 28234
-  examine: "A repository of knowledge."
 - id: 28235
-  examine: "A repository of knowledge."
 - id: 28236
-  examine: "A repository of knowledge."
 - id: 28237
-  examine: "A repository of knowledge."
 - id: 28238
-  examine: "A repository of knowledge."
 - id: 28239
-  examine: "A repository of knowledge."
 - id: 28240
-  examine: "A repository of knowledge."
 - id: 28241
-  examine: "A repository of knowledge."
 - id: 28242
-  examine: "A repository of knowledge."
 - id: 28243
-  examine: "A repository of knowledge."
 - id: 28244
-  examine: "A repository of knowledge."
 - id: 28245
-  examine: "A repository of knowledge."
 - id: 28246
-  examine: "A repository of knowledge."
 - id: 28247
-  examine: "A repository of knowledge."
 - id: 28248
-  examine: "A repository of knowledge."
 - id: 28249
-  examine: "A repository of knowledge."
 - id: 28250
-  examine: "A repository of knowledge."
 - id: 28251
-  examine: "A repository of knowledge."
 - id: 28252
-  examine: "A repository of knowledge."
 - id: 28253
-  examine: "A repository of knowledge."
 - id: 28254
-  examine: "A repository of knowledge."
 - id: 28255
-  examine: "A repository of knowledge."
 - id: 28256
-  examine: "A repository of knowledge."
 - id: 28257
-  examine: "A repository of knowledge."
 - id: 28258
-  examine: "A repository of knowledge."
 - id: 28259
-  examine: "A repository of knowledge."
 - id: 28260
-  examine: "A repository of knowledge."
 - id: 28261
-  examine: "A repository of knowledge."
 - id: 28262
-  examine: "A repository of knowledge."
 - id: 28263
-  examine: "A repository of knowledge."
 - id: 28264
-  examine: "A repository of knowledge."
 - id: 28265
-  examine: "A repository of knowledge."
 - id: 28266
-  examine: "A repository of knowledge."
 - id: 28267
-  examine: "A repository of knowledge."
 - id: 28268
-  examine: "A repository of knowledge."
 - id: 28269
-  examine: "A repository of knowledge."
 - id: 28270
-  examine: "A repository of knowledge."
 - id: 28271
-  examine: "A repository of knowledge."
 - id: 28272
-  examine: "A repository of knowledge."
 - id: 28273
-  examine: "A repository of knowledge."
 - id: 28274
-  examine: "A repository of knowledge."
 - id: 28275
-  examine: "A repository of knowledge."
 - id: 28276
-  examine: "A repository of knowledge."
 - id: 28277
-  examine: "A repository of knowledge."
 - id: 28278
-  examine: "A repository of knowledge."
 - id: 28279
-  examine: "A repository of knowledge."
 - id: 28280
-  examine: "A repository of knowledge."
 - id: 28281
-  examine: "A repository of knowledge."
 - id: 28282
-  examine: "A repository of knowledge."
 - id: 28283
-  examine: "A repository of knowledge."
 - id: 28284
-  examine: "A repository of knowledge."
 - id: 28285
-  examine: "A repository of knowledge."
 - id: 28286
-  examine: "A repository of knowledge."
 - id: 28287
-  examine: "A repository of knowledge."
 - id: 28288
-  examine: "A repository of knowledge."
 - id: 28289
-  examine: "A repository of knowledge."
 - id: 28290
-  examine: "A repository of knowledge."
 - id: 28291
-  examine: "A repository of knowledge."
 - id: 28292
-  examine: "A repository of knowledge."
 - id: 28293
-  examine: "A repository of knowledge."
 - id: 28294
-  examine: "A repository of knowledge."
 - id: 28295
-  examine: "A repository of knowledge."
 - id: 28296
-  examine: "A repository of knowledge."
 - id: 28297
-  examine: "A repository of knowledge."
 - id: 28298
-  examine: "A repository of knowledge."
 - id: 28299
-  examine: "A repository of knowledge."
 - id: 28300
-  examine: "A repository of knowledge."
 - id: 28301
-  examine: "A repository of knowledge."
 - id: 28302
-  examine: "A repository of knowledge."
 - id: 28303
-  examine: "A repository of knowledge."
 - id: 28304
-  examine: "A repository of knowledge."
 - id: 28305
-  examine: "A repository of knowledge."
 - id: 28306
-  examine: "A repository of knowledge."
 - id: 28307
-  examine: "A repository of knowledge."
 - id: 28308
-  examine: "A repository of knowledge."
 - id: 28309
-  examine: "A repository of knowledge."
 - id: 28310
-  examine: "A repository of knowledge."
 - id: 28311
-  examine: "A repository of knowledge."
 - id: 28312
-  examine: "A repository of knowledge."
 - id: 28313
-  examine: "A repository of knowledge."
 - id: 28314
-  examine: "A repository of knowledge."
 - id: 28315
-  examine: "A repository of knowledge."
 - id: 28316
-  examine: "A repository of knowledge."
 - id: 28317
-  examine: "A repository of knowledge."
 - id: 28318
-  examine: "A repository of knowledge."
 - id: 28319
-  examine: "A repository of knowledge."
 - id: 28320
-  examine: "A repository of knowledge."
 - id: 28321
-  examine: "A repository of knowledge."
 - id: 28322
-  examine: "A repository of knowledge."
 - id: 28323
-  examine: "A repository of knowledge."
 - id: 28324
-  examine: "A repository of knowledge."
 - id: 28325
-  examine: "A repository of knowledge."
 - id: 28326
-  examine: "A repository of knowledge."
 - id: 28327
-  examine: "A repository of knowledge."
 - id: 28328
-  examine: "A repository of knowledge."
 - id: 28329
-  examine: "A repository of knowledge."
 - id: 28330
-  examine: "A repository of knowledge."
 - id: 28331
-  examine: "A repository of knowledge."
 - id: 28332
-  examine: "A repository of knowledge."
 - id: 28333
-  examine: "A repository of knowledge."
 - id: 28334
-  examine: "A repository of knowledge."
 - id: 28335
-  examine: "A repository of knowledge."
 - id: 28336
-  examine: "A repository of knowledge."
 - id: 28337
-  examine: "A repository of knowledge."
 - id: 28338
-  examine: "A repository of knowledge."
 - id: 28339
-  examine: "A repository of knowledge."
 - id: 28340
-  examine: "A repository of knowledge."
 - id: 28341
-  examine: "A repository of knowledge."
 - id: 28342
-  examine: "A repository of knowledge."
 - id: 28343
-  examine: "A repository of knowledge."
 - id: 28344
-  examine: "A repository of knowledge."
 - id: 28345
-  examine: "A repository of knowledge."
 - id: 28346
-  examine: "A repository of knowledge."
 - id: 28347
-  examine: "A repository of knowledge."
 - id: 28348
-  examine: "A repository of knowledge."
 - id: 28349
-  examine: "A repository of knowledge."
 - id: 28350
-  examine: "A repository of knowledge."
 - id: 28351
 - id: 28352
 - id: 28353
@@ -43779,17 +37821,11 @@
 - id: 28361
 - id: 28362
 - id: 28363
-  examine: "A good workspace for readers."
 - id: 28364
-  examine: "A good workspace for readers."
 - id: 28365
-  examine: "A good workspace for readers."
 - id: 28366
-  examine: "A good workspace for readers."
 - id: 28367
-  examine: "A good workspace for readers."
 - id: 28368
-  examine: "A good workspace for readers."
 - id: 28369
 - id: 28370
 - id: 28371
@@ -43807,174 +37843,92 @@
 - id: 28383
 - id: 28384
 - id: 28385
-  examine: "Ancient pieces of parchment."
 - id: 28386
-  examine: "Ancient pieces of parchment."
 - id: 28387
-  examine: "Ancient pieces of parchment."
 - id: 28388
-  examine: "Ancient pieces of parchment."
 - id: 28389
-  examine: "Ancient pieces of parchment."
 - id: 28390
-  examine: "Ancient pieces of parchment."
 - id: 28391
-  examine: "Ancient pieces of parchment."
 - id: 28392
-  examine: "Ancient pieces of parchment."
 - id: 28393
-  examine: "Ancient vials."
 - id: 28394
-  examine: "Ancient vials."
 - id: 28395
-  examine: "A bookcase."
 - id: 28396
-  examine: "A bookcase."
 - id: 28397
-  examine: "A bookcase."
 - id: 28398
-  examine: "Plenty of old books here."
 - id: 28399
-  examine: "Plenty of old books here."
 - id: 28400
-  examine: "Plenty of old books here."
 - id: 28401
-  examine: "A table."
 - id: 28402
-  examine: "A table."
 - id: 28403
-  examine: "A table."
 - id: 28404
-  examine: "A table."
 - id: 28405
 - id: 28406
-  examine: "Only the most volatile spirits pump through here."
 - id: 28407
-  examine: "Only the most volatile sprits pump through here."
 - id: 28408
-  examine: "Filled with a toxic, blue substance."
 - id: 28409
-  examine: "Filled with a toxic, out of date blue substance."
 - id: 28410
 - id: 28411
-  examine: "A table."
 - id: 28412
-  examine: "A table."
 - id: 28413
-  examine: "A table."
 - id: 28414
-  examine: "A table."
 - id: 28415
-  examine: "A table."
 - id: 28416
-  examine: "A table."
 - id: 28417
-  examine: "A table."
 - id: 28418
-  examine: "A table."
 - id: 28419
-  examine: "A bed where a mortal would sleep."
 - id: 28420
-  examine: "A bed where a mortal would sleep."
 - id: 28421
-  examine: "A bed where a mortal would sleep."
 - id: 28422
-  examine: "Shelf filled with old-looking supplies."
 - id: 28423
-  examine: "Shelf filled with old-looking supplies."
 - id: 28424
-  examine: "Shelf filled with old-looking supplies."
 - id: 28425
-  examine: "Shelf filled with old-looking supplies."
 - id: 28426
-  examine: "Don't touch!"
 - id: 28427
-  examine: "Don't touch!"
 - id: 28428
-  examine: "Don't touch!"
 - id: 28429
-  examine: "It's closed for business."
 - id: 28430
-  examine: "It's more spacious than the typical booth."
 - id: 28431
-  examine: "Otherwise known as a table."
 - id: 28432
-  examine: "A prime spot for banking."
 - id: 28433
-  examine: "Counter service."
 - id: 28434
-  examine: "A place for the dead."
 - id: 28435
-  examine: "A place for the dead."
 - id: 28436
-  examine: "A place for the dead."
 - id: 28437
-  examine: "A place for the dead."
 - id: 28438
-  examine: "A place for the dead."
 - id: 28439
-  examine: "A place for the dead."
 - id: 28440
-  examine: "A place for the dead."
 - id: 28441
-  examine: "A place for the dead."
 - id: 28442
-  examine: "A place for the dead."
 - id: 28443
-  examine: "A place for the dead."
 - id: 28444
-  examine: "A place for the dead."
 - id: 28445
-  examine: "A place for the dead."
 - id: 28446
-  examine: "A place for the dead."
 - id: 28447
-  examine: "A place for the dead."
 - id: 28448
-  examine: "A place for the dead."
 - id: 28449
-  examine: "A place for the dead."
 - id: 28450
-  examine: "A place for the dead."
 - id: 28451
-  examine: "A place for the dead."
 - id: 28452
 - id: 28453
 - id: 28454
 - id: 28455
-  examine: "There are no symbols on this altar indicating to which god it is dedicated."
 - id: 28456
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28457
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28458
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28459
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28460
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28461
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28462
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28463
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28464
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28465
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28466
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28467
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28468
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28469
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28470
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28471
-  examine: "It bears the emblem of the Arceuus family."
 - id: 28472
 - id: 28473
 - id: 28474
@@ -43983,13 +37937,9 @@
 - id: 28477
 - id: 28478
 - id: 28479
-  examine: "It looks very sturdy."
 - id: 28480
-  examine: "It looks very sturdy."
 - id: 28481
-  examine: "It looks very sturdy."
 - id: 28482
-  examine: "It looks very sturdy."
 - id: 28483
 - id: 28484
 - id: 28485
@@ -44004,11 +37954,8 @@
 - id: 28494
 - id: 28495
 - id: 28496
-  examine: "A sulphur-based mixture is extruding from the unstable minerals below."
 - id: 28497
-  examine: "A sulphur-based mixture is extruding from the unstable minerals below."
 - id: 28498
-  examine: "A sulphur-based mixture is extruding from the unstable minerals below."
 - id: 28499
 - id: 28500
 - id: 28501
@@ -44026,101 +37973,58 @@
 - id: 28513
 - id: 28514
 - id: 28515
-  examine: "A bed without a mattress."
 - id: 28516
-  examine: "A neatly folded bed."
 - id: 28517
-  examine: "A not so comfortable bed."
 - id: 28518
-  examine: "A double bed without a mattress."
 - id: 28519
-  examine: "A neatly folded double bed."
 - id: 28520
-  examine: "A not so comfortable double bed."
 - id: 28521
-  examine: "Sleeping rough tonight."
 - id: 28522
-  examine: "A large mechanical glass based table."
 - id: 28523
-  examine: "A vintage table."
 - id: 28524
-  examine: "A table used to conduct mechanical practices on."
 - id: 28525
-  examine: "A table used to conduct mechanical practices on."
 - id: 28526
-  examine: "A portable table."
 - id: 28527
-  examine: "A stool to sit on."
 - id: 28528
-  examine: "A stool to sit on."
 - id: 28529
-  examine: "A chair to sit on."
 - id: 28530
-  examine: "A chair to sit on."
 - id: 28531
-  examine: "A round chair to sit on."
 - id: 28532
-  examine: "Golden embossed wardrobe."
 - id: 28533
-  examine: "Golden embossed wardrobe."
 - id: 28534
-  examine: "Golden embossed wardrobe."
 - id: 28535
-  examine: "Contains a lot of drawers."
 - id: 28536
-  examine: "Contains a lot of drawers."
 - id: 28537
-  examine: "Contains a lot of drawers."
 - id: 28538
-  examine: "Used for washing plates only."
 - id: 28539
-  examine: "A durable metal ladder."
 - id: 28540
-  examine: "A durable metal ladder."
 - id: 28541
 - id: 28542
 - id: 28543
 - id: 28544
 - id: 28545
 - id: 28546
-  examine: "The bank teller will serve you from here."
 - id: 28547
-  examine: "The bank teller will serve you from here."
 - id: 28548
-  examine: "The bank teller will serve you from here."
 - id: 28549
-  examine: "The bank teller will serve you from here."
 - id: 28550
-  examine: "You can tell by the bank lights that this booth is closed."
 - id: 28551
-  examine: "A light signalling whether the bank is closed today or not."
 - id: 28552
-  examine: "A light signalling whether the bank is closed today or not."
 - id: 28553
-  examine: "Hopefully there's nothing confidential on these."
 - id: 28554
 - id: 28555
 - id: 28556
 - id: 28557
 - id: 28558
 - id: 28559
-  examine: "Lovakengj's finest armour."
 - id: 28560
-  examine: "Lovakengj's finest armour."
 - id: 28561
-  examine: "The armourer stores items here."
 - id: 28562
-  examine: "A terrifyingly hot furnace."
 - id: 28563
-  examine: "Immensely solid anvil."
 - id: 28564
-  examine: "Someone's mounted an anvil for display purposes."
 - id: 28565
-  examine: "Smelt your ores here."
 - id: 28566
-  examine: "A sacred shrine."
 - id: 28567
-  examine: "The sort of bench you get in churches."
 - id: 28568
 - id: 28569
 - id: 28570
@@ -44133,39 +38037,24 @@
 - id: 28577
 - id: 28578
 - id: 28579
-  examine: "You're going to need some dynamite to blow this up."
 - id: 28580
-  examine: "You're going to need some dynamite to blow this up."
 - id: 28581
-  examine: "A cavity has been excavated in this rockface."
 - id: 28582
-  examine: "A cavity has been excavated in this rockface."
 - id: 28583
-  examine: "A pot of dynamite has been inserted into the cavity"
 - id: 28584
-  examine: "A pot of dynamite has been inserted into the cavity"
 - id: 28585
-  examine: "Run away! Run away!"
 - id: 28586
-  examine: "Run away! Run away!"
 - id: 28587
-  examine: "It's been blasted apart."
 - id: 28588
-  examine: "It's been blasted apart."
 - id: 28589
 - id: 28590
 - id: 28591
 - id: 28592
-  examine: "Blasted ore is deposited here for the dwarves to clean."
 - id: 28593
 - id: 28594
-  examine: "It looks rough, but it's secure."
 - id: 28595
-  examine: "It looks very rough, but it's secure."
 - id: 28596
-  examine: "A rocky outcrop."
 - id: 28597
-  examine: "A rocky outcrop."
 - id: 28598
 - id: 28599
 - id: 28600
@@ -44173,51 +38062,28 @@
 - id: 28602
 - id: 28603
 - id: 28604
-  examine: "Old looking support."
 - id: 28605
-  examine: "Old looking support."
 - id: 28606
-  examine: "Old looking support."
 - id: 28607
-  examine: "Old looking support."
 - id: 28608
-  examine: "Old looking support."
 - id: 28609
-  examine: "Old looking support."
 - id: 28610
-  examine: "Old looking support."
 - id: 28611
-  examine: "Old looking support."
 - id: 28612
-  examine: "Old looking support."
 - id: 28613
-  examine: "Old looking support."
 - id: 28614
-  examine: "Old looking support."
 - id: 28615
-  examine: "Old looking support."
 - id: 28616
-  examine: "Old looking support."
 - id: 28617
-  examine: "Old looking support."
 - id: 28618
-  examine: "I can climb this."
 - id: 28619
-  examine: "I can climb this."
 - id: 28620
-  examine: "I can climb this."
 - id: 28621
-  examine: "This part of the platform looks structurally compromised."
 - id: 28622
-  examine: "This part of the platform looks structurally compromised."
 - id: 28623
-  examine: "This part of the platform looks structurally compromised."
 - id: 28624
-  examine: "This part of the platform looks structurally compromised."
 - id: 28625
-  examine: "A cylinder full of explosive gas."
 - id: 28626
-  examine: "A cylinder full of explosive gas."
 - id: 28627
 - id: 28628
 - id: 28629
@@ -44231,100 +38097,54 @@
 - id: 28637
 - id: 28638
 - id: 28639
-  examine: "A crate for storing airship components."
 - id: 28640
-  examine: "Crates for storing airship components."
 - id: 28641
-  examine: "Crates for storing airship components."
 - id: 28642
-  examine: "Crates for storing airship components."
 - id: 28643
-  examine: "Crates for storing airship components."
 - id: 28644
-  examine: "Crates for storing airship components."
 - id: 28645
-  examine: "A barrel for storing airship fuel."
 - id: 28646
-  examine: "A barrel for storing airship fuel."
 - id: 28647
-  examine: "An old anchor."
 - id: 28648
-  examine: "They're trying to build a prison?"
 - id: 28649
-  examine: "Used for circulating gases."
 - id: 28650
-  examine: "A large window."
 - id: 28651
-  examine: "Looks pretty secure."
 - id: 28652
-  examine: "A crate full of empty satchels."
 - id: 28653
-  examine: "Danger"
 - id: 28654
-  examine: "I might be able to swing across this."
 - id: 28655
-  examine: "A fence surrounding the Gnome Stronghold."
 - id: 28656
-  examine: "The Stronghold fence has been damaged, leaving an opening."
 - id: 28657
-  examine: "I reckon I could climb that!"
 - id: 28658
-  examine: "Branchy."
 - id: 28659
 - id: 28660
-  examine: "I reckon I could climb that!"
 - id: 28661
-  examine: "A recently extinguished fire."
 - id: 28662
-  examine: "A recently extinguished fire."
 - id: 28663
 - id: 28664
-  examine: "This may be worth opening."
 - id: 28665
-  examine: "This may be worth searching."
 - id: 28666
-  examine: "For storage."
 - id: 28667
-  examine: "For extra storage."
 - id: 28668
-  examine: "An ornamental arrangement of candles."
 - id: 28669
-  examine: "This must be Glough's desk."
 - id: 28670
-  examine: "What kind of person owns a bust of themself?"
 - id: 28671
-  examine: "Where could these lead?"
 - id: 28672
-  examine: "Where could these lead?"
 - id: 28673
-  examine: "Looks good for hiding in..."
 - id: 28674
-  examine: "Looks good for hiding in..."
 - id: 28675
-  examine: "A worthy opponent, slain in battle."
 - id: 28676
-  examine: "A ladder constructed from bamboo."
 - id: 28677
-  examine: "An empty rowboat."
 - id: 28678
-  examine: "An empty rowboat."
 - id: 28679
-  examine: "An empty rowboat."
 - id: 28680
 - id: 28681
-  examine: "Looks like any other wall in the cavern."
 - id: 28682
-  examine: "A passage concealed in the wall of the cavern."
 - id: 28683
-  examine: "A passage concealed in the wall of the cavern."
 - id: 28684
-  examine: "I might be able to squeeze through here."
 - id: 28685
-  examine: "I might be able to squeeze through here."
 - id: 28686
-  examine: "It looks like something has burrowed into the caverns below."
 - id: 28687
-  examine: "I can climb my way back out of the cavern using this."
 - id: 28688
 - id: 28689
 - id: 28690
@@ -44355,24 +38175,16 @@
 - id: 28715
 - id: 28716
 - id: 28717
-  examine: "The airship crash has caused a rupture in the cavern."
 - id: 28718
-  examine: "The airship crash has caused a rupture in the cavern."
 - id: 28719
-  examine: "The airship crash has caused a rupture in the cavern."
 - id: 28720
-  examine: "The airship crash has caused a rupture in the cavern."
 - id: 28721
-  examine: "Some inconsiderate individual has parked their boulder right in front of this doorway!"
 - id: 28722
 - id: 28723
-  examine: "In memory of Nieve, she looks rich and dead."
 - id: 28724
-  examine: "I might be able to swing across."
 - id: 28725
 - id: 28726
 - id: 28727
-  examine: "I might be able to swing across."
 - id: 28728
 - id: 28729
 - id: 28730
@@ -44398,99 +38210,58 @@
 - id: 28750
 - id: 28751
 - id: 28752
-  examine: "I could scale the cave wall using these."
 - id: 28753
-  examine: "I could scale the cave wall using these."
 - id: 28754
-  examine: "For swinging on."
 - id: 28755
-  examine: "A vine that looks like you might be able to balance on it."
 - id: 28756
-  examine: "I could hang off this."
 - id: 28757
-  examine: "Tread carefully!"
 - id: 28758
-  examine: "Looks suspiciously like a pressure pad to me."
 - id: 28759
-  examine: "I might be able to jump across."
 - id: 28760
 - id: 28761
 - id: 28762
 - id: 28763
-  examine: "I can balance on this log."
 - id: 28764
-  examine: "I might be able to squeeze through here."
 - id: 28765
-  examine: "I might be able to jump across."
 - id: 28766
-  examine: "I might be able to jump across."
 - id: 28767
-  examine: "This doesn't look very safe."
 - id: 28768
-  examine: "This doesn't look very safe."
 - id: 28769
-  examine: "This doesn't look very safe."
 - id: 28770
 - id: 28771
 - id: 28772
-  examine: "A vine choked hole."
 - id: 28773
 - id: 28774
 - id: 28775
-  examine: "I should be able to climb this."
 - id: 28776
-  examine: "A tripwire."
 - id: 28777
-  examine: "Makes human colanders."
 - id: 28778
-  examine: "Shoots poisoned darts."
 - id: 28779
-  examine: "I might want to avoid this nasty blade."
 - id: 28780
-  examine: "I might want to avoid this nasty blade."
 - id: 28781
-  examine: "I might want to avoid this nasty blade."
 - id: 28782
-  examine: "Makes sliced human."
 - id: 28783
-  examine: "This door is locked, perhaps you can pick the lock or find the key."
 - id: 28784
 - id: 28785
-  examine: "This chest is locked, perhaps you can pick the lock."
 - id: 28786
-  examine: "A heap of rocks that looks like it fell from the ceiling."
 - id: 28787
 - id: 28788
-  examine: "A heap of tough unbreakable rocks."
 - id: 28789
-  examine: "This huge web blocks your path."
 - id: 28790
-  examine: "I may be able to walk through this tattered web."
 - id: 28791
-  examine: "Hot!"
 - id: 28792
-  examine: "I wonder what's inside it."
 - id: 28793
-  examine: "An open chest."
 - id: 28794
-  examine: "A door, looks locked."
 - id: 28795
 - id: 28796
-  examine: "I wonder what's inside it."
 - id: 28797
-  examine: "An open chest."
 - id: 28798
-  examine: "There appears to be something different about this section of wall."
 - id: 28799
-  examine: "A passage concealed in the wall of the cavern."
 - id: 28800
 - id: 28801
-  examine: "I reckon I could climb that!"
 - id: 28802
-  examine: "A magical lectern."
 - id: 28803
 - id: 28804
-  examine: "A very large plant with waxy leaves."
 - id: 28805
 - id: 28806
 - id: 28807
@@ -44503,47 +38274,27 @@
 - id: 28814
 - id: 28815
 - id: 28816
-  examine: "Allows you to access your bank account."
 - id: 28817
-  examine: "A container for the rapid exothermic oxidation of logs.<br>It's better than setting fire to the floor."
 - id: 28818
-  examine: "A container for the rapid exothermic oxidation of logs.<br>It's better than setting fire to the floor."
 - id: 28819
 - id: 28820
-  examine: "The airship crash has caused a rupture in the cavern."
 - id: 28821
-  examine: "The airship crash has caused a rupture in the cavern."
 - id: 28822
-  examine: "Home sweet home?"
 - id: 28823
-  examine: "A fruit stall."
 - id: 28824
-  examine: "A large boulder surrounded by debris."
 - id: 28825
-  examine: "A large boulder surrounded by debris."
 - id: 28826
-  examine: "A large boulder surrounded by debris."
 - id: 28827
-  examine: "This probably breaches all kinds of health and safety guidelines."
 - id: 28828
-  examine: "Look out below!"
 - id: 28829
-  examine: "Look out below!"
 - id: 28830
-  examine: "There's something trapped under this boulder."
 - id: 28831
-  examine: "There's something trapped under this boulder."
 - id: 28832
-  examine: "Look out below!"
 - id: 28833
-  examine: "Look out below!"
 - id: 28834
-  examine: "Look out below!"
 - id: 28835
-  examine: "A transport system operated by the Lovakengj House."
 - id: 28836
 - id: 28837
-  examine: "The dwarves use it to control the minecarts."
 - id: 28838
 - id: 28839
 - id: 28840
@@ -44556,37 +38307,23 @@
 - id: 28847
 - id: 28848
 - id: 28849
-  examine: "Hmmm... I wonder if it's loose enough to get through."
 - id: 28850
 - id: 28851
-  examine: "Entrance to the prestigious woodcutting guild."
 - id: 28852
-  examine: "Entrance to the prestigious woodcutting guild."
 - id: 28853
 - id: 28854
 - id: 28855
-  examine: "There appear to be large shadowy figures moving around inside."
 - id: 28856
-  examine: "It might be sturdy enough to climb."
 - id: 28857
-  examine: "It looks sturdy enough to climb."
 - id: 28858
-  examine: "It looks sturdy enough to climb."
 - id: 28859
-  examine: "Leave money here so the servant needn't bother asking you for it."
 - id: 28860
 - id: 28861
-  examine: "A handy bank chest."
 - id: 28862
-  examine: "A table."
 - id: 28863
-  examine: "A small table."
 - id: 28864
-  examine: "A counter made of wooden planks."
 - id: 28865
-  examine: "A place to cremate the dead. Needs a body."
 - id: 28866
-  examine: "A place to cremate the dead. Needs a light."
 - id: 28867
 - id: 28868
 - id: 28869
@@ -44611,45 +38348,31 @@
 - id: 28888
 - id: 28889
 - id: 28890
-  examine: "Some rocks block the tunnel."
 - id: 28891
 - id: 28892
-  examine: "I might be able to squeeze through here."
 - id: 28893
-  examine: "I might be able to jump to this."
 - id: 28894
-  examine: "I can climb my way back out of these catacombs using this."
 - id: 28895
-  examine: "I can climb my way back out of these catacombs using this."
 - id: 28896
-  examine: "I can climb my way back out of these catacombs using this."
 - id: 28897
-  examine: "I can climb my way back out of these catacombs using this."
 - id: 28898
-  examine: "I can climb my way back out of these catacombs using this."
 - id: 28899
 - id: 28900
-  examine: "A power emanates from this structure."
 - id: 28901
-  examine: "Is it greener on the other side?"
 - id: 28902
 - id: 28903
 - id: 28904
-  examine: "Is it greener on this side?"
 - id: 28905
 - id: 28906
 - id: 28907
 - id: 28908
 - id: 28909
-  examine: "Dirty!"
 - id: 28910
 - id: 28911
 - id: 28912
-  examine: "A mysterious hole."
 - id: 28913
 - id: 28914
 - id: 28915
-  examine: "A mysterious hole."
 - id: 28916
 - id: 28917
 - id: 28918
@@ -44657,78 +38380,44 @@
 - id: 28920
 - id: 28921
 - id: 28922
-  examine: "The altar looks dead, perhaps there's something inside it."
 - id: 28923
-  examine: "A power emanates from this structure."
 - id: 28924
-  examine: "Power no longer emanates from this structure."
 - id: 28925
-  examine: "A portal from this mystical place."
 - id: 28926
 - id: 28927
 - id: 28928
-  examine: "An ancient giant serpent."
 - id: 28929
-  examine: "An ancient giant serpent."
 - id: 28930
-  examine: "This looks like it's being used to block entrance to the village."
 - id: 28931
-  examine: "This looks like it's being used to block entrance to the village."
 - id: 28932
-  examine: "Imported yellow nectar. Refreshes the parts that wine can't reach."
 - id: 28933
-  examine: "Store things and stuff here."
 - id: 28934
-  examine: "A conveniently located bush."
 - id: 28935
-  examine: "Store things and stuff here."
 - id: 28936
-  examine: "A conveniently located hole."
 - id: 28937
-  examine: "Store things and stuff here."
 - id: 28938
-  examine: "Conveniently located rocks."
 - id: 28939
-  examine: "Store things and stuff here."
 - id: 28940
-  examine: "A conveniently located crate."
 - id: 28941
-  examine: "Store things and stuff here."
 - id: 28942
-  examine: "A conveniently located bush."
 - id: 28943
-  examine: "Store things and stuff here."
 - id: 28944
-  examine: "A conveniently located hole."
 - id: 28945
-  examine: "Store things and stuff here."
 - id: 28946
-  examine: "Conveniently located rocks."
 - id: 28947
-  examine: "Store things and stuff here."
 - id: 28948
-  examine: "A conveniently located crate."
 - id: 28949
-  examine: "Store things and stuff here."
 - id: 28950
-  examine: "A conveniently located bush."
 - id: 28951
   depleted: 28954
-  examine: "Store things and stuff here."
 - id: 28952
   depleted: 28955
-  examine: "A conveniently located hole."
 - id: 28953
   depleted: 28956
-  examine: "Store things and stuff here."
 - id: 28954
-  examine: "Conveniently located rocks."
 - id: 28955
-  examine: "Store things and stuff here."
 - id: 28956
-  examine: "A conveniently located crate."
 - id: 28957
-  examine: "Store things and stuff here."
 - id: 28958
 - id: 28959
 - id: 28960
@@ -44833,440 +38522,240 @@
 - id: 29059
 - id: 29060
 - id: 29061
-  examine: "Good for climbing."
 - id: 29062
-  examine: "Allows access to level above."
 - id: 29063
-  examine: "Last Man Standing winnings are kept in here."
 - id: 29064
-  examine: "You can see your Last Man Standing scores here."
 - id: 29065
-  examine: "A rough plinth."
 - id: 29066
-  examine: "The door is closed."
 - id: 29067
-  examine: "The door is closed."
 - id: 29068
-  examine: "The door is open."
 - id: 29069
-  examine: "I wonder what's inside?"
 - id: 29070
-  examine: "I wonder what's inside?"
 - id: 29071
-  examine: "I wonder what's inside?"
 - id: 29072
-  examine: "I wonder what's inside?"
 - id: 29073
-  examine: "I wonder what's inside?"
 - id: 29074
-  examine: "I wonder what's inside?"
 - id: 29075
-  examine: "I wonder what's inside?"
 - id: 29076
-  examine: "I wonder what's inside?"
 - id: 29077
-  examine: "I wonder what's inside?"
 - id: 29078
-  examine: "I wonder what's inside?"
 - id: 29079
-  examine: "I wonder what's inside?"
 - id: 29080
-  examine: "I wonder what's inside?"
 - id: 29081
-  examine: "I wonder what's inside?"
 - id: 29082
-  examine: "A wooden rowboat."
 - id: 29083
-  examine: "A very slippery stepping stone"
 - id: 29084
 - id: 29085
-  examine: "A campfire."
 - id: 29086
 - id: 29087
-  examine: "You must put money in here to pay for competitive Last Man Standing games."
 - id: 29088
   depleted: 3371
-  examine: "I wonder what happens if I place coloured eggs here."
 - id: 29089
   depleted: 3371
-  examine: "Allows access to level below."
 - id: 29090
-  examine: "Mysteriously transports items into your bank."
 - id: 29091
-  examine: "The mysterious shrine can trade tokens for items."
 - id: 29092
-  examine: "I can climb up and down the watchtower using this."
 - id: 29093
 - id: 29094
 - id: 29095
 - id: 29096
 - id: 29097
 - id: 29098
-  examine: "Can be used to repair certain untradeable gear!"
 - id: 29099
 - id: 29100
-  examine: "Best used with a bucket."
 - id: 29101
-  examine: "A barrel full of water."
 - id: 29102
-  examine: "A sturdy looking rock."
 - id: 29103
-  examine: "Lets you put items into your bank."
 - id: 29104
-  examine: "Lets you put items into your bank."
 - id: 29105
-  examine: "Lets you put items into your bank."
 - id: 29106
-  examine: "Lets you put items into your bank."
 - id: 29107
-  examine: "It's a pot made out of bamboo."
 - id: 29108
-  examine: "Lets you put items into your bank."
 - id: 29109
 - id: 29110
 - id: 29111
-  examine: "A teak garden bench."
 - id: 29112
-  examine: "A teak garden bench."
 - id: 29113
-  examine: "A bench in the style preferred by gnomes."
 - id: 29114
-  examine: "A bench in the style preferred by gnomes."
 - id: 29115
-  examine: "A marble garden bench."
 - id: 29116
-  examine: "A marble garden bench."
 - id: 29117
-  examine: "An obsidian garden bench."
 - id: 29118
-  examine: "An obsidian garden bench."
 - id: 29119
-  examine: "You can build a tip jar here."
 - id: 29120
-  examine: "You can add teleports here."
 - id: 29121
-  examine: "You can add a carefully sculpted bush here."
 - id: 29122
-  examine: "You can construct a pool here and sip from it."
 - id: 29123
-  examine: "Give your garden some ambience."
 - id: 29124
-  examine: "Give your garden some ambience."
 - id: 29125
-  examine: "Give your garden some ambience."
 - id: 29126
-  examine: "Give your garden some ambience."
 - id: 29127
-  examine: "Give your garden some ambience."
 - id: 29128
-  examine: "Give your garden some ambience."
 - id: 29129
-  examine: "Give your garden some ambience."
 - id: 29130
-  examine: "Give your garden some ambience."
 - id: 29131
-  examine: "Like a wall with gaps in."
 - id: 29132
-  examine: "Like a wall with gaps in."
 - id: 29133
-  examine: "Like a wall with gaps in."
 - id: 29134
 - id: 29135
 - id: 29136
-  examine: "Decorative seating."
 - id: 29137
-  examine: "Decorative seating."
 - id: 29138
-  examine: "Decorative seating."
 - id: 29139
-  examine: "Decorative seating."
 - id: 29140
-  examine: "You can add a magical altar here."
 - id: 29141
-  examine: "You can add a log of your adventures here."
 - id: 29142
-  examine: "You can put jewellery here."
 - id: 29143
-  examine: "You can build a shrine honouring a defeated boss."
 - id: 29144
-  examine: "You can display prestigious items or capes here."
 - id: 29145
-  examine: "You can show your quest status here."
 - id: 29146
-  examine: "Show appreciation to your host."
 - id: 29147
-  examine: "A limestone altar imbued with the magic of an ancient era."
 - id: 29148
-  examine: "An altar imbued with the power of the cosmos."
 - id: 29149
-  examine: "A limestone altar imbued with the corruption of the dark."
 - id: 29150
 - id: 29151
-  examine: "A mahogany table featuring a small book of adventures."
 - id: 29152
-  examine: "A gilded mahogany table featuring a large book of adventures."
 - id: 29153
-  examine: "A gilded marble table featuring a giant book of adventures."
 - id: 29154
-  examine: "A steel box featuring some enchanted sapphire and emerald jewellery."
 - id: 29155
-  examine: "A fancy steel box featuring some enchanted sapphire, emerald and dragonstone jewellery."
 - id: 29156
-  examine: "An ornate steel box featuring many enchanted sapphire, emerald and dragonstone jewellery."
 - id: 29157
-  examine: "The lairs of defeated bosses can be generated here from their jars."
 - id: 29158
-  examine: "A large display of the Kraken in their dank lair."
 - id: 29159
-  examine: "A large display of Zulrah in her poisonous lair."
 - id: 29160
-  examine: "A large display of the Kalphite Queen in her sandy lair."
 - id: 29161
-  examine: "A large display of Cerberus in her gloomy lair."
 - id: 29162
-  examine: "A large display of the Abyssal Sire in his miasmic lair."
 - id: 29163
-  examine: "A large display of Skotizo in his dark lair."
 - id: 29164
-  examine: "A display of player killing mastery... or possibly a wanted criminal..."
 - id: 29165
-  examine: "100 million of your finest coins!"
 - id: 29166
-  examine: "You could display a prestigious cape here."
 - id: 29167
-  examine: "A mounted cape worn by the most elite adventurers."
 - id: 29168
-  examine: "A mounted cape worn by the most elite adventurers."
 - id: 29169
-  examine: "A mounted cape of fire."
 - id: 29170
-  examine: "A mounted cape worn by the most experienced players."
 - id: 29171
-  examine: "A mounted cape worn by the most experienced players."
 - id: 29172
-  examine: "A mounted cape worn by the most experienced players."
 - id: 29173
-  examine: "A mounted cape worn by the most experienced players."
 - id: 29174
-  examine: "A mounted cape worn by the most experienced players."
 - id: 29175
-  examine: "A mounted cape worn by the most experienced players."
 - id: 29176
-  examine: "A mounted cape worn by music aficionados."
 - id: 29177
-  examine: "A mounted cape worn by music aficionados."
 - id: 29178
-  examine: "A mounted cape worn by the most experienced adventurers."
 - id: 29179
-  examine: "A mounted cape worn by the most experienced adventurers."
 - id: 29180
-  examine: "A cape worn by the most agile of heroes."
 - id: 29181
-  examine: "A cape worn by the most agile of heroes."
 - id: 29182
-  examine: "A cape worn by masters of Attack."
 - id: 29183
-  examine: "A cape worn by masters of Attack."
 - id: 29184
-  examine: "A cape worn by master builders."
 - id: 29185
-  examine: "A cape worn by master builders."
 - id: 29186
-  examine: "A cape worn by the world's best chefs."
 - id: 29187
-  examine: "A cape worn by the world's best chefs."
 - id: 29188
-  examine: "A cape worn by master craftworkers."
 - id: 29189
-  examine: "A cape worn by master craftworkers."
 - id: 29190
-  examine: "A cape worn by masters of the art of Defence."
 - id: 29191
-  examine: "A cape worn by masters of the art of Defence."
 - id: 29192
-  examine: "A cape worn by master farmers."
 - id: 29193
-  examine: "A cape worn by master farmers."
 - id: 29194
-  examine: "A cape worn by master firelighters."
 - id: 29195
-  examine: "A cape worn by master firelighters."
 - id: 29196
-  examine: "A cape worn by the best fishermen."
 - id: 29197
-  examine: "A cape worn by the best fishermen."
 - id: 29198
-  examine: "A cape worn by the best of fletchers."
 - id: 29199
-  examine: "A cape worn by the best of fletchers."
 - id: 29200
-  examine: "A cape worn by the most skilled at the art of Herblore."
 - id: 29201
-  examine: "A cape worn by the most skilled at the art of Herblore."
 - id: 29202
-  examine: "A cape worn by the healthiest adventurers."
 - id: 29203
-  examine: "A cape worn by the healthiest adventurers."
 - id: 29204
-  examine: "A cape worn by master hunters."
 - id: 29205
-  examine: "A cape worn by master hunters."
 - id: 29206
-  examine: "A cape worn by the most powerful mages."
 - id: 29207
-  examine: "A cape worn by the most powerful mages."
 - id: 29208
-  examine: "A cape worn by the most skilled miners."
 - id: 29209
-  examine: "A cape worn by the most skilled miners."
 - id: 29210
-  examine: "A cape worn by the most pious of heroes."
 - id: 29211
-  examine: "A cape worn by the most pious of heroes."
 - id: 29212
-  examine: "A cape worn by master archers."
 - id: 29213
-  examine: "A cape worn by master archers."
 - id: 29214
-  examine: "A cape worn by master runecrafters."
 - id: 29215
   depleted: 17026
-  examine: "A cape worn by master runecrafters."
 - id: 29216
   depleted: 29219
-  examine: "A cape worn by Slayer masters."
 - id: 29217
   depleted: 29220
-  examine: "A cape worn by Slayer masters."
 - id: 29218
-  examine: "A cape worn by master smiths."
 - id: 29219
-  examine: "A cape worn by master smiths."
 - id: 29220
-  examine: "A cape worn by only the strongest people."
 - id: 29221
   depleted: 17026
-  examine: "A cape worn by only the strongest people."
 - id: 29222
   depleted: 29219
-  examine: "A cape worn by master thieves."
 - id: 29223
   depleted: 29220
-  examine: "A cape worn by master thieves."
 - id: 29224
   depleted: 17026
-  examine: "A cape worn by master woodcutters."
 - id: 29225
   depleted: 29219
-  examine: "A cape worn by master woodcutters."
 - id: 29226
   depleted: 29220
-  examine: "A long list of quest progress."
 - id: 29227
   depleted: 17026
-  examine: "A young sentient tree."
 - id: 29228
 - id: 29229
   depleted: 29220
 - id: 29230
   depleted: 17026
-  examine: "A large bush that can be sculpted into shapes."
 - id: 29231
   depleted: 29219
-  examine: "A bush sculpted into a fearsome Kraken!"
 - id: 29232
-  examine: "A bush sculpted into the almighty Zulrah!"
 - id: 29233
   depleted: 17026
-  examine: "A bush sculpted into the royal Kalphite Queen!"
 - id: 29234
-  examine: "A bush sculpted into the soul-devouring Cerberus!"
 - id: 29235
   depleted: 29220
-  examine: "A bush sculpted into the Abyssal Sire, father of the Abyss!"
 - id: 29236
   depleted: 17026
-  examine: "A bush sculpted into the corrupted demon, Skotizo!"
 - id: 29237
-  examine: "A special mixture that restores special attack."
 - id: 29238
-  examine: "A special mixture that restores special attack and run energy."
 - id: 29239
-  examine: "A special mixture that restores special attack, run energy and prayer."
 - id: 29240
-  examine: "A special mixture that restores special attack, run energy, prayer and all stats."
 - id: 29241
-  examine: "A special mixture that makes you feel like a brand new person."
 - id: 29242
-  examine: "A relaxing sand pathway."
 - id: 29243
-  examine: "A relaxing sand pathway."
 - id: 29244
-  examine: "A calming grass edging."
 - id: 29245
-  examine: "A calming grass edging."
 - id: 29246
-  examine: "A calming grass edging."
 - id: 29247
-  examine: "A lush Cherry Blossom tree in a serene garden."
 - id: 29248
-  examine: "An odd dirt pathway."
 - id: 29249
-  examine: "An odd dirt pathway."
 - id: 29250
-  examine: "A strange grass edging."
 - id: 29251
-  examine: "A strange grass edging."
 - id: 29252
-  examine: "A strange grass edging."
 - id: 29253
-  examine: "A rather peculiar mushroom in a strange blue world."
 - id: 29254
-  examine: "A fiery rock pathway."
 - id: 29255
-  examine: "A fiery rock pathway."
 - id: 29256
-  examine: "A fiery rock pathway."
 - id: 29257
-  examine: "A fiery rock pathway."
 - id: 29258
-  examine: "A fiery rock edging."
 - id: 29259
-  examine: "A fiery rock edging."
 - id: 29260
-  examine: "A fiery rock edging."
 - id: 29261
-  examine: "How do you get a lawn like this? Start several million years ago."
 - id: 29262
-  examine: "A redwood fence."
 - id: 29263
-  examine: "A redwood fence post."
 - id: 29264
-  examine: "A redwood fence post."
 - id: 29265
 - id: 29266
 - id: 29267
-  examine: "A fence made from TzHaar weaponry."
 - id: 29268
-  examine: "A fence made from TzHaar weaponry."
 - id: 29269
-  examine: "A fence made from TzHaar weaponry."
 - id: 29270
-  examine: "A teak garden bench."
 - id: 29271
-  examine: "A teak garden bench."
 - id: 29272
-  examine: "A bench in the style preferred by gnomes."
 - id: 29273
-  examine: "A bench in the style preferred by gnomes."
 - id: 29274
-  examine: "A marble garden bench."
 - id: 29275
-  examine: "A marble garden bench."
 - id: 29276
-  examine: "An obsidian garden bench."
 - id: 29277
-  examine: "An obsidian garden bench."
 - id: 29278
 - id: 29279
 - id: 29280
@@ -45290,666 +38779,342 @@
 - id: 29298
 - id: 29299
 - id: 29300
-  examine: "A great place to rest."
 - id: 29301
-  examine: "It's empty."
 - id: 29302
-  examine: "Wonder what's inside it."
 - id: 29303
-  examine: "No bananas in this one."
 - id: 29304
-  examine: "After closer examination you can confirm beyond doubt that it is indeed a crate."
 - id: 29305
-  examine: "Yup, that's a crate."
 - id: 29306
-  examine: "Better than nothing."
 - id: 29307
-  examine: "Better than nothing."
 - id: 29308
-  examine: "The vortex spins furiously as the cold pierces through your bones."
 - id: 29309
-  examine: "The vortex is less furious."
 - id: 29310
-  examine: "A tall anvil for a small guy."
 - id: 29311
-  examine: "Woody roots from the Bruma tree."
 - id: 29312
-  examine: "This brazier is currently unlit and hence quite useless."
 - id: 29313
-  examine: "Broken beyond use, this brazier needs fixing."
 - id: 29314
-  examine: "Magical heat eminates from this brazier."
 - id: 29315
-  examine: "The roots here are sprouting leaves."
 - id: 29316
-  examine: "An open crate full of hammers."
 - id: 29317
-  examine: "An open crate full of knives."
 - id: 29318
-  examine: "An open crate full of axes."
 - id: 29319
-  examine: "An open crate full of tinderboxes."
 - id: 29320
-  examine: "An open crate full of concoctions."
 - id: 29321
-  examine: "Use for quick access to your bank."
 - id: 29322
-  examine: "Hold the door!"
 - id: 29323
 - id: 29324
 - id: 29325
 - id: 29326
-  examine: "I might be able to jump across."
 - id: 29327
-  examine: "Lets you put items into your bank."
 - id: 29328
-  examine: "For paying dwarves to do the hard work for you."
 - id: 29329
-  examine: "For paying dwarves to do the hard work for you."
 - id: 29330
 - id: 29331
-  examine: "Awarded to the people of RuneScape by SpecialEffect."
 - id: 29332
-  examine: "It looks cramped and dark."
 - id: 29333
-  examine: "It looks cramped and dark."
 - id: 29334
-  examine: "A handy table for putting stuff on."
 - id: 29335
-  examine: "You can build a combat dummy here."
 - id: 29336
-  examine: "The sandbag needs attaching before I can use it."
 - id: 29337
-  examine: "The sandbag needs attaching before I can use it."
 - id: 29338
-  examine: "A gateway to Kharyrll."
 - id: 29339
-  examine: "A gateway to Lunar Isle."
 - id: 29340
-  examine: "A gateway to Senntisten."
 - id: 29341
-  examine: "A gateway to Annakarl."
 - id: 29342
-  examine: "A gateway to Waterbirth Island."
 - id: 29343
-  examine: "A gateway to the Fishing Guild."
 - id: 29344
-  examine: "A gateway to Marim on Ape Atoll."
 - id: 29345
-  examine: "A gateway to Great Kourend."
 - id: 29346
-  examine: "A gateway to Kharyrll."
 - id: 29347
-  examine: "A gateway to Lunar Isle."
 - id: 29348
-  examine: "A gateway to Senntisten."
 - id: 29349
-  examine: "A gateway to Annakarl."
 - id: 29350
-  examine: "A gateway to Waterbirth Island."
 - id: 29351
-  examine: "A gateway to the Fishing Guild."
 - id: 29352
-  examine: "A gateway to Marim on Ape Atoll."
 - id: 29353
-  examine: "A gateway to Great Kourend."
 - id: 29354
-  examine: "A gateway to Kharyrll."
 - id: 29355
-  examine: "A gateway to Lunar Isle."
 - id: 29356
-  examine: "A gateway to Senntisten."
 - id: 29357
-  examine: "A gateway to Annakarl."
 - id: 29358
-  examine: "A gateway to Waterbirth Island."
 - id: 29359
-  examine: "A gateway to the Fishing Guild."
 - id: 29360
-  examine: "A gateway to Marim on Ape Atoll."
 - id: 29361
-  examine: "A gateway to Great Kourend."
 - id: 29362
-  examine: "Don't eat any!"
 - id: 29363
-  examine: "Don't eat any!"
 - id: 29364
-  examine: "Don't eat any!"
 - id: 29365
-  examine: "Don't eat any!"
 - id: 29366
-  examine: "Don't eat any!"
 - id: 29367
-  examine: "Don't eat any!"
 - id: 29368
-  examine: "Don't eat any!"
 - id: 29369
-  examine: "Don't eat any!"
 - id: 29370
-  examine: "Don't eat any!"
 - id: 29371
-  examine: "Don't eat any!"
 - id: 29372
-  examine: "Don't eat any!"
 - id: 29373
-  examine: "Don't eat any!"
 - id: 29374
-  examine: "Don't eat any!"
 - id: 29375
-  examine: "Don't eat any!"
 - id: 29376
-  examine: "Don't eat any!"
 - id: 29377
-  examine: "Don't eat any!"
 - id: 29378
-  examine: "Don't eat any!"
 - id: 29379
-  examine: "Don't eat any!"
 - id: 29380
-  examine: "Don't eat any!"
 - id: 29381
-  examine: "Don't eat any!"
 - id: 29382
-  examine: "Don't eat any!"
 - id: 29383
-  examine: "Don't eat any!"
 - id: 29384
-  examine: "Don't eat any!"
 - id: 29385
-  examine: "Don't eat any!"
 - id: 29386
-  examine: "Don't eat any!"
 - id: 29387
-  examine: "Don't eat any!"
 - id: 29388
-  examine: "Don't eat any!"
 - id: 29389
-  examine: "Don't eat any!"
 - id: 29390
-  examine: "Don't eat any!"
 - id: 29391
-  examine: "Don't eat any!"
 - id: 29392
-  examine: "Don't eat any!"
 - id: 29393
-  examine: "Don't eat any!"
 - id: 29394
-  examine: "Don't eat any!"
 - id: 29395
-  examine: "Don't eat any!"
 - id: 29396
-  examine: "Don't eat any!"
 - id: 29397
-  examine: "Don't eat any!"
 - id: 29398
-  examine: "Don't eat any!"
 - id: 29399
-  examine: "Don't eat any!"
 - id: 29400
-  examine: "Don't eat any!"
 - id: 29401
-  examine: "Don't eat any!"
 - id: 29402
-  examine: "Don't eat any!"
 - id: 29403
-  examine: "Don't eat any!"
 - id: 29404
-  examine: "Don't eat any!"
 - id: 29405
-  examine: "Don't eat any!"
 - id: 29406
-  examine: "Don't eat any!"
 - id: 29407
-  examine: "Don't eat any!"
 - id: 29408
-  examine: "Don't eat any!"
 - id: 29409
-  examine: "Don't eat any!"
 - id: 29410
-  examine: "Don't eat any!"
 - id: 29411
-  examine: "Don't eat any!"
 - id: 29412
-  examine: "Don't eat any!"
 - id: 29413
-  examine: "Don't eat any!"
 - id: 29414
-  examine: "Don't eat any!"
 - id: 29415
-  examine: "Don't eat any!"
 - id: 29416
-  examine: "Don't eat any!"
 - id: 29417
-  examine: "Don't eat any!"
 - id: 29418
-  examine: "Don't eat any!"
 - id: 29419
-  examine: "Don't eat any!"
 - id: 29420
-  examine: "Don't eat any!"
 - id: 29421
-  examine: "Don't eat any!"
 - id: 29422
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29423
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29424
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29425
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29426
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29427
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29428
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29429
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29430
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29431
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29432
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29433
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29434
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29435
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29436
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29437
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29438
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29439
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29440
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29441
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29442
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29443
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29444
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29445
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29446
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29447
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29448
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29449
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29450
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29451
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29452
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29453
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29454
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29455
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29456
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29457
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29458
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29459
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29460
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29461
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29462
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29463
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29464
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29465
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29466
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29467
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29468
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29469
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29470
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29471
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29472
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29473
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29474
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29475
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29476
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29477
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29478
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29479
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29480
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29481
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29482
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29483
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29484
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29485
-  examine: "A young sentient tree surrounded by a fairy ring."
 - id: 29486
-  examine: "It's a gate."
 - id: 29487
-  examine: "It's a gate."
 - id: 29488
-  examine: "It's a gate."
 - id: 29489
-  examine: "It's a gate."
 - id: 29490
 - id: 29491
-  examine: "A rocky outcrop."
 - id: 29492
-  examine: "His adventuring days are over."
 - id: 29493
-  examine: "He hasn't eaten in a long time."
 - id: 29494
-  examine: "Looks like he isn't doing too well..."
 - id: 29495
 - id: 29496
-  examine: "Better not eat them!"
 - id: 29497
-  examine: "Better not eat them!"
 - id: 29498
-  examine: "Better not eat them!"
 - id: 29499
-  examine: "Better not eat them!"
 - id: 29500
-  examine: "Better not eat them!"
 - id: 29501
-  examine: "Better not eat them!"
 - id: 29502
-  examine: "Better not eat them!"
 - id: 29503
-  examine: "Better not eat them!"
 - id: 29504
-  examine: "Better not eat them!"
 - id: 29505
-  examine: "Better not eat them!"
 - id: 29506
-  examine: "Better not eat them!"
 - id: 29507
-  examine: "Better not eat them!"
 - id: 29508
-  examine: "Better not eat them!"
 - id: 29509
-  examine: "Better not eat them!"
 - id: 29510
-  examine: "Better not eat them!"
 - id: 29511
-  examine: "Better not eat them!"
 - id: 29512
-  examine: "Better not eat them!"
 - id: 29513
-  examine: "Better not eat them!"
 - id: 29514
-  examine: "Better not eat them!"
 - id: 29515
-  examine: "Better not eat them!"
 - id: 29516
-  examine: "Better not eat them!"
 - id: 29517
-  examine: "Better not eat them!"
 - id: 29518
-  examine: "Better not eat them!"
 - id: 29519
-  examine: "Better not eat them!"
 - id: 29520
-  examine: "Better not eat them!"
 - id: 29521
-  examine: "Better not eat them!"
 - id: 29522
-  examine: "Better not eat them!"
 - id: 29523
-  examine: "Better not eat them!"
 - id: 29524
-  examine: "Better not eat them!"
 - id: 29525
-  examine: "Better not eat them!"
 - id: 29526
-  examine: "Better not eat them!"
 - id: 29527
-  examine: "Better not eat them!"
 - id: 29528
-  examine: "Better not eat them!"
 - id: 29529
-  examine: "Better not eat them!"
 - id: 29530
-  examine: "Better not eat them!"
 - id: 29531
-  examine: "Better not eat them!"
 - id: 29532
-  examine: "Better not eat them!"
 - id: 29533
-  examine: "Better not eat them!"
 - id: 29534
-  examine: "Better not eat them!"
 - id: 29535
-  examine: "Better not eat them!"
 - id: 29536
-  examine: "Better not eat them!"
 - id: 29537
-  examine: "Better not eat them!"
 - id: 29538
-  examine: "Better not eat them!"
 - id: 29539
-  examine: "Better not eat them!"
 - id: 29540
-  examine: "Better not eat them!"
 - id: 29541
-  examine: "Better not eat them!"
 - id: 29542
-  examine: "Better not eat them!"
 - id: 29543
-  examine: "Better not eat them!"
 - id: 29544
-  examine: "Better not eat them!"
 - id: 29545
-  examine: "Better not eat them!"
 - id: 29546
-  examine: "Better not eat them!"
 - id: 29547
-  examine: "Better not eat them!"
 - id: 29548
-  examine: "Better not eat them!"
 - id: 29549
-  examine: "Better not eat them!"
 - id: 29550
-  examine: "Better not eat them!"
 - id: 29551
-  examine: "Better not eat them!"
 - id: 29552
-  examine: "Better not eat them!"
 - id: 29553
-  examine: "Better not eat them!"
 - id: 29554
-  examine: "Better not eat them!"
 - id: 29555
-  examine: "Better not eat them!"
 - id: 29556
-  examine: "Better not eat them!"
 - id: 29557
-  examine: "Better not eat them!"
 - id: 29558
-  examine: "Better not eat them!"
 - id: 29559
-  examine: "Better not eat them!"
 - id: 29560
 - id: 29561
-  examine: "Better not eat them!"
 - id: 29562
-  examine: "Better not eat them!"
 - id: 29563
-  examine: "Better not eat them!"
 - id: 29564
-  examine: "Better not eat them!"
 - id: 29565
-  examine: "Better not eat them!"
 - id: 29566
-  examine: "Better not eat them!"
 - id: 29567
-  examine: "Better not eat them!"
 - id: 29568
-  examine: "Better not eat them!"
 - id: 29569
-  examine: "Better not eat them!"
 - id: 29570
-  examine: "Better not eat them!"
 - id: 29571
-  examine: "Better not eat them!"
 - id: 29572
-  examine: "Better not eat them!"
 - id: 29573
-  examine: "Better not eat them!"
 - id: 29574
-  examine: "Better not eat them!"
 - id: 29575
-  examine: "Better not eat them!"
 - id: 29576
-  examine: "Better not eat them!"
 - id: 29577
-  examine: "Better not eat them!"
 - id: 29578
-  examine: "Better not eat them!"
 - id: 29579
-  examine: "Better not eat them!"
 - id: 29580
-  examine: "Better not eat them!"
 - id: 29581
-  examine: "Better not eat them!"
 - id: 29582
-  examine: "Better not eat them!"
 - id: 29583
-  examine: "Better not eat them!"
 - id: 29584
-  examine: "Better not eat them!"
 - id: 29585
-  examine: "Better not eat them!"
 - id: 29586
-  examine: "Better not eat them!"
 - id: 29587
-  examine: "Better not eat them!"
 - id: 29588
-  examine: "Better not eat them!"
 - id: 29589
-  examine: "Better not eat them!"
 - id: 29590
-  examine: "Better not eat them!"
 - id: 29591
-  examine: "Better not eat them!"
 - id: 29592
-  examine: "Better not eat them!"
 - id: 29593
-  examine: "Better not eat them!"
 - id: 29594
-  examine: "Better not eat them!"
 - id: 29595
-  examine: "Better not eat them!"
 - id: 29596
-  examine: "Better not eat them!"
 - id: 29597
-  examine: "Better not eat them!"
 - id: 29598
-  examine: "Better not eat them!"
 - id: 29599
-  examine: "Better not eat them!"
 - id: 29600
-  examine: "Better not eat them!"
 - id: 29601
-  examine: "Better not eat them!"
 - id: 29602
-  examine: "Better not eat them!"
 - id: 29603
-  examine: "Better not eat them!"
 - id: 29604
-  examine: "Better not eat them!"
 - id: 29605
-  examine: "Better not eat them!"
 - id: 29606
-  examine: "Better not eat them!"
 - id: 29607
-  examine: "Better not eat them!"
 - id: 29608
-  examine: "Better not eat them!"
 - id: 29609
-  examine: "Better not eat them!"
 - id: 29610
-  examine: "Better not eat them!"
 - id: 29611
-  examine: "Better not eat them!"
 - id: 29612
-  examine: "Better not eat them!"
 - id: 29613
-  examine: "Better not eat them!"
 - id: 29614
-  examine: "Better not eat them!"
 - id: 29615
-  examine: "Better not eat them!"
 - id: 29616
-  examine: "Better not eat them!"
 - id: 29617
-  examine: "Better not eat them!"
 - id: 29618
-  examine: "Better not eat them!"
 - id: 29619
-  examine: "Better not eat them!"
 - id: 29620
-  examine: "Better not eat them!"
 - id: 29621
-  examine: "Better not eat them!"
 - id: 29622
-  examine: "Better not eat them!"
 - id: 29623
-  examine: "Better not eat them!"
 - id: 29624
-  examine: "Better not eat them!"
 - id: 29625
-  examine: "A mounted cape worn by the most experienced players."
 - id: 29626
-  examine: "I might be able to squeeze through."
 - id: 29627
-  examine: "I might be able to squeeze through."
 - id: 29628
 - id: 29629
 - id: 29630
 - id: 29631
-  examine: "An altar upon which to craft runes."
 - id: 29632
 - id: 29633
 - id: 29634
 - id: 29635
-  examine: "Into the darkness..."
 - id: 29636
-  examine: "Into the light!"
 - id: 29637
 - id: 29638
 - id: 29639
@@ -45981,15 +39146,10 @@
 - id: 29665
 - id: 29666
 - id: 29667
-  examine: "Takes you back to Clan Wars."
 - id: 29668
-  examine: "An enormous majestic tree."
 - id: 29669
-  examine: "This section of the tree has been carved out."
 - id: 29670
-  examine: "An enormous majestic tree."
 - id: 29671
-  examine: "This section of the tree has been carved out."
 - id: 29672
 - id: 29673
 - id: 29674
@@ -45999,11 +39159,8 @@
 - id: 29678
 - id: 29679
 - id: 29680
-  examine: "I can climb up the tree from the inside."
 - id: 29681
-  examine: "I can climb up the tree from the inside."
 - id: 29682
-  examine: "I can climb down the tree from the inside."
 - id: 29683
 - id: 29684
 - id: 29685
@@ -46027,16 +39184,11 @@
 - id: 29703
 - id: 29704
 - id: 29705
-  examine: "You can just about see the shape of the cavern below."
 - id: 29706
-  examine: "Happy Birthday!"
 - id: 29707
 - id: 29708
-  examine: "A table covered in delicious food!"
 - id: 29709
-  examine: "A table covered in presents!"
 - id: 29710
-  examine: "A table covered in birthday hats!"
 - id: 29711
 - id: 29712
 - id: 29713
@@ -46045,129 +39197,69 @@
 - id: 29716
 - id: 29717
 - id: 29718
-  examine: "Keep track of your STASH."
 - id: 29719
-  examine: "Shayzien built defences."
 - id: 29720
-  examine: "How odd."
 - id: 29721
-  examine: "Some form of ancient terraforming device, in need of repair."
 - id: 29722
-  examine: "Amongst other things... I can hear the ocean within."
 - id: 29723
-  examine: "Handy for boarding boats."
 - id: 29724
-  examine: "Handy for boarding boats."
 - id: 29725
-  examine: "A table where the leaders of Great Kourend meet."
 - id: 29726
-  examine: "A defence against the threat of the lizardmen."
 - id: 29727
-  examine: "We are discovered. Flee immediately."
 - id: 29728
-  examine: "A very slippery stepping stone."
 - id: 29729
-  examine: "A very slippery stepping stone."
 - id: 29730
-  examine: "A very slippery stepping stone."
 - id: 29731
-  examine: "An artist's impression of King Byrne I."
 - id: 29732
-  examine: "A wooden crate."
 - id: 29733
 - id: 29734
-  examine: "So far, so good."
 - id: 29735
-  examine: "It doesn't look very inviting."
 - id: 29736
-  examine: "How inconvenient."
 - id: 29737
-  examine: "How convenient."
 - id: 29738
-  examine: "How inconvenient."
 - id: 29739
-  examine: "How convenient."
 - id: 29740
-  examine: "Take courage - get a little boulder."
 - id: 29741
-  examine: "The skeletal mystics' ritual is causing it to glow."
 - id: 29742
-  examine: "Looks locked."
 - id: 29743
-  examine: "It's open."
 - id: 29744
-  examine: "The cocoons have not hatched."
 - id: 29745
-  examine: "Some cocoons have hatched."
 - id: 29746
   depleted: 29747
-  examine: "An empty trough for feeding animals."
 - id: 29747
-  examine: "It's dead."
 - id: 29748
-  examine: "It's lit."
 - id: 29749
-  examine: "I wonder if there is something that can dispel this?"
 - id: 29750
-  examine: "One foot after another..."
 - id: 29751
-  examine: "A power emanates from the crystal."
 - id: 29752
-  examine: "It's emitting white globes of energy."
 - id: 29753
-  examine: "A dark crystal that's blocking the way."
 - id: 29754
-  examine: "A fairly dark crystal that's blocking the way."
 - id: 29755
-  examine: "A slightly dark crystal that's blocking the way."
 - id: 29756
-  examine: "A dim crystal that's blocking the way."
 - id: 29757
-  examine: "A glowing crystal that's blocking the way."
 - id: 29758
-  examine: "It's a black crystal."
 - id: 29759
-  examine: "It's a cyan crystal."
 - id: 29760
-  examine: "It's a magenta crystal."
 - id: 29761
-  examine: "It's a yellow crystal."
 - id: 29762
-  examine: "It's a white crystal."
 - id: 29763
-  examine: "Looks like you could chop some wood off here."
 - id: 29764
-  examine: "Hopefully it'll grow back."
 - id: 29765
-  examine: "What sort of herbs could grow down here?"
 - id: 29766
-  examine: "Tick tock."
 - id: 29767
-  examine: "Not something you really want to touch."
 - id: 29768
-  examine: "Not something you really want to touch."
 - id: 29769
-  examine: "For holding items."
 - id: 29770
-  examine: "For holding items."
 - id: 29771
-  examine: "I wonder how long they've been down here."
 - id: 29772
-  examine: "A tree bearing a vessel shaped fruit."
 - id: 29773
-  examine: "Weeds really do grow everywhere."
 - id: 29774
 - id: 29775
 - id: 29776
-  examine: "For party recruitment."
 - id: 29777
-  examine: "This place really doesn't look like somewhere to explore alone."
 - id: 29778
-  examine: "The steps lead back out to the surface."
 - id: 29779
-  examine: "For holding items."
 - id: 29780
-  examine: "For holding items."
 - id: 29781
 - id: 29782
 - id: 29783
@@ -46177,13 +39269,11 @@
 - id: 29787
 - id: 29788
 - id: 29789
-  examine: "Leads to another chamber."
 - id: 29790
 - id: 29791
 - id: 29792
 - id: 29793
 - id: 29794
-  examine: "A large shining green crystal."
 - id: 29795
 - id: 29796
 - id: 29797
@@ -46201,7 +39291,6 @@
 - id: 29809
 - id: 29810
 - id: 29811
-  examine: "Some ancient beast, sculpted from the living rock."
 - id: 29812
 - id: 29813
 - id: 29814
@@ -46225,9 +39314,7 @@
 - id: 29832
 - id: 29833
 - id: 29834
-  examine: "Don't look down."
 - id: 29835
-  examine: "Don't look down."
 - id: 29836
 - id: 29837
 - id: 29838
@@ -46257,13 +39344,9 @@
 - id: 29862
 - id: 29863
 - id: 29864
-  examine: "A common weed."
 - id: 29865
-  examine: "A common weed."
 - id: 29866
-  examine: "A stylised representation of Xeric."
 - id: 29867
-  examine: "An electromagnetic field is emanating from this giant anvil."
 - id: 29868
 - id: 29869
 - id: 29870
@@ -46271,36 +39354,21 @@
 - id: 29872
 - id: 29873
 - id: 29874
-  examine: "Grub's up."
 - id: 29875
-  examine: "He's dead."
 - id: 29876
-  examine: "The power of the icefiends has created a storm of ice."
 - id: 29877
 - id: 29878
-  examine: "Fresh warm water. This should be good for mixing potions with."
 - id: 29879
-  examine: "It looks like you can pass through it."
 - id: 29880
-  examine: "Whatever was down there is coming out!"
 - id: 29881
-  examine: "Now I know what was down there."
 - id: 29882
-  examine: "I wonder what's down there."
 - id: 29883
-  examine: "The rock has cracks and holes right through it."
 - id: 29884
-  examine: "The rock has cracks and holes right through it."
 - id: 29885
-  examine: "The rock has cracks and holes right through it."
 - id: 29886
-  examine: "Crystals poke out of this large cracked up rock."
 - id: 29887
-  examine: "Crystals poke out of this large cracked up rock."
 - id: 29888
-  examine: "Crystals poke out of this large cracked up rock."
 - id: 29889
-  examine: "Something is stirring beneath the water."
 - id: 29890
 - id: 29891
 - id: 29892
@@ -46309,7 +39377,6 @@
 - id: 29895
 - id: 29896
 - id: 29897
-  examine: "Slain during a battle with the Lizardmen"
 - id: 29898
 - id: 29899
 - id: 29900
@@ -46333,7 +39400,6 @@
 - id: 29918
 - id: 29919
 - id: 29920
-  examine: "A signal to alert when the Lizardman attack."
 - id: 29921
 - id: 29922
 - id: 29923
@@ -46351,32 +39417,21 @@
 - id: 29935
 - id: 29936
 - id: 29937
-  examine: "An ancient Xerician Priest... or possibly Xeric himself? It's weathered beyond recognition."
 - id: 29938
 - id: 29939
 - id: 29940
 - id: 29941
-  examine: "A cloth-covered altar with a mounted symbol of unknown origin."
 - id: 29942
 - id: 29943
 - id: 29944
-  examine: "Who disturbs my slumber?"
 - id: 29945
-  examine: "Who disturbed their slumber? Lost their head too, it seems."
 - id: 29946
-  examine: "Someone should really put that back."
 - id: 29947
-  examine: "Completely drained of all power."
 - id: 29948
-  examine: "Completely drained of all power."
 - id: 29949
-  examine: "Rubble dub dub."
 - id: 29950
-  examine: "Rubble dub dub."
 - id: 29951
-  examine: "Rubble dub dub."
 - id: 29952
-  examine: "Rubble dub dub."
 - id: 29953
 - id: 29954
 - id: 29955
@@ -46400,118 +39455,66 @@
 - id: 29973
 - id: 29974
 - id: 29975
-  examine: "Slain during a battle with the Lizardmen"
 - id: 29976
-  examine: "Slain during a battle with the Lizardmen"
 - id: 29977
-  examine: "Slain during a battle with the Lizardmen"
 - id: 29978
-  examine: "Slain during a battle with the Lizardmen"
 - id: 29979
 - id: 29980
 - id: 29981
 - id: 29982
 - id: 29983
-  examine: "Slain during a battle with the Shayzien Guard"
 - id: 29984
-  examine: "Slain during a battle with the Shayzien Guard"
 - id: 29985
-  examine: "Slain during a battle with the Shayzien Guard"
 - id: 29986
-  examine: "Heads, spikes, walls."
 - id: 29987
-  examine: "Heads, spikes, walls."
 - id: 29988
-  examine: "Heads, spikes, walls."
 - id: 29989
-  examine: "Heads, spikes, walls."
 - id: 29990
-  examine: "A dark and dank lair of the Lizardmen."
 - id: 29991
-  examine: "A rather spooky lamp."
 - id: 29992
 - id: 29993
-  examine: "Roughly carved from the wall of the cave."
 - id: 29994
 - id: 29995
-  examine: "Glory does not lie up there."
 - id: 29996
-  examine: "Emergency exit."
 - id: 29997
-  examine: "A noxifer herb is growing here."
 - id: 29998
-  examine: "A golpar herb is growing here."
 - id: 29999
-  examine: "A buchu leaf is growing here."
 - id: 30000
-  examine: "A noxifer herb is growing here."
 - id: 30001
-  examine: "A golpar herb is growing here."
 - id: 30002
-  examine: "A buchu leaf is growing here."
 - id: 30003
-  examine: "A noxifer herb is growing here."
 - id: 30004
-  examine: "A golpar herb is growing here."
 - id: 30005
-  examine: "A buchu leaf is growing here."
 - id: 30006
-  examine: "A noxifer leaf herb is growing here."
 - id: 30007
-  examine: "A golpar herb is growing here."
 - id: 30008
-  examine: "A buchu leaf is growing here."
 - id: 30009
-  examine: "A noxifer herb has grown here."
 - id: 30010
-  examine: "A golpar herb has grown here."
 - id: 30011
-  examine: "A buchu leaf has grown here."
 - id: 30012
-  examine: "A bloodstained pile of rocks."
 - id: 30013
-  examine: "All of the meat has been stripped from this tree."
 - id: 30014
-  examine: "A small blood crystal."
 - id: 30015
-  examine: "It's blocking the passage."
 - id: 30016
-  examine: "It's blocking the passage."
 - id: 30017
-  examine: "It's blocking the passage."
 - id: 30018
-  examine: "It's blocking the passage."
 - id: 30019
-  examine: "There's something weird about this fire, but it's definitely hot."
 - id: 30020
-  examine: "The ancient writings of a crazed mage."
 - id: 30021
-  examine: "This looks like it will hurt."
 - id: 30022
-  examine: "Scrawled jottings of a diminished mind."
 - id: 30023
 - id: 30024
-  examine: "Not something you really want to touch."
 - id: 30025
-  examine: "Ancient notes on transdimensional travel."
 - id: 30026
-  examine: "Judgement of the Vanguard."
 - id: 30027
-  examine: "There seems to be something locked in the heart of the crystal."
 - id: 30028
-  examine: "Someone must have really wanted to protect whatever they kept in here."
 - id: 30029
 - id: 30030
 - id: 30031
-  examine: "Confessions of a troubled soul."
 - id: 30032
-  examine: "I really shouldn't stand in that."
 - id: 30033
-  examine: "They're moving..."
 - id: 30034
-  examine: "They grew quick!"
 - id: 30035
-  examine: "Some ancient beast, sculpted from the living rock."
 - id: 30036
 - id: 30037
 - id: 30038
@@ -46543,20 +39546,13 @@
 - id: 30064
 - id: 30065
 - id: 30066
-  examine: "A strange focus of energy"
 - id: 30067
 - id: 30068
-  examine: "The medivaemia has flowered."
 - id: 30069
-  examine: "This medivaemia has no flowers."
 - id: 30070
-  examine: "An abyssal pustule obstructing the exit."
 - id: 30071
-  examine: "The pustule has popped. How pleasant."
 - id: 30072
-  examine: "They're supporting the portal."
 - id: 30073
-  examine: "Hopefully the portal won't come back."
 - id: 30074
 - id: 30075
 - id: 30076
@@ -46569,147 +39565,82 @@
 - id: 30083
 - id: 30084
 - id: 30085
-  examine: "A bucket of blood."
 - id: 30086
-  examine: "For whom?"
 - id: 30087
-  examine: "It looks rough, but it's secure."
 - id: 30088
 - id: 30089
 - id: 30090
 - id: 30091
-  examine: "A repository of knowledge."
 - id: 30092
-  examine: "A repository of knowledge."
 - id: 30093
-  examine: "A repository of knowledge."
 - id: 30094
-  examine: "A repository of knowledge."
 - id: 30095
-  examine: "A written history of Great Kourend"
 - id: 30096
-  examine: "An ancient relic sitting on a table."
 - id: 30097
-  examine: "An ancient book, mounted on a lectern."
 - id: 30098
-  examine: "An ancient book, mounted on a lectern."
 - id: 30099
-  examine: "An ancient book, mounted on a lectern."
 - id: 30100
-  examine: "An ancient book, mounted on a lectern."
 - id: 30101
-  examine: "An ancient book, mounted on a lectern."
 - id: 30102
-  examine: "An ancient book, mounted on a lectern."
 - id: 30103
-  examine: "An ancient text"
 - id: 30104
 - id: 30105
 - id: 30106
 - id: 30107
-  examine: "In case you left something in storage in the Chambers of Xeric."
 - id: 30108
-  examine: "An empty rowboat."
 - id: 30109
-  examine: "An empty rowboat."
 - id: 30110
-  examine: "A large double door."
 - id: 30111
-  examine: "A large double door."
 - id: 30112
-  examine: "The handle appears to be crafted from red topaz."
 - id: 30113
-  examine: "The handle appears to be crafted from jade."
 - id: 30114
-  examine: "The handle appears to be crafted from opal."
 - id: 30115
-  examine: "The handle appears to be crafted from dragonstone."
 - id: 30116
-  examine: "The handle appears to be crafted from ruby."
 - id: 30117
-  examine: "The handle appears to be crafted from emerald."
 - id: 30118
-  examine: "The handle appears to be crafted from diamond."
 - id: 30119
-  examine: "The handle appears to be crafted from sapphire."
 - id: 30120
-  examine: "Somebody has left a note on the ground."
 - id: 30121
-  examine: "Somebody has left a note on the ground."
 - id: 30122
-  examine: "Somebody has left a note on the ground."
 - id: 30123
-  examine: "An emptied barrel."
 - id: 30124
-  examine: "A barrel full of rain water."
 - id: 30125
-  examine: "A gloomy looking valley."
 - id: 30126
-  examine: "The painting has been slashed open."
 - id: 30127
-  examine: "The label reads"
 - id: 30128
-  examine: "The remains of a barrel."
 - id: 30129
-  examine: "The candle has been blown out."
 - id: 30130
-  examine: "A lit candle."
 - id: 30131
-  examine: "I should be able to climb over this."
 - id: 30132
-  examine: "It's in need of some serious repairs."
 - id: 30133
-  examine: "The wall must have been damaged in a storm."
 - id: 30134
-  examine: "A grand piano."
 - id: 30135
-  examine: "A piano with some sort of compartment."
 - id: 30136
-  examine: "A grand old fireplace."
 - id: 30137
-  examine: "A grand old fireplace."
 - id: 30138
-  examine: "A grand old fireplace."
 - id: 30139
-  examine: "Dare I go up?"
 - id: 30140
 - id: 30141
-  examine: "I wonder what's inside..."
 - id: 30142
-  examine: "It's too dark to see what's inside."
 - id: 30143
 - id: 30144
 - id: 30145
-  examine: "There's a knife on the table."
 - id: 30146
-  examine: "There are tinderboxes on the shelves."
 - id: 30147
-  examine: "It's a wooden bucket."
 - id: 30148
-  examine: "A commonly found fern."
 - id: 30149
-  examine: "A commonly found fern."
 - id: 30150
-  examine: "It's only useful for firewood now."
 - id: 30151
-  examine: "A view of mountains."
 - id: 30152
-  examine: "A view of mountains."
 - id: 30153
-  examine: "A painting of the King looking royal."
 - id: 30154
-  examine: "A mysterious figure stands alone in this haunting image."
 - id: 30155
-  examine: "A tree in autumn."
 - id: 30156
 - id: 30157
-  examine: "It's cold and dead."
 - id: 30158
-  examine: "A hot furnace."
 - id: 30159
 - id: 30160
 - id: 30161
-  examine: "Paaaaartay!"
 - id: 30162
 - id: 30163
 - id: 30164
@@ -46718,64 +39649,38 @@
 - id: 30167
 - id: 30168
 - id: 30169
-  examine: "You can just about see the shape of the cavern below."
 - id: 30170
-  examine: "Whatever plant grew this must have had incredibly deep roots."
 - id: 30171
 - id: 30172
-  examine: "Home sweet home?"
 - id: 30173
-  examine: "This portal looks inactive."
 - id: 30174
-  examine: "The opening is wide, but it looks very narrow further in there."
 - id: 30175
-  examine: "The opening is wide, but it looks very narrow further in there."
 - id: 30176
-  examine: "You can smell smoke emanating from the cavern."
 - id: 30177
-  examine: "Beware"
 - id: 30178
-  examine: "A way out!"
 - id: 30179
-  examine: "Interesting. A hole."
 - id: 30180
-  examine: "An insectoid chittering sound emanates from the depths."
 - id: 30181
 - id: 30182
 - id: 30183
 - id: 30184
 - id: 30185
-  examine: "Looks empty."
 - id: 30186
 - id: 30187
-  examine: "Something unpleasant is dripping from above."
 - id: 30188
-  examine: "For lighting a room."
 - id: 30189
-  examine: "Rough steps, carved from the rock of the cave."
 - id: 30190
-  examine: "Rough steps, carved from the rock of the cave."
 - id: 30191
-  examine: "Looks spooky!"
 - id: 30192
-  examine: "I came down, it works the other way too... right?"
 - id: 30193
-  examine: "Something expensive must have been kept down here."
 - id: 30194
-  examine: "Must be the furnace for the boiler. Doubt I could get it going again though."
 - id: 30195
-  examine: "You imagine the faint screams of its past occupants."
 - id: 30196
-  examine: "Because you never know when you'll need some."
 - id: 30197
 - id: 30198
-  examine: "I can hear the clang of metal scales through here."
 - id: 30199
-  examine: "A hole."
 - id: 30200
-  examine: "A rope leads down into the depths."
 - id: 30201
-  examine: "Smells like fresh air."
 - id: 30202
 - id: 30203
 - id: 30204
@@ -46809,10 +39714,8 @@
 - id: 30232
 - id: 30233
 - id: 30234
-  examine: "This will take me back to the surface."
 - id: 30235
 - id: 30236
-  examine: "A rope into the chasm."
 - id: 30237
 - id: 30238
 - id: 30239
@@ -46831,66 +39734,39 @@
 - id: 30252
 - id: 30253
 - id: 30254
-  examine: "A deposit of rocks."
 - id: 30255
-  examine: "A deposit of rocks."
 - id: 30256
-  examine: "A deposit of rocks."
 - id: 30257
-  examine: "A deposit of rocks."
 - id: 30258
-  examine: "The door has been removed, getting out shouldn't be an issue... I guess it will take me lower."
 - id: 30259
-  examine: "The door has been removed, getting out shouldn't be an issue... It may take me up a floor."
 - id: 30260
-  examine: "Wouldn't want to end up locked in that."
 - id: 30261
 - id: 30262
 - id: 30263
 - id: 30264
 - id: 30265
 - id: 30266
-  examine: "A barrier of heat."
 - id: 30267
-  examine: "I can access my bank from here."
 - id: 30268
-  examine: "Lets you put items into your bank."
 - id: 30269
-  examine: "A TzHaar is resting in this terminal, drawing warmth from the volcano to prolong its life."
 - id: 30270
-  examine: "An empty TzHaar resting terminal that provides warmth from the volcano."
 - id: 30271
-  examine: "A TzHaar terminal node."
 - id: 30272
 - id: 30273
 - id: 30274
-  examine: "A cold, former TzHaar, solidified as a result of old age."
 - id: 30275
-  examine: "A cold, former TzHaar, hardened due to growing old."
 - id: 30276
-  examine: "A former TzHaar, cooled to rock form in old age."
 - id: 30277
-  examine: "A former TzHaar that has solidified in old age."
 - id: 30278
-  examine: "A counter made from a chunk of the surrounding obsidian."
 - id: 30279
-  examine: "Lots of ore on here."
 - id: 30280
-  examine: "Oooh shiny!"
 - id: 30281
-  examine: "I can feel my heart pulsating."
 - id: 30282
-  examine: "I can feel my heart pulsating."
 - id: 30283
-  examine: "This looks like the way out."
 - id: 30284
-  examine: "A large rocky column. It looks to be holding up well."
 - id: 30285
-  examine: "A large rocky column. It looks to have taken a little damage."
 - id: 30286
-  examine: "A large rocky column. It's starting to become unstable."
 - id: 30287
-  examine: "A large rocky column. It looks like it could break apart if it takes any more damage!"
 - id: 30288
 - id: 30289
 - id: 30290
@@ -46935,7 +39811,6 @@
 - id: 30329
 - id: 30330
 - id: 30331
-  examine: "A roof."
 - id: 30332
 - id: 30333
 - id: 30334
@@ -46943,15 +39818,12 @@
 - id: 30336
 - id: 30337
 - id: 30338
-  examine: "An ancient glyph which imprisons an ancient evil."
 - id: 30339
 - id: 30340
 - id: 30341
 - id: 30342
 - id: 30343
-  examine: "A falling rock."
 - id: 30344
-  examine: "A falling rock."
 - id: 30345
 - id: 30346
 - id: 30347
@@ -46966,192 +39838,107 @@
 - id: 30356
 - id: 30357
 - id: 30358
-  examine: "No staves in a barrel."
 - id: 30359
 - id: 30360
 - id: 30361
 - id: 30362
 - id: 30363
 - id: 30364
-  examine: "The door is closed."
 - id: 30365
-  examine: "The door is closed."
 - id: 30366
-  examine: "The door is closed."
 - id: 30367
-  examine: "I can climb down this."
 - id: 30368
 - id: 30369
 - id: 30370
 - id: 30371
-  examine: "This wall is densely packed with crystals."
 - id: 30372
-  examine: "This wall is densely packed with crystals."
 - id: 30373
-  examine: "There's nothing here."
 - id: 30374
-  examine: "Leads to a deeper part of the mine."
 - id: 30375
-  examine: "Leads to the Mining Guild."
 - id: 30376
-  examine: "I can use this to access the minnow fishing platform."
 - id: 30377
-  examine: "I can use this to leave the minnow fishing platform."
 - id: 30378
 - id: 30379
 - id: 30380
-  examine: "A dark and dank lair of the Lizardmen."
 - id: 30381
-  examine: "The way out of here."
 - id: 30382
-  examine: "I can squeeze through here."
 - id: 30383
-  examine: "I can squeeze through here."
 - id: 30384
-  examine: "I can squeeze through here."
 - id: 30385
-  examine: "I can squeeze through here."
 - id: 30386
-  examine: "A portal to Castle Wars."
 - id: 30387
-  examine: "A large double door."
 - id: 30388
-  examine: "A large double door."
 - id: 30389
 - id: 30390
-  examine: "The clerks and tellers will serve you here."
 - id: 30391
-  examine: "I could climb this if I wanted."
 - id: 30392
-  examine: "I could climb this if I wanted."
 - id: 30393
 - id: 30394
 - id: 30395
-  examine: "This isn't going to take me anywhere."
 - id: 30396
-  examine: "A magical barrier restricting access to this team's preparation area."
 - id: 30397
-  examine: "A magical barrier restricting access to this team's preparation area."
 - id: 30398
-  examine: "A magical barrier restricting access to this team's preparation area."
 - id: 30399
-  examine: "A magical barrier restricting access to this team's preparation area."
 - id: 30400
-  examine: "A magical barrier restricting access to this team's preparation area."
 - id: 30401
 - id: 30402
 - id: 30403
-  examine: "The Cape of the Champion of Champions."
 - id: 30404
 - id: 30405
 - id: 30406
-  examine: "A Mahogany sapling has been planted in this tree patch."
 - id: 30407
-  examine: "A Mahogany tree is growing in this tree patch."
 - id: 30408
-  examine: "A Mahogany tree is growing in this tree patch."
 - id: 30409
-  examine: "A Mahogany tree is growing in this tree patch."
 - id: 30410
-  examine: "A Mahogany tree is growing in this tree patch."
 - id: 30411
-  examine: "A Mahogany tree is growing in this tree patch."
 - id: 30412
-  examine: "A Mahogany tree is growing in this tree patch."
 - id: 30413
-  examine: "A Mahogany tree is growing in this tree patch."
 - id: 30414
-  examine: "A Mahogany tree is growing in this tree patch."
 - id: 30415
-  examine: "A Mahogany tree is growing in this tree patch."
 - id: 30416
-  examine: "A fully grown Mahogany tree."
 - id: 30417
-  examine: "A fully grown Mahogany tree."
 - id: 30418
-  examine: "You can uproot this tree stump with a spade."
 - id: 30419
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30420
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30421
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30422
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30423
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30424
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30425
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30426
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30427
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30428
-  examine: "This Mahogany tree has become diseased and died."
 - id: 30429
-  examine: "This Mahogany tree has become diseased and died."
 - id: 30430
-  examine: "This Mahogany tree has become diseased and died."
 - id: 30431
-  examine: "This Mahogany tree has become diseased and died."
 - id: 30432
-  examine: "This Mahogany tree has become diseased and died."
 - id: 30433
-  examine: "This Mahogany tree has become diseased and died."
 - id: 30434
-  examine: "This Mahogany tree has become diseased and died."
 - id: 30435
-  examine: "This Mahogany tree has become diseased and died."
 - id: 30436
-  examine: "This Mahogany tree has become diseased and died."
 - id: 30437
-  examine: "A Teak tree sapling has been planted in this tree patch."
 - id: 30438
-  examine: "A Teak tree is growing in this tree patch."
 - id: 30439
-  examine: "A Teak tree is growing in this tree patch."
 - id: 30440
-  examine: "A Teak tree is growing in this tree patch."
 - id: 30441
-  examine: "A Teak tree is growing in this tree patch."
 - id: 30442
-  examine: "A Teak tree is growing in this tree patch."
 - id: 30443
-  examine: "A Teak tree is growing in this tree patch."
 - id: 30444
-  examine: "A fully grown Teak tree."
 - id: 30445
-  examine: "A fully grown Teak tree."
 - id: 30446
-  examine: "You can uproot this stump with a spade."
 - id: 30447
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30448
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30449
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30450
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30451
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30452
-  examine: "To remove all signs of disease, prune the tree with secateurs."
 - id: 30453
-  examine: "This Teak tree has become diseased and died."
 - id: 30454
-  examine: "This Teak tree has become diseased and died."
 - id: 30455
-  examine: "This Teak tree has become diseased and died."
 - id: 30456
-  examine: "This Teak tree has become diseased and died."
 - id: 30457
-  examine: "This Teak tree has become diseased and died."
 - id: 30458
-  examine: "This Teak tree has become diseased and died."
 - id: 30459
-  examine: "This Teak tree has become diseased and died."
 - id: 30460
 - id: 30461
 - id: 30462
@@ -47167,98 +39954,55 @@
 - id: 30472
 - id: 30473
 - id: 30474
-  examine: "This Teak tree has become diseased and died."
 - id: 30475
-  examine: "This Teak tree has become diseased and died."
 - id: 30476
-  examine: "You can grow hardwood trees in this Farming patch."
 - id: 30477
-  examine: "You can grow hardwood trees in this Farming patch."
 - id: 30478
-  examine: "You can grow hardwood trees in this Farming patch."
 - id: 30479
-  examine: "You can grow hardwood trees in this Farming patch."
 - id: 30480
 - id: 30481
 - id: 30482
 - id: 30483
-  examine: "You can grow seaweed in this Farming patch."
 - id: 30484
-  examine: "You can grow seaweed in this Farming patch."
 - id: 30485
-  examine: "You can grow seaweed in this Farming patch."
 - id: 30486
-  examine: "You can grow seaweed in this Farming patch."
 - id: 30487
-  examine: "Seaweed spores have been sown in this farming patch."
 - id: 30488
-  examine: "Seaweed is growing in this farming patch."
 - id: 30489
-  examine: "Seaweed is growing in this farming patch."
 - id: 30490
-  examine: "Seaweed is growing in this farming patch."
 - id: 30491
-  examine: "A patch of seaweed."
 - id: 30492
-  examine: "A patch of seaweed."
 - id: 30493
-  examine: "A patch of seaweed."
 - id: 30494
-  examine: "This seaweed has become diseased."
 - id: 30495
-  examine: "This seaweed has become diseased."
 - id: 30496
-  examine: "This seaweed has become diseased."
 - id: 30497
-  examine: "This seaweed has become diseased and died."
 - id: 30498
-  examine: "This seaweed has become diseased and died."
 - id: 30499
-  examine: "This seaweed has become diseased and died."
 - id: 30500
 - id: 30501
 - id: 30502
-  examine: "This compost bin contains ultracompost (1/15)."
 - id: 30503
-  examine: "This compost bin contains ultracompost (2/15)."
 - id: 30504
-  examine: "This compost bin contains ultracompost (3/15)."
 - id: 30505
-  examine: "This compost bin contains ultracompost (4/15)."
 - id: 30506
-  examine: "This compost bin contains ultracompost (5/15)."
 - id: 30507
-  examine: "This compost bin contains ultracompost (6/15)."
 - id: 30508
-  examine: "This compost bin contains ultracompost (7/15)."
 - id: 30509
-  examine: "This compost bin contains ultracompost (8/15)."
 - id: 30510
-  examine: "This compost bin contains ultracompost (9/15)."
 - id: 30511
-  examine: "This compost bin contains ultracompost (10/15)."
 - id: 30512
-  examine: "This compost bin contains ultracompost (11/15)."
 - id: 30513
-  examine: "This compost bin contains ultracompost (12/15)."
 - id: 30514
-  examine: "This compost bin contains ultracompost (13/15)."
 - id: 30515
-  examine: "This compost bin contains ultracompost (14/15)."
 - id: 30516
-  examine: "This compost bin is full of ultracompost."
 - id: 30517
 - id: 30518
 - id: 30519
-  examine: "Looks like a tuft of fur has been caught on the rock."
 - id: 30520
-  examine: "Looks like a mushroom with a chunk out of it or some obvious spoor."
 - id: 30521
-  examine: "Looks like a tuft of fur has been caught on the rock."
 - id: 30522
-  examine: "Looks like a tuft of fur has been caught on the rock."
 - id: 30523
-  examine: "There's a tuft of fur next to the driftwood. I wonder where that came from..."
 - id: 30524
 - id: 30525
 - id: 30526
@@ -47268,79 +40012,44 @@
 - id: 30530
 - id: 30531
 - id: 30532
-  examine: "Something has dug a tunnel here. I wonder if they're home?"
 - id: 30533
-  examine: "A muddy patch of soil."
 - id: 30534
-  examine: "A basket mushroom."
 - id: 30535
-  examine: "A rather smelly mushroom."
 - id: 30536
-  examine: "A muddy patch of soil."
 - id: 30537
-  examine: "A pile of seaweed."
 - id: 30538
-  examine: "A pile of seaweed."
 - id: 30539
-  examine: "A basket mushroom."
 - id: 30540
-  examine: "A rather smelly mushroom."
 - id: 30541
-  examine: "A rather smelly mushroom."
 - id: 30542
-  examine: "A pile of seaweed."
 - id: 30543
-  examine: "A muddy patch of soil."
 - id: 30544
-  examine: "A muddy patch of soil."
 - id: 30545
-  examine: "A rather smelly mushroom."
 - id: 30546
-  examine: "A muddy patch of soil."
 - id: 30547
-  examine: "A muddy patch of soil."
 - id: 30548
-  examine: "A basket mushroom."
 - id: 30549
-  examine: "A muddy patch of soil."
 - id: 30550
-  examine: "A pile of seaweed."
 - id: 30551
-  examine: "A pile of seaweed."
 - id: 30552
-  examine: "A space to place your birdhouse."
 - id: 30553
-  examine: "A simple device for catching birds - needs to be filled with seeds."
 - id: 30554
-  examine: "A simple device for catching birds. Full of seed."
 - id: 30555
-  examine: "There's something caught in it."
 - id: 30556
-  examine: "A simple device for catching birds."
 - id: 30557
-  examine: "A simple device for catching birds. Full of seed."
 - id: 30558
-  examine: "There's something caught in it."
 - id: 30559
-  examine: "A simple device for catching birds."
 - id: 30560
-  examine: "A simple device for catching birds. Full of seed."
 - id: 30561
-  examine: "There's something caught in it."
 - id: 30562
-  examine: "A simple device for catching birds."
 - id: 30563
-  examine: "A simple device for catching birds. Full of seed."
 - id: 30564
-  examine: "There's something caught in it."
 - id: 30565
 - id: 30566
 - id: 30567
 - id: 30568
 - id: 30569
-  examine: "I can use this to control the speed and direction of the barge."
 - id: 30570
-  examine: "Used to control the speed and direction of the barge."
 - id: 30571
 - id: 30572
 - id: 30573
@@ -47358,7 +40067,6 @@
 - id: 30585
 - id: 30586
 - id: 30587
-  examine: "Leads to the bowels of the ship."
 - id: 30588
 - id: 30589
 - id: 30590
@@ -47374,15 +40082,10 @@
 - id: 30600
 - id: 30601
 - id: 30602
-  examine: "Looks edible, sort of."
 - id: 30603
-  examine: "Looks far too small to harvest."
 - id: 30604
-  examine: "A pit."
 - id: 30605
-  examine: "A pit... full of bittercaps. Cushy!"
 - id: 30606
-  examine: "Just the cap."
 - id: 30607
 - id: 30608
 - id: 30609
@@ -47421,55 +40124,33 @@
 - id: 30642
 - id: 30643
 - id: 30644
-  examine: "A rake could clear these."
 - id: 30645
-  examine: "A hatchet could cut these."
 - id: 30646
-  examine: "A hatchet could cut this."
 - id: 30647
-  examine: "A hatchet could cut this."
 - id: 30648
-  examine: "A hatchet could cut these."
 - id: 30649
-  examine: "A hatchet could cut these."
 - id: 30650
-  examine: "A rake could clear these."
 - id: 30651
 - id: 30652
 - id: 30653
 - id: 30654
 - id: 30655
 - id: 30656
-  examine: "A sinister looking agaric."
 - id: 30657
-  examine: "A sinister looking agaric."
 - id: 30658
-  examine: "A sinister looking agaric."
 - id: 30659
-  examine: "A sinister looking agaric."
 - id: 30660
-  examine: "A sinister looking agaric."
 - id: 30661
-  examine: "A sinister looking agaric."
 - id: 30662
-  examine: "A deathly looking lilly."
 - id: 30663
-  examine: "A large column of spiney mushrooms."
 - id: 30664
-  examine: "A large column of spiney mushrooms."
 - id: 30665
-  examine: "That liquid inside looks toxic."
 - id: 30666
-  examine: "Mmmmmm?"
 - id: 30667
-  examine: "The stagnant goo bubbles horribly."
 - id: 30668
-  examine: "A deathly looking lilly."
 - id: 30669
 - id: 30670
-  examine: "Ring the bell, pay a toll?"
 - id: 30671
-  examine: "Rings a bell. Likely poisonous."
 - id: 30672
 - id: 30673
 - id: 30674
@@ -47480,9 +40161,7 @@
 - id: 30679
 - id: 30680
 - id: 30681
-  examine: "Climb them, 1 step at a time."
 - id: 30682
-  examine: "Climb them, 1 step at a time."
 - id: 30683
 - id: 30684
 - id: 30685
@@ -47505,9 +40184,7 @@
 - id: 30702
 - id: 30703
 - id: 30704
-  examine: "Wouldn't want to fall into that."
 - id: 30705
-  examine: "Wouldn't want to fall into that."
 - id: 30706
 - id: 30707
 - id: 30708
@@ -47518,35 +40195,20 @@
 - id: 30713
 - id: 30714
 - id: 30715
-  examine: "Falling apart and full of an ancient script."
 - id: 30716
-  examine: "Falling apart and full of an ancient script."
 - id: 30717
-  examine: "I wonder what strange concotion used to be brewed here."
 - id: 30718
-  examine: "I wonder what strange concotion used to be brewed here."
 - id: 30719
-  examine: "I wonder what strange concotion used to be brewed here."
 - id: 30720
-  examine: "Locked tight. There appears to be a strange hole in the front."
 - id: 30721
-  examine: "This chest has been looted recently."
 - id: 30722
-  examine: "Hewn from the very rock we stand upon. The word Skeka is carved into the surface."
 - id: 30723
-  examine: "Stacked crates of stone."
 - id: 30724
-  examine: "It's too heavy to topple."
 - id: 30725
-  examine: "An entrance to the basement."
 - id: 30726
-  examine: "A closed trapdoor."
 - id: 30727
-  examine: "A way out of the basement."
 - id: 30728
-  examine: "It seems to have been hit with swords."
 - id: 30729
-  examine: "Why would playing blocks be in a place like this?"
 - id: 30730
 - id: 30731
 - id: 30732
@@ -47566,9 +40228,7 @@
 - id: 30746
 - id: 30747
 - id: 30748
-  examine: "Caution. Smells fishy."
 - id: 30749
-  examine: "In need of some anchor management."
 - id: 30750
 - id: 30751
 - id: 30752
@@ -47586,9 +40246,7 @@
 - id: 30764
 - id: 30765
 - id: 30766
-  examine: "I could probably fit through it."
 - id: 30767
-  examine: "I could probably fit through it."
 - id: 30768
 - id: 30769
 - id: 30770
@@ -47596,25 +40254,15 @@
 - id: 30772
 - id: 30773
 - id: 30774
-  examine: "It's in the way."
 - id: 30775
-  examine: "A plant on the ocean floor."
 - id: 30776
-  examine: "A plant on the ocean floor."
 - id: 30777
-  examine: "A plant on the ocean floor."
 - id: 30778
-  examine: "A plant on the ocean floor."
 - id: 30779
-  examine: "A plant on the ocean floor."
 - id: 30780
-  examine: "A plant on the ocean floor."
 - id: 30781
-  examine: "A plant on the ocean floor."
 - id: 30782
-  examine: "A plant on the ocean floor."
 - id: 30783
-  examine: "A strong ocean current."
 - id: 30784
 - id: 30785
 - id: 30786
@@ -47628,122 +40276,68 @@
 - id: 30794
 - id: 30795
 - id: 30796
-  examine: "A bank chest seems to have washed up on shore."
 - id: 30797
-  examine: "Looks awfully like a pile of seaweed."
 - id: 30798
-  examine: "Is it safe to eat?"
 - id: 30799
-  examine: "Is it safe to eat?"
 - id: 30800
 - id: 30801
-  examine: "Mushy."
 - id: 30802
 - id: 30803
 - id: 30804
-  examine: "Mushy."
 - id: 30805
-  examine: "It's covered in strange orange spores."
 - id: 30806
-  examine: "A well slept in bed."
 - id: 30807
 - id: 30808
 - id: 30809
 - id: 30810
-  examine: "Filled with various supplies."
 - id: 30811
-  examine: "An empty crate."
 - id: 30812
-  examine: "Must contain something precious."
 - id: 30813
 - id: 30814
-  examine: "Must contain something precious."
 - id: 30815
 - id: 30816
-  examine: "Various small boxes."
 - id: 30817
-  examine: "Contains... something."
 - id: 30818
-  examine: "A barrel full of pickaxes."
 - id: 30819
-  examine: "An empty barrel for pickaxes."
 - id: 30820
-  examine: "A barrel full of volcanic rock."
 - id: 30821
-  examine: "An empty barrel."
 - id: 30822
-  examine: "Don't think I'd like to eat these."
 - id: 30823
-  examine: "Don't think I'd like to eat these."
 - id: 30824
-  examine: "Don't think I'd like to eat these."
 - id: 30825
-  examine: "Don't think I'd like to eat these."
 - id: 30826
-  examine: "Definitely won't be eating this."
 - id: 30827
-  examine: "Definitely won't be eating this."
 - id: 30828
-  examine: "Looks like candy floss. Chances are it doesn't taste like it though."
 - id: 30829
-  examine: "Looks like candy floss. Chances are it doesn't taste like it though."
 - id: 30830
-  examine: "I hope that isn't actually blood in there..."
 - id: 30831
-  examine: "I hope that isn't actually blood in there..."
 - id: 30832
-  examine: "I hope that isn't actually blood in there..."
 - id: 30833
-  examine: "Something tells me it might be poisonous."
 - id: 30834
-  examine: "Looks to be surrounded by spores. Better not touch them."
 - id: 30835
-  examine: "Looks to be surrounded by spores. Better not touch them."
 - id: 30836
-  examine: "Looks to be surrounded by spores. Better not touch them."
 - id: 30837
-  examine: "A decaying tree trunk."
 - id: 30838
-  examine: "Can't imagine this is edible."
 - id: 30839
-  examine: "Can't imagine this is edible."
 - id: 30840
-  examine: "Eww."
 - id: 30841
-  examine: "Not yet corrupted by the swampland."
 - id: 30842
-  examine: "I can hear something big down here..."
 - id: 30843
-  examine: "Looks like some driftwood."
 - id: 30844
-  examine: "Looks like a way out!"
 - id: 30845
-  examine: "Some steps, for stepping up."
 - id: 30846
-  examine: "Some steps, for stepping down."
 - id: 30847
-  examine: "Small steps upwards."
 - id: 30848
 - id: 30849
-  examine: "Small steps upwards."
 - id: 30850
-  examine: "Some steps, for stepping down."
 - id: 30851
-  examine: "Forcae castil draekeun. Ortha lokur. Lith kletter ortha lokur. Draekeun fia Lithkren."
 - id: 30852
-  examine: "Quite crispy."
 - id: 30853
-  examine: "Too burnt to be of any use."
 - id: 30854
-  examine: "Quite crispy."
 - id: 30855
-  examine: "This tree has been cut down."
 - id: 30856
-  examine: "This tree has been cut down."
 - id: 30857
-  examine: "Some slightly damp rocks."
 - id: 30858
-  examine: "Some slightly damp rocks."
 - id: 30859
 - id: 30860
 - id: 30861
@@ -47751,27 +40345,19 @@
 - id: 30863
 - id: 30864
 - id: 30865
-  examine: "A long way from home."
 - id: 30866
-  examine: "Bad luck, Chuck."
 - id: 30867
-  examine: "Washed up."
 - id: 30868
-  examine: "A sinister looking agaric."
 - id: 30869
-  examine: "I wonder what could be in here..."
 - id: 30870
 - id: 30871
-  examine: "An old stone table topped with an ancient symbol."
 - id: 30872
-  examine: "A broken table, probably used by the ancient inhabitant of this island."
 - id: 30873
 - id: 30874
 - id: 30875
 - id: 30876
 - id: 30877
 - id: 30878
-  examine: "If it wasn't already clear, this is the exit."
 - id: 30879
 - id: 30880
 - id: 30881
@@ -47808,142 +40394,81 @@
 - id: 30912
 - id: 30913
 - id: 30914
-  examine: "A wooden rowboat."
 - id: 30915
-  examine: "A wooden rowboat."
 - id: 30916
-  examine: "An anchor for rope. Maybe I can climb this?"
 - id: 30917
-  examine: "An anchor for rope. Maybe I can climb this?"
 - id: 30918
 - id: 30919
-  examine: "A wooden rowboat."
 - id: 30920
-  examine: "Not mushroom to squeeze in there."
 - id: 30921
 - id: 30922
-  examine: "Not mushroom to squeeze in there."
 - id: 30923
 - id: 30924
-  examine: "Not mushroom to squeeze in there."
 - id: 30925
 - id: 30926
-  examine: "An open bank chest."
 - id: 30927
-  examine: "Looks like a good spot for a bank chest. Requires Construction level 21, 2 oak planks, 1 iron bar, 5 nails and a hammer."
 - id: 30928
-  examine: "An area specifically for the cleaning of fossil finds."
 - id: 30929
-  examine: "Looks like a good spot for a cleaning bench. Requires Construction level 5, 5 planks, 5 nails and a hammer."
 - id: 30930
-  examine: "A river runs through it."
 - id: 30931
-  examine: "Someone has marked a nice spot for a well. Requires Construction level 22, 2 oak planks, a rope, an empty bucket, 5 nails and a hammer."
 - id: 30932
-  examine: "Cook your food here."
 - id: 30933
-  examine: "Looks like a good spot for some cooking facilities. Requires Construction level 24, 3 soft clay, 1 iron bar, 2 logs, a tinderbox and a hammer."
 - id: 30934
-  examine: "Round and round it goes."
 - id: 30935
-  examine: "Looks like it's missing a wheel. Requires Construction level 28, 4 oak planks, 5 nails and a hammer."
 - id: 30936
-  examine: "A loom."
 - id: 30937
-  examine: "Looks like I should finish assembling the loom. Requires Construction level 29, 2 oak planks, 5 nails, a rope and a hammer."
 - id: 30938
-  examine: "Going up?"
 - id: 30939
-  examine: "Going down?"
 - id: 30940
-  examine: "Going up?"
 - id: 30941
-  examine: "Going down?"
 - id: 30942
-  examine: "An open crate full of useful equipment for cleaning fossils."
 - id: 30943
-  examine: "An ancient book of spells, the symbols show of a pendant with a ruby jewel."
 - id: 30944
-  examine: "A powerful tool sits upon the table."
 - id: 30945
-  examine: "A broken glass chamber. Perhaps it has powers pertaining to life and death?"
 - id: 30946
-  examine: "Falling apart and full of an ancient script."
 - id: 30947
-  examine: "A pot of gold just weighting around."
 - id: 30948
-  examine: "A chain hangs here with an anchor on it."
 - id: 30949
-  examine: "Leads back to the surface"
 - id: 30950
-  examine: "It looks slippy but I think you can climb this."
 - id: 30951
-  examine: "An anchor rope hangs here."
 - id: 30952
-  examine: "Looks like a good place to anchor a drift net."
 - id: 30953
-  examine: "An empty drift net."
 - id: 30954
-  examine: "Looks like this net has some fish in it."
 - id: 30955
-  examine: "Looks like this net is stocked with fish."
 - id: 30956
 - id: 30957
 - id: 30958
 - id: 30959
-  examine: "Can't go round it, can't go over it... I better go through it."
 - id: 30960
-  examine: "The plant wont let me pass while I wearing a diving helmet."
 - id: 30961
-  examine: "Like a door, made of seaweed. Well, more like a curtain actually."
 - id: 30962
-  examine: "Can't go round it, can't go over it... I better go through it."
 - id: 30963
 - id: 30964
-  examine: "Can't go round it, can't go over it... I better go through it."
 - id: 30965
 - id: 30966
-  examine: "I wonder where it goes?"
 - id: 30967
-  examine: "Bowls have been banned from the depths, place your bowl here."
 - id: 30968
-  examine: "Bowls have been banned from the depths, place your bowl here."
 - id: 30969
-  examine: "I wonder what's inside?"
 - id: 30970
-  examine: "It's... sleeping?"
 - id: 30971
-  examine: "Yep, certainly not your average chest."
 - id: 30972
-  examine: "Is something living within?"
 - id: 30973
-  examine: "Helps channel fossils or other items into the pool."
 - id: 30974
-  examine: "Helps channel fossils or other items into the rinsing pool."
 - id: 30975
-  examine: "Helps channel fossils or other items into the rinsing pool."
 - id: 30976
-  examine: "A bonus pool. For rinsing."
 - id: 30977
-  examine: "A bonus pool. For rinsing."
 - id: 30978
 - id: 30979
 - id: 30980
-  examine: "A strange mushroom."
 - id: 30981
 - id: 30982
 - id: 30983
 - id: 30984
 - id: 30985
-  examine: "A pile of ash."
 - id: 30986
-  examine: "No more ash here."
 - id: 30987
-  examine: "This crate rocks."
 - id: 30988
-  examine: "Crateaceous box of storage."
 - id: 30989
-  examine: "A handy bank chest."
 - id: 30990
 - id: 30991
 - id: 30992
@@ -47952,7 +40477,6 @@
 - id: 30995
 - id: 30996
 - id: 30997
-  examine: "Hot!"
 - id: 30998
 - id: 30999
 - id: 31000
@@ -47985,551 +40509,282 @@
 - id: 31027
 - id: 31028
 - id: 31029
-  examine: "These rocks have conveniently formed a staircase."
 - id: 31030
-  examine: "These rocks have conveniently formed a staircase."
 - id: 31031
-  examine: "Phew! Smells awfully like Brimstone... Better keep my mouth closed."
 - id: 31032
-  examine: "Looks like a way out!"
 - id: 31033
 - id: 31034
-  examine: "It's attached."
 - id: 31035
-  examine: "Giant, but it still floats."
 - id: 31036
-  examine: "Not such a giant boulder anymore."
 - id: 31037
-  examine: "It's getting smaller, maybe there are goodies in the middle, like a pi?ata."
 - id: 31038
-  examine: "Rich with minerals."
 - id: 31039
-  examine: "Hot and whirly."
 - id: 31040
-  examine: "Allows one to inspect the gas levels in the chamber below..."
 - id: 31041
 - id: 31042
-  examine: "The heat distorts the light."
 - id: 31043
-  examine: "To block or not to block."
 - id: 31044
-  examine: "To block or not to block."
 - id: 31045
-  examine: "A large rock."
 - id: 31046
-  examine: "A large rock was once here. Maybe it will be back soon."
 - id: 31047
-  examine: "Scorching gas leaks out."
 - id: 31048
-  examine: "Scorching gas leaks out."
 - id: 31049
-  examine: "Scorching gas leaks out."
 - id: 31050
-  examine: "Scorching gas leaks out."
 - id: 31051
-  examine: "Scorching gas leaks out."
 - id: 31052
-  examine: "Scorching gas leaks out."
 - id: 31053
-  examine: "Massive snake like leviathan."
 - id: 31054
-  examine: "Massive snake like leviathan."
 - id: 31055
-  examine: "Massive snake like leviathan."
 - id: 31056
-  examine: "Massive snake like leviathan."
 - id: 31057
-  examine: "Massive snake like leviathan."
 - id: 31058
-  examine: "Massive snake like leviathan."
 - id: 31059
-  examine: "This is made for supporting large fossils."
 - id: 31060
-  examine: "This is made for supporting large fossils."
 - id: 31061
-  examine: "This is made for supporting large fossils."
 - id: 31062
-  examine: "This is made for supporting large fossils."
 - id: 31063
-  examine: "This is made for supporting large fossils."
 - id: 31064
-  examine: "This is made for supporting large fossils."
 - id: 31065
-  examine: "Massive snake like leviathan."
 - id: 31066
-  examine: "Massive snake like leviathan."
 - id: 31067
-  examine: "Massive snake like leviathan."
 - id: 31068
-  examine: "Massive snake like leviathan."
 - id: 31069
-  examine: "Massive snake like leviathan."
 - id: 31070
-  examine: "Massive snake like leviathan."
 - id: 31071
-  examine: "This is made for supporting large fossils."
 - id: 31072
-  examine: "This is made for supporting large fossils."
 - id: 31073
-  examine: "This is made for supporting large fossils."
 - id: 31074
-  examine: "This is made for supporting large fossils."
 - id: 31075
-  examine: "This is made for supporting large fossils."
 - id: 31076
-  examine: "Massive snake like leviathan."
 - id: 31077
-  examine: "Massive snake like leviathan."
 - id: 31078
-  examine: "Massive snake like leviathan."
 - id: 31079
-  examine: "Massive snake like leviathan."
 - id: 31080
-  examine: "Massive snake like leviathan."
 - id: 31081
-  examine: "Massive snake like leviathan."
 - id: 31082
-  examine: "Massive snake like leviathan."
 - id: 31083
-  examine: "This is made for supporting large fossils."
 - id: 31084
-  examine: "This is made for supporting large fossils."
 - id: 31085
-  examine: "This is made for supporting large fossils."
 - id: 31086
-  examine: "This is made for supporting large fossils."
 - id: 31087
-  examine: "This is made for supporting large fossils."
 - id: 31088
-  examine: "Massive snake like leviathan."
 - id: 31089
-  examine: "Massive snake like leviathan."
 - id: 31090
-  examine: "Massive snake like leviathan."
 - id: 31091
-  examine: "Massive snake like leviathan."
 - id: 31092
-  examine: "Massive snake like leviathan."
 - id: 31093
-  examine: "Massive snake like leviathan."
 - id: 31094
-  examine: "Massive snake like leviathan."
 - id: 31095
-  examine: "This is made for supporting large fossils."
 - id: 31096
-  examine: "This is made for supporting large fossils."
 - id: 31097
-  examine: "This is made for supporting large fossils."
 - id: 31098
-  examine: "This is made for supporting large fossils."
 - id: 31099
-  examine: "This is made for supporting large fossils."
 - id: 31100
-  examine: "Massive snake like leviathan."
 - id: 31101
-  examine: "A bone of this size must belong to a Leviathan."
 - id: 31102
-  examine: "A partialy completed fossil."
 - id: 31103
-  examine: "A partialy completed fossil."
 - id: 31104
-  examine: "A partialy completed fossil."
 - id: 31105
-  examine: "A partialy completed fossil."
 - id: 31106
-  examine: "Massive snake like leviathan."
 - id: 31107
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31108
-  examine: "A partialy completed fossil."
 - id: 31109
-  examine: "A partialy completed fossil."
 - id: 31110
-  examine: "A partialy completed fossil."
 - id: 31111
-  examine: "A partialy completed fossil."
 - id: 31112
-  examine: "Looks like there's no mush-room left in that case!"
 - id: 31113
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31114
-  examine: "A partialy completed fossil."
 - id: 31115
-  examine: "A partialy completed fossil."
 - id: 31116
-  examine: "A partialy completed fossil."
 - id: 31117
-  examine: "A partialy completed fossil."
 - id: 31118
-  examine: "Crash, bang, wallop what a pitcher."
 - id: 31119
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31120
-  examine: "A partialy completed fossil."
 - id: 31121
-  examine: "A partialy completed fossil."
 - id: 31122
-  examine: "A partialy completed fossil."
 - id: 31123
-  examine: "A partialy completed fossil."
 - id: 31124
-  examine: "Looks like there's not much-skroom left in that case!"
 - id: 31125
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31126
-  examine: "A partialy completed fossil."
 - id: 31127
-  examine: "A partialy completed fossil."
 - id: 31128
-  examine: "A partialy completed fossil."
 - id: 31129
-  examine: "A partialy completed fossil."
 - id: 31130
-  examine: "It has terrible posture."
 - id: 31131
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31132
-  examine: "A partialy completed fossil."
 - id: 31133
-  examine: "A partialy completed fossil."
 - id: 31134
-  examine: "A partialy completed fossil."
 - id: 31135
-  examine: "A partialy completed fossil."
 - id: 31136
-  examine: "Looks past its eat by date."
 - id: 31137
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31138
-  examine: "A partially completed fossil."
 - id: 31139
-  examine: "A partially completed fossil."
 - id: 31140
-  examine: "A partially completed fossil."
 - id: 31141
-  examine: "A partially completed fossil."
 - id: 31142
-  examine: "Something looks fishy."
 - id: 31143
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31144
-  examine: "A partially completed fossil."
 - id: 31145
-  examine: "A partially completed fossil."
 - id: 31146
-  examine: "A partially completed fossil."
 - id: 31147
-  examine: "A partially completed fossil."
 - id: 31148
-  examine: "All puffed up and no where to blow."
 - id: 31149
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31150
-  examine: "A partially completed fossil."
 - id: 31151
-  examine: "A partially completed fossil."
 - id: 31152
-  examine: "A partially completed fossil."
 - id: 31153
-  examine: "A partially completed fossil."
 - id: 31154
-  examine: "Talk about putting your foot in your mouth."
 - id: 31155
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31156
-  examine: "A partially completed fossil."
 - id: 31157
-  examine: "A partially completed fossil."
 - id: 31158
-  examine: "A partially completed fossil."
 - id: 31159
-  examine: "A partially completed fossil."
 - id: 31160
-  examine: "Eggtraordinary"
 - id: 31161
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31162
-  examine: "A partially completed fossil."
 - id: 31163
-  examine: "A partially completed fossil."
 - id: 31164
-  examine: "A partially completed fossil."
 - id: 31165
-  examine: "A partially completed fossil."
 - id: 31166
-  examine: "Looks like someone finally came out of their shell."
 - id: 31167
   depleted: 15582
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31168
   depleted: 15583
-  examine: "A partially completed fossil."
 - id: 31169
   depleted: 15584
-  examine: "A partially completed fossil."
 - id: 31170
   depleted: 15582
-  examine: "A partially completed fossil."
 - id: 31171
-  examine: "A partially completed fossil."
 - id: 31172
-  examine: "I wonder if it can still be carbon dated?"
 - id: 31173
   depleted: 15582
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31174
   depleted: 15583
-  examine: "A partially completed fossil."
 - id: 31175
-  examine: "A partially completed fossil."
 - id: 31176
-  examine: "A partially completed fossil."
 - id: 31177
-  examine: "A partially completed fossil."
 - id: 31178
-  examine: "It's a big, foot print."
 - id: 31179
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31180
-  examine: "A partially completed fossil."
 - id: 31181
-  examine: "A partially completed fossil."
 - id: 31182
-  examine: "A partially completed fossil."
 - id: 31183
-  examine: "A partially completed fossil."
 - id: 31184
-  examine: "Not mushroom in there."
 - id: 31185
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31186
-  examine: "A partially completed fossil."
 - id: 31187
-  examine: "A partially completed fossil."
 - id: 31188
-  examine: "A partially completed fossil."
 - id: 31189
-  examine: "A partially completed fossil."
 - id: 31190
-  examine: "A shell of its former self."
 - id: 31191
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31192
-  examine: "A partially completed fossil."
 - id: 31193
-  examine: "A partially completed fossil."
 - id: 31194
-  examine: "A partially completed fossil."
 - id: 31195
-  examine: "A partially completed fossil."
 - id: 31196
-  examine: "The shape of this foot print must have belonged to a mythical animal..."
 - id: 31197
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31198
-  examine: "A partially completed fossil."
 - id: 31199
-  examine: "A partially completed fossil."
 - id: 31200
-  examine: "A partially completed fossil."
 - id: 31201
-  examine: "A partially completed fossil."
 - id: 31202
-  examine: "This fossil appears to have a crack in it."
 - id: 31203
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31204
-  examine: "A partially completed fossil."
 - id: 31205
-  examine: "A partially completed fossil."
 - id: 31206
-  examine: "A partially completed fossil."
 - id: 31207
-  examine: "A partially completed fossil."
 - id: 31208
-  examine: "It's a drawing."
 - id: 31209
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31210
-  examine: "A partially completed fossil."
 - id: 31211
-  examine: "A partially completed fossil."
 - id: 31212
-  examine: "A partially completed fossil."
 - id: 31213
-  examine: "A partially completed fossil."
 - id: 31214
-  examine: "Two heads are better than one."
 - id: 31215
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31216
-  examine: "A partially completed fossil."
 - id: 31217
-  examine: "A partially completed fossil."
 - id: 31218
-  examine: "A partially completed fossil."
 - id: 31219
-  examine: "A partially completed fossil."
 - id: 31220
-  examine: "Not so dangerous now!"
 - id: 31221
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31222
-  examine: "A partialy completed fossil."
 - id: 31223
-  examine: "A partialy completed fossil."
 - id: 31224
-  examine: "A partialy completed fossil."
 - id: 31225
-  examine: "A partialy completed fossil."
 - id: 31226
-  examine: "Lobservably crusty."
 - id: 31227
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31228
-  examine: "A partialy completed fossil."
 - id: 31229
-  examine: "A partialy completed fossil."
 - id: 31230
-  examine: "A partialy completed fossil."
 - id: 31231
-  examine: "A partialy completed fossil."
 - id: 31232
-  examine: "You make everything, gooooey."
 - id: 31233
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31234
-  examine: "A partialy completed fossil."
 - id: 31235
-  examine: "A partialy completed fossil."
 - id: 31236
-  examine: "A partialy completed fossil."
 - id: 31237
-  examine: "A partialy completed fossil."
 - id: 31238
-  examine: "In life it was a goblin merfish but now it has no eyes."
 - id: 31239
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31240
-  examine: "A partialy completed fossil."
 - id: 31241
-  examine: "A partialy completed fossil."
 - id: 31242
-  examine: "A partialy completed fossil."
 - id: 31243
-  examine: "A partialy completed fossil."
 - id: 31244
-  examine: "Two can play at this game."
 - id: 31245
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31246
-  examine: "A partialy completed fossil."
 - id: 31247
-  examine: "A partialy completed fossil."
 - id: 31248
-  examine: "A partialy completed fossil."
 - id: 31249
-  examine: "A partialy completed fossil."
 - id: 31250
-  examine: "I wonder if its feathers were slimy?"
 - id: 31251
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31252
-  examine: "A partialy completed fossil."
 - id: 31253
-  examine: "A partialy completed fossil."
 - id: 31254
-  examine: "A partialy completed fossil."
 - id: 31255
-  examine: "A partialy completed fossil."
 - id: 31256
-  examine: "Seems a bit withdrawn."
 - id: 31257
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31258
-  examine: "A partialy completed fossil."
 - id: 31259
-  examine: "A partialy completed fossil."
 - id: 31260
-  examine: "A partialy completed fossil."
 - id: 31261
-  examine: "A partialy completed fossil."
 - id: 31262
-  examine: "Some-fin jaw-some from the deep."
 - id: 31263
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31264
-  examine: "A partialy completed fossil."
 - id: 31265
-  examine: "A partialy completed fossil."
 - id: 31266
-  examine: "A partialy completed fossil."
 - id: 31267
-  examine: "A partialy completed fossil."
 - id: 31268
-  examine: "Ain't half a fun guy."
 - id: 31269
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31270
-  examine: "A partialy completed fossil."
 - id: 31271
-  examine: "A partialy completed fossil."
 - id: 31272
-  examine: "A partialy completed fossil."
 - id: 31273
-  examine: "A partialy completed fossil."
 - id: 31274
-  examine: "A Paleontological nut case."
 - id: 31275
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31276
-  examine: "A partialy completed fossil."
 - id: 31277
-  examine: "A partialy completed fossil."
 - id: 31278
-  examine: "A partialy completed fossil."
 - id: 31279
-  examine: "A partialy completed fossil."
 - id: 31280
-  examine: "Why the long face?"
 - id: 31281
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31282
-  examine: "A partialy completed fossil."
 - id: 31283
-  examine: "A partialy completed fossil."
 - id: 31284
-  examine: "A partialy completed fossil."
 - id: 31285
-  examine: "A partialy completed fossil."
 - id: 31286
-  examine: "I don't want to know how this abomination came to be..."
 - id: 31287
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31288
-  examine: "A partialy completed fossil."
 - id: 31289
-  examine: "A partialy completed fossil."
 - id: 31290
-  examine: "A partialy completed fossil."
 - id: 31291
-  examine: "A partialy completed fossil."
 - id: 31292
-  examine: "I don't want to know how this abomination came to be..."
 - id: 31293
-  examine: "Looks like this case is lacking any contents at the moment."
 - id: 31294
-  examine: "A partialy completed fossil."
 - id: 31295
-  examine: "A partialy completed fossil."
 - id: 31296
-  examine: "A partialy completed fossil."
 - id: 31297
-  examine: "A partialy completed fossil."
 - id: 31298
-  examine: "Did you know you can eat lava? But only once."
 - id: 31299
-  examine: "For getting a better look at the larger display."
 - id: 31300
 - id: 31301
 - id: 31302
@@ -48710,18 +40965,12 @@
 - id: 31477
 - id: 31478
 - id: 31479
-  examine: "A muddy patch of soil."
 - id: 31480
-  examine: "A muddy patch of soil."
 - id: 31481
-  examine: "Maybe I can climb through this?"
 - id: 31482
-  examine: "Maybe I can climb through this?"
 - id: 31483
 - id: 31484
-  examine: "You would be hard pressed to fit fifteen people on that!"
 - id: 31485
-  examine: "Good for climbing."
 - id: 31486
 - id: 31487
 - id: 31488
@@ -48791,19 +41040,13 @@
 - id: 31552
 - id: 31553
 - id: 31554
-  examine: "I wonder what this does..."
 - id: 31555
-  examine: "What's the worst that could happen?"
 - id: 31556
-  examine: "What's the worst that could happen?"
 - id: 31557
-  examine: "It's not any safer out there."
 - id: 31558
-  examine: "It's not any safer out there."
 - id: 31559
 - id: 31560
 - id: 31561
-  examine: "Don't look down."
 - id: 31562
 - id: 31563
 - id: 31564
@@ -48814,38 +41057,22 @@
 - id: 31569
 - id: 31570
 - id: 31571
-  examine: "Guess what's inside it."
 - id: 31572
-  examine: "Guess what's inside it."
 - id: 31573
-  examine: "Guess what's inside it."
 - id: 31574
-  examine: "Guess what's inside it."
 - id: 31575
-  examine: "Guess what's inside it."
 - id: 31576
-  examine: "Guess what's inside it."
 - id: 31577
-  examine: "Guess what's inside it."
 - id: 31578
-  examine: "Guess what's inside it."
 - id: 31579
-  examine: "Guess what's inside it."
 - id: 31580
-  examine: "Guess what's inside it."
 - id: 31581
-  examine: "Guess what's inside it."
 - id: 31582
-  examine: "Guess what's inside it."
 - id: 31583
-  examine: "Where has all the rum gone?"
 - id: 31584
-  examine: "Closed for business."
 - id: 31585
-  examine: "Popular with farmers and treasure hunters."
 - id: 31586
 - id: 31587
-  examine: "Fit for a king."
 - id: 31588
 - id: 31589
 - id: 31590
@@ -48865,57 +41092,34 @@
 - id: 31604
 - id: 31605
 - id: 31606
-  examine: "A small hole in a hillock."
 - id: 31607
 - id: 31608
 - id: 31609
-  examine: "Stairs leading to the upper floor."
 - id: 31610
-  examine: "Stairs leading to the lower floor."
 - id: 31611
-  examine: "I can climb up this."
 - id: 31612
-  examine: "I can climb this."
 - id: 31613
-  examine: "I can climb down this."
 - id: 31614
 - id: 31615
 - id: 31616
-  examine: "A barrier that judges the worth of an adventurer."
 - id: 31617
-  examine: "A barrier that judges the worth of an adventurer."
 - id: 31618
-  examine: "A gateway to the Champions' Guild"
 - id: 31619
-  examine: "For Jarvis, who died saving Gielinor."
 - id: 31620
-  examine: "A dead bush."
 - id: 31621
-  examine: "A gateway to the Heroes' Guild"
 - id: 31622
-  examine: "A gateway to the Legends' Guild"
 - id: 31623
-  examine: "Three anvils in one."
 - id: 31624
-  examine: "An altar adorned with strange figures."
 - id: 31625
-  examine: "An old fountain... Or an Uhld fountain?"
 - id: 31626
-  examine: "A statue of a long forgotten hero of Uhld."
 - id: 31627
-  examine: "Going up?"
 - id: 31628
 - id: 31629
-  examine: "Books written by the great adventurers of Uhld."
 - id: 31630
-  examine: "Books written by the great adventurers of Uhld."
 - id: 31631
-  examine: "Cook some delicious food on here!"
 - id: 31632
-  examine: "See the sea. It's big and it's right in front of you, but someone might want a better view."
 - id: 31633
 - id: 31634
-  examine: "Useful for lighting a fire."
 - id: 31635
 - id: 31636
 - id: 31637
@@ -48952,121 +41156,71 @@
 - id: 31668
 - id: 31669
 - id: 31670
-  examine: "The Guardian of Dusk keeps watch to the west."
 - id: 31671
-  examine: "The Guardian of Dawn keeps watch to the east."
 - id: 31672
-  examine: "A staircase to the Slayer Tower's roof."
 - id: 31673
-  examine: "A staircase to the Slayer Tower's roof."
 - id: 31674
-  examine: "A staircase back down to the Slayer Tower."
 - id: 31675
-  examine: "Contains items from those who died on the roof."
 - id: 31676
-  examine: "The Guardian of Dusk keeps watch to the west."
 - id: 31677
-  examine: "The Guardian of Dawn keeps watch to the east."
 - id: 31678
-  examine: "A small energy sphere. It's growing."
 - id: 31679
-  examine: "A medium sized energy sphere. It's glowing with energy."
 - id: 31680
-  examine: "A large energy sphere. It's bursting with energy."
 - id: 31681
 - id: 31682
 - id: 31683
 - id: 31684
-  examine: "To be struck in times of conflict."
 - id: 31685
-  examine: "To be struck in times of conflict."
 - id: 31686
 - id: 31687
 - id: 31688
 - id: 31689
-  examine: "A large display of the Grotesque Guardians atop the Slayer Tower Roof."
 - id: 31690
-  examine: "Who knows what could be down here."
 - id: 31691
-  examine: "I can use this to climb out of here."
 - id: 31692
-  examine: "Someone has tied a rope here."
 - id: 31693
-  examine: "Good for climbing."
 - id: 31694
-  examine: "Good for climbing."
 - id: 31695
-  examine: "I can squeeze through here."
 - id: 31696
-  examine: "I can squeeze through here."
 - id: 31697
-  examine: "I might be able to climb over these."
 - id: 31698
-  examine: "I might be able to climb over these."
 - id: 31699
-  examine: "It's a good job these are here."
 - id: 31700
 - id: 31701
 - id: 31702
 - id: 31703
-  examine: "An old chest."
 - id: 31704
-  examine: "Allows access to the level above."
 - id: 31705
-  examine: "Allows access to the level below."
 - id: 31706
-  examine: "There's a cover over this manhole."
 - id: 31707
-  examine: "I wonder what's down here."
 - id: 31708
-  examine: "The way out of this place."
 - id: 31709
-  examine: "I can go through here."
 - id: 31710
-  examine: "A sturdy chest to keep things in."
 - id: 31711
-  examine: "I wonder what's inside..."
 - id: 31712
-  examine: "There's something fishy about this stall."
 - id: 31713
-  examine: "For someone important."
 - id: 31714
-  examine: "A statue of King Kharedst IV, the last King of Kourend."
 - id: 31715
-  examine: "A rare type of Rose."
 - id: 31716
-  examine: "A gravestone engraved with a rose. A strange energy emanates here."
 - id: 31717
-  examine: "An old broken market stall, I wonder why it was abandoned?"
 - id: 31718
-  examine: "A lumpy pile of sand."
 - id: 31719
-  examine: "A small pile of sand."
 - id: 31720
 - id: 31721
-  examine: "Some dry tinder for firewood, carefully stored under this hut."
 - id: 31722
-  examine: "That's not going to be good for the hut."
 - id: 31723
-  examine: "Now it's wet and useless."
 - id: 31724
 - id: 31725
 - id: 31726
-  examine: "It banks your bits."
 - id: 31727
 - id: 31728
 - id: 31729
 - id: 31730
 - id: 31731
-  examine: "It may lead to a vault full of pirate treasure? Interesting..."
 - id: 31732
-  examine: "Walls would probably be better for security."
 - id: 31733
-  examine: "Go up them."
 - id: 31734
-  examine: "Go down them."
 - id: 31735
-  examine: "Climb them."
 - id: 31736
 - id: 31737
 - id: 31738
@@ -49080,38 +41234,24 @@
 - id: 31746
 - id: 31747
 - id: 31748
-  examine: "Not overly secure... It must be a decoy."
 - id: 31749
-  examine: "Bank of RuneScape."
 - id: 31750
 - id: 31751
 - id: 31752
 - id: 31753
 - id: 31754
-  examine: "Apparently pirates have thrones now."
 - id: 31755
-  examine: "Someone has been digging..."
 - id: 31756
-  examine: "Don't pirates threaten to make people walk the plank? It doesn't look so scary."
 - id: 31757
-  examine: "I can climb over these."
 - id: 31758
-  examine: "I can climb up here."
 - id: 31759
-  examine: "I can climb down here."
 - id: 31760
 - id: 31761
-  examine: "To deter any form of robbery."
 - id: 31762
-  examine: "A chair made from a stump."
 - id: 31763
-  examine: "Looks like Haris is prepared for everything."
 - id: 31764
-  examine: "Looks as if someone is up to no good."
 - id: 31765
-  examine: "A vine-choked hole."
 - id: 31766
-  examine: "I wonder what's inside?"
 - id: 31767
 - id: 31768
 - id: 31769
@@ -49127,409 +41267,225 @@
 - id: 31779
 - id: 31780
 - id: 31781
-  examine: "Large rocks."
 - id: 31782
-  examine: "Large rocks."
 - id: 31783
-  examine: "Large rocks."
 - id: 31784
-  examine: "Large rocks."
 - id: 31785
-  examine: "Large rocks."
 - id: 31786
-  examine: "Large rocks."
 - id: 31787
-  examine: "Large rocks."
 - id: 31788
-  examine: "Large rocks."
 - id: 31789
-  examine: "Large rocks."
 - id: 31790
-  examine: "Can they even climb this?"
 - id: 31791
-  examine: "The vines look strong enough... for a human."
 - id: 31792
-  examine: "They're just waiting to trip someone up."
 - id: 31793
 - id: 31794
 - id: 31795
 - id: 31796
-  examine: "Probably hard to trip over this."
 - id: 31797
-  examine: "Fit for an ogre."
 - id: 31798
-  examine: "An ogre fire. Looks fierce."
 - id: 31799
-  examine: "I wonder what's inside."
 - id: 31800
-  examine: "The standard of the ogre race."
 - id: 31801
 - id: 31802
 - id: 31803
 - id: 31804
 - id: 31805
 - id: 31806
-  examine: "If it wasn't already clear, this is the exit."
 - id: 31807
-  examine: "I can get out here."
 - id: 31808
-  examine: "A barrier that judges the worth of an adventurer."
 - id: 31809
-  examine: "I can probably jump to that."
 - id: 31810
 - id: 31811
 - id: 31812
 - id: 31813
 - id: 31814
-  examine: "A holy warrior. A dead one."
 - id: 31815
-  examine: "A holy warrior. A dead one."
 - id: 31816
-  examine: "Shiny armour! Shame he's dead."
 - id: 31817
-  examine: "Shiny armour! Shame he's dead."
 - id: 31818
-  examine: "I don't think he'll be getting back up."
 - id: 31819
-  examine: "I don't think he'll be getting back up."
 - id: 31820
 - id: 31821
 - id: 31822
-  examine: "I can climb over these."
 - id: 31823
 - id: 31824
-  examine: "I can climb over these."
 - id: 31825
-  examine: "It looks magical."
 - id: 31826
-  examine: "I wonder what it says."
 - id: 31827
-  examine: "A simple device for catching birds."
 - id: 31828
-  examine: "A simple device for catching birds. Full of seed."
 - id: 31829
-  examine: "There's something caught in it."
 - id: 31830
-  examine: "A simple device for catching birds."
 - id: 31831
-  examine: "A simple device for catching birds. Full of seed."
 - id: 31832
-  examine: "There's something caught in it."
 - id: 31833
-  examine: "A simple device for catching birds."
 - id: 31834
-  examine: "A simple device for catching birds. Full of seed."
 - id: 31835
-  examine: "There's something caught in it."
 - id: 31836
-  examine: "A simple device for catching birds."
 - id: 31837
-  examine: "A simple device for catching birds. Full of seed."
 - id: 31838
-  examine: "There's something caught in it."
 - id: 31839
-  examine: "A simple device for catching birds."
 - id: 31840
-  examine: "A simple device for catching birds. Full of seed."
 - id: 31841
-  examine: "There's something caught in it."
 - id: 31842
-  examine: "Swampy."
 - id: 31843
-  examine: "Need a net? Here's Annette."
 - id: 31844
-  examine: "Can't go round it, can't go over it... I better go through it."
 - id: 31845
-  examine: "Can't go round it, can't go over it... I better go through it."
 - id: 31846
-  examine: "Someone's written a to-do list here."
 - id: 31847
 - id: 31848
-  examine: "These look secure enough to grapple."
 - id: 31849
 - id: 31850
-  examine: "That looks like it could hold my weight."
 - id: 31851
 - id: 31852
 - id: 31853
-  examine: "It's a rope."
 - id: 31854
-  examine: "Some scattered pebbles."
 - id: 31855
 - id: 31856
-  examine: "Looks like the Mannequin has protection."
 - id: 31857
-  examine: "Looks like the Mannequin has protection."
 - id: 31858
-  examine: "An altar of the occult, imbued with ancient, cosmic and dark magic."
 - id: 31859
-  examine: "An altar of the occult, imbued with ancient, cosmic and dark magic."
 - id: 31860
-  examine: "An altar of the occult, imbued with ancient, cosmic and dark magic."
 - id: 31861
-  examine: "An altar of the occult, imbued with ancient, cosmic and dark magic."
 - id: 31862
-  examine: "Useful for chopping wood."
 - id: 31863
-  examine: "This compost bin contains ultracompost (1/15)."
 - id: 31864
-  examine: "This compost bin contains ultracompost (2/15)."
 - id: 31865
-  examine: "This compost bin contains ultracompost (3/15)."
 - id: 31866
-  examine: "This compost bin contains ultracompost (4/15)."
 - id: 31867
-  examine: "This compost bin contains ultracompost (5/15)."
 - id: 31868
-  examine: "This compost bin contains ultracompost (6/15)."
 - id: 31869
-  examine: "This compost bin contains ultracompost (7/15)."
 - id: 31870
-  examine: "This compost bin contains ultracompost (8/15)."
 - id: 31871
-  examine: "This compost bin contains ultracompost (9/15)."
 - id: 31872
-  examine: "This compost bin contains ultracompost (10/15)."
 - id: 31873
-  examine: "This compost bin contains ultracompost (11/15)."
 - id: 31874
-  examine: "This compost bin contains ultracompost (12/15)."
 - id: 31875
-  examine: "This compost bin contains ultracompost (13/15)."
 - id: 31876
-  examine: "This compost bin contains ultracompost (14/15)."
 - id: 31877
-  examine: "This compost bin is full of ultracompost."
 - id: 31878
-  examine: "Where does it lead?"
 - id: 31879
-  examine: "Where does it lead?"
 - id: 31880
-  examine: "Where does it lead?"
 - id: 31881
-  examine: "Where does it lead?"
 - id: 31882
-  examine: "A table adorned with a strange glass globe."
 - id: 31883
 - id: 31884
 - id: 31885
-  examine: "What a lovely backdrop."
 - id: 31886
 - id: 31887
-  examine: "A peculiar arrangement of items."
 - id: 31888
-  examine: "An iconic brazier."
 - id: 31889
 - id: 31890
-  examine: "A candle stand."
 - id: 31891
-  examine: "Where does it go? Perhaps a journey into the past?"
 - id: 31892
-  examine: "Where does it go? Probably back to the party room."
 - id: 31893
 - id: 31894
 - id: 31895
 - id: 31896
 - id: 31897
 - id: 31898
-  examine: "A chair to sit on."
 - id: 31899
 - id: 31900
-  examine: "A rowdy rabble of goblins. The Goblin Invasion event came into the game on August 16th, 2013."
 - id: 31901
-  examine: "A rowdy rabble of goblins. The Goblin Invasion event came into the game on August 16th, 2013."
 - id: 31902
-  examine: "A slayer helmet. This came into the game on January 6th, 2014."
 - id: 31903
-  examine: "A set of Bandos armour. This came into the game on October 16th, 2013."
 - id: 31904
-  examine: "A set of Armadyl armour. This came into the game on October 16th, 2013."
 - id: 31905
-  examine: "A map of Zeah. This came into the game on January 7th, 2016."
 - id: 31906
-  examine: "A display of the Kraken. This came into the game on April 10th, 2014."
 - id: 31907
-  examine: "A display of Zulrah. This came into the game on January 8th, 2015."
 - id: 31908
-  examine: "A display of Cerberus. This came into the game on August 27th, 2015"
 - id: 31909
-  examine: "A display of the Abyssal Sire. This came into the game on October 1st, 2015."
 - id: 31910
-  examine: "A display of Skotizo. This came into the game on June 16th, 2016."
 - id: 31911
-  examine: "A display of the Grotesque Guardians. They came into the game on October 26th, 2017."
 - id: 31912
-  examine: "A display of Vorkath. Dragon Slayer 2 was released on January 4th, 2018."
 - id: 31913
-  examine: "Achievement Diaries were released on March 5th, 2015."
 - id: 31914
-  examine: "Achievement Diaries were released on March 5th, 2015."
 - id: 31915
-  examine: "Elite clue scrolls were added to the game on June 12th, 2014."
 - id: 31916
-  examine: "Master clue scrolls were added to the game on July 6th, 2016."
 - id: 31917
-  examine: "Runite Minor, the player who designed the Motherload Mine. Released on April 24th, 2014."
 - id: 31918
-  examine: "Raids I"
 - id: 31919
-  examine: "The Inferno was released on June 1st, 2017."
 - id: 31920
-  examine: "The Godwars Dungeon was added to the game on October 16th, 2013."
 - id: 31921
-  examine: "The Corporeal Beast was added to the game on October 16th, 2014."
 - id: 31922
-  examine: "The construction expansion was added on August 25th, 2016."
 - id: 31923
-  examine: "The construction expansion was added on August 25th, 2016."
 - id: 31924
-  examine: "The construction expansion was added on August 25th, 2016."
 - id: 31925
-  examine: "The construction expansion was added on August 25th, 2016."
 - id: 31926
-  examine: "The Wintertodt was released on September 8th, 2016."
 - id: 31927
-  examine: "The Wintertodt was released on September 8th, 2016."
 - id: 31928
-  examine: "Deadman mode was added on October 29th, 2015."
 - id: 31929
-  examine: "Deadman mode was added on October 29th, 2015."
 - id: 31930
-  examine: "The in-game world map was added to the game on May 25th, 2017."
 - id: 31931
-  examine: "A map of Fossil Island. This came into the game on September 7th, 2017."
 - id: 31932
-  examine: "They can't trade others. By the way, this mode was added to the game on October 13th, 2014."
 - id: 31933
-  examine: "A hardcore ironman succumbing to death. This mode was added to the game on November 10th, 2016."
 - id: 31934
-  examine: "Monkey Madness 2, the first new quest for OSRS was added to the game on May 6th, 2016."
 - id: 31935
-  examine: "Rooftop agility courses were added to the game on December 5th, 2013. They were designed by the player BigRedJapan."
 - id: 31936
-  examine: "The Nightmare Zone was added to the game on September 5th, 2013."
 - id: 31937
 - id: 31938
 - id: 31939
-  examine: "The Grand Exchange was added to the game on February 26th, 2015."
 - id: 31940
-  examine: "I guess one way to fix something is to hit it really hard with a hammer."
 - id: 31941
-  examine: "Where does it lead?"
 - id: 31942
-  examine: "Where does it lead?"
 - id: 31943
-  examine: "A wooden crate."
 - id: 31944
-  examine: "See what it's got for you, champion!"
 - id: 31945
 - id: 31946
-  examine: "A supply chest will spawn here."
 - id: 31947
-  examine: "A supply chest will soon spawn here."
 - id: 31948
-  examine: "You can use this to access your bank or switch spellbooks."
 - id: 31949
-  examine: "You can use this to access your bank or switch spellbooks."
 - id: 31950
-  examine: "Quite ferocious looking."
 - id: 31951
 - id: 31952
-  examine: "Where does it lead?"
 - id: 31953
-  examine: "Where does it lead?"
 - id: 31954
-  examine: "Where does it lead?"
 - id: 31955
-  examine: "It's a Cell Gate"
 - id: 31956
-  examine: "It's a Cell Gate"
 - id: 31957
-  examine: "It's a Cyan Crystal"
 - id: 31958
-  examine: "It's a Magenta Crystal"
 - id: 31959
-  examine: "It's a Yellow Crystal"
 - id: 31960
-  examine: "It's a White Crystal"
 - id: 31961
-  examine: "It's a Portal"
 - id: 31962
-  examine: "A wall of chocolate!"
 - id: 31963
-  examine: "It's a Skeleton"
 - id: 31964
 - id: 31965
-  examine: "It's a Crevice"
 - id: 31966
-  examine: "The way out!"
 - id: 31967
-  examine: "The way out!"
 - id: 31968
-  examine: "It's a Rope"
 - id: 31969
-  examine: "It's a Crystal"
 - id: 31970
-  examine: "It's a Crystal"
 - id: 31971
-  examine: "It's a Bed"
 - id: 31972
-  examine: "It's a Ivory table"
 - id: 31973
-  examine: "It's a Ivory table"
 - id: 31974
-  examine: "It's a Brazier"
 - id: 31975
-  examine: "It's a Plant"
 - id: 31976
 - id: 31977
-  examine: "A trophy of a mighty dragon slayer!"
 - id: 31978
-  examine: "A large display of Vorkath in his icy home."
 - id: 31979
-  examine: "A mounted cape worn by the most experienced players."
 - id: 31980
-  examine: "A mounted cape worn by the most experienced players."
 - id: 31981
-  examine: "A mounted cape worn by the most experienced players."
 - id: 31982
-  examine: "A mounted cape worn by the most experienced players."
 - id: 31983
-  examine: "The cape worn by members of the Myths' Guild."
 - id: 31984
-  examine: "Its scales seem to be made of runite."
 - id: 31985
-  examine: "A bush sculpted into Vorkath, the undead dragon!"
 - id: 31986
-  examine: "The beautiful cape worn exclusively by members of the Myths' Guild."
 - id: 31987
-  examine: "I wonder if there's anything inside."
 - id: 31988
-  examine: "I wonder if there's anything inside."
 - id: 31989
-  examine: "A short long boat!"
 - id: 31990
-  examine: "I can climb over these."
 - id: 31991
-  examine: "Chunky pieces of ice."
 - id: 31992
-  examine: "I can climb over these."
 - id: 31993
-  examine: "Chunky pieces of ice."
 - id: 31994
-  examine: "I can climb over these."
 - id: 31995
-  examine: "Chunky pieces of ice."
 - id: 31996
-  examine: "I can climb down here."
 - id: 31997
-  examine: "Chunky pieces of ice."
 - id: 31998
-  examine: "I can climb up here."
 - id: 31999
-  examine: "Who knows what's in there."
 - id: 32000
-  examine: "Looks nasty."
 - id: 32001
 - id: 32002
 - id: 32003
@@ -49539,17 +41495,12 @@
 - id: 32007
 - id: 32008
 - id: 32009
-  examine: "Chunky pieces of ice."
 - id: 32010
-  examine: "Chunky pieces of ice."
 - id: 32011
-  examine: "Chunky pieces of ice."
 - id: 32012
-  examine: "Chunky pieces of ice."
 - id: 32013
 - id: 32014
 - id: 32015
-  examine: "Vicious ice spikes block the path."
 - id: 32016
 - id: 32017
 - id: 32018
@@ -49582,23 +41533,16 @@
 - id: 32045
 - id: 32046
 - id: 32047
-  examine: "I can get through here."
 - id: 32048
 - id: 32049
 - id: 32050
 - id: 32051
 - id: 32052
-  examine: "A closed, sturdy door."
 - id: 32053
-  examine: "Maybe there's something in it."
 - id: 32054
-  examine: "A locked chest."
 - id: 32055
-  examine: "A random lever."
 - id: 32056
-  examine: "A random lever."
 - id: 32057
-  examine: "An open chest."
 - id: 32058
 - id: 32059
 - id: 32060
@@ -49609,48 +41553,30 @@
 - id: 32065
 - id: 32066
 - id: 32067
-  examine: "A stone crate."
 - id: 32068
-  examine: "A stone crate."
 - id: 32069
-  examine: "A stone crate."
 - id: 32070
 - id: 32071
 - id: 32072
 - id: 32073
-  examine: "It has some strange markings on it."
 - id: 32074
-  examine: "I think it's probably broken."
 - id: 32075
-  examine: "Some strange equipment."
 - id: 32076
-  examine: "I don't think it works any more."
 - id: 32077
-  examine: "I wonder what this was for."
 - id: 32078
-  examine: "It looks very old."
 - id: 32079
-  examine: "A wooden rowboat."
 - id: 32080
-  examine: "Looks to descend into a dungeon."
 - id: 32081
-  examine: "Climb them, 1 step at a time."
 - id: 32082
-  examine: "Climb them, 1 step at a time."
 - id: 32083
-  examine: "A way out of the basement."
 - id: 32084
-  examine: "An entrance to the basement."
 - id: 32085
 - id: 32086
 - id: 32087
 - id: 32088
 - id: 32089
-  examine: "I can climb up these."
 - id: 32090
-  examine: "Yup, he's dead."
 - id: 32091
-  examine: "Yup, he's dead."
 - id: 32092
 - id: 32093
 - id: 32094
@@ -49672,103 +41598,64 @@
 - id: 32110
 - id: 32111
 - id: 32112
-  examine: "I can climb up these."
 - id: 32113
-  examine: "I can climb these."
 - id: 32114
-  examine: "There is a large recess in the middle of the doors."
 - id: 32115
-  examine: "There is a large recess in the middle of the doors."
 - id: 32116
-  examine: "Who knows what secrets lie on the other side."
 - id: 32117
-  examine: "The doors are broken but should still be useable."
 - id: 32118
-  examine: "It's a torch."
 - id: 32119
-  examine: "A large brazier."
 - id: 32120
 - id: 32121
 - id: 32122
 - id: 32123
 - id: 32124
 - id: 32125
-  examine: "Hmm, big teeth."
 - id: 32126
-  examine: "Falling apart and full of an ancient script."
 - id: 32127
-  examine: "Falling apart and full of an ancient script."
 - id: 32128
-  examine: "Oooh look! A candle!"
 - id: 32129
 - id: 32130
 - id: 32131
 - id: 32132
-  examine: "The doors are broken but should still be useable."
 - id: 32133
-  examine: "Guess I know whats on the other side now."
 - id: 32134
 - id: 32135
 - id: 32136
 - id: 32137
 - id: 32138
-  examine: "Looks to have been used to distill some kind of liquid."
 - id: 32139
-  examine: "An incubator of some sorts."
 - id: 32140
 - id: 32141
-  examine: "Looks to be wheely old."
 - id: 32142
 - id: 32143
-  examine: "This looks to be describing the creation of dragons."
 - id: 32144
-  examine: "This looks to be displaying some data."
 - id: 32145
 - id: 32146
 - id: 32147
-  examine: "Appears to be malfunctioning."
 - id: 32148
-  examine: "An ancient machine. A spellbook sits upon it."
 - id: 32149
 - id: 32150
 - id: 32151
-  examine: "Looks to be wheely old."
 - id: 32152
 - id: 32153
-  examine: "Some sort of magical barrier."
 - id: 32154
-  examine: "Something lurks below the surface, it seems to be sleeping."
 - id: 32155
 - id: 32156
-  examine: "Looks to have been used to distill some kind of liquid."
 - id: 32157
-  examine: "Looks to have been used to distill some kind of liquid."
 - id: 32158
-  examine: "Appears to be malfunctioning."
 - id: 32159
-  examine: "It seems to be damaged."
 - id: 32160
-  examine: "It seems to be damaged."
 - id: 32161
-  examine: "Looks to have been used to distill some kind of liquid."
 - id: 32162
-  examine: "A stone crate."
 - id: 32163
-  examine: "It's a wall."
 - id: 32164
-  examine: "It's a wall."
 - id: 32165
-  examine: "It looks like there is something behind this."
 - id: 32166
-  examine: "It looks like there is something behind this."
 - id: 32167
-  examine: "I might be able to mine this."
 - id: 32168
-  examine: "I might be able to mine this."
 - id: 32169
-  examine: "I can get through here now."
 - id: 32170
-  examine: "I can get through here now."
 - id: 32171
 - id: 32172
 - id: 32173
@@ -49784,19 +41671,12 @@
 - id: 32183
 - id: 32184
 - id: 32185
-  examine: "I wonder what this was for."
 - id: 32186
-  examine: "I don't want to know what was in that..."
 - id: 32187
-  examine: "A stone crate."
 - id: 32188
-  examine: "Some stone crates."
 - id: 32189
-  examine: "A somewhat large stack of stone crates."
 - id: 32190
-  examine: "An empty open chest."
 - id: 32191
-  examine: "I wonder what strange concotion used to be brewed here."
 - id: 32192
 - id: 32193
 - id: 32194
@@ -49804,41 +41684,24 @@
 - id: 32196
 - id: 32197
 - id: 32198
-  examine: "I can get through here."
 - id: 32199
-  examine: "Doesn't look very edible."
 - id: 32200
-  examine: "Doesn't look very edible."
 - id: 32201
-  examine: "Doesn't look very edible."
 - id: 32202
-  examine: "Doesn't look very edible."
 - id: 32203
-  examine: "A strange piece of artwork."
 - id: 32204
 - id: 32205
-  examine: "I can climb up this."
 - id: 32206
-  examine: "Going down?"
 - id: 32207
 - id: 32208
-  examine: "It has an odd sheen and looks more durable than you might expect."
 - id: 32209
-  examine: "I wonder what this orb is for."
 - id: 32210
-  examine: "I wonder what this orb is for."
 - id: 32211
-  examine: "Some steps, for stepping down."
 - id: 32212
-  examine: "These steps, once slippery seem to be much less so now."
 - id: 32213
-  examine: "A carving of a dragon's skull; it has white-hot molten fluid pouring from its mouth."
 - id: 32214
-  examine: "A carving of a dragon's skull."
 - id: 32215
-  examine: "An ancient metallic anvil, completely undamaged or corroded despite its age."
 - id: 32216
-  examine: "An ancient metallic anvil, completely undamaged or corroded despite its age."
 - id: 32217
 - id: 32218
 - id: 32219
@@ -49916,72 +41779,41 @@
 - id: 32291
 - id: 32292
 - id: 32293
-  examine: "Some hammers."
 - id: 32294
-  examine: "Some water containers."
 - id: 32295
-  examine: "Some swamp paste."
 - id: 32296
-  examine: "Some potions."
 - id: 32297
-  examine: "To destroy all you've done."
 - id: 32298
-  examine: "Might want to deal with that."
 - id: 32299
-  examine: "A hardened Fremennik warrior."
 - id: 32300
-  examine: "He doesn't look well."
 - id: 32301
-  examine: "A hardened Fremennik warrior."
 - id: 32302
-  examine: "He doesn't look well."
 - id: 32303
-  examine: "A hardened Fremennik warrior."
 - id: 32304
-  examine: "It's in good condition."
 - id: 32305
-  examine: "It needs repairing."
 - id: 32306
 - id: 32307
-  examine: "He doesn't look well."
 - id: 32308
-  examine: "He doesn't look well."
 - id: 32309
-  examine: "It's a bit broken."
 - id: 32310
 - id: 32311
 - id: 32312
-  examine: "I can jump over here."
 - id: 32313
-  examine: "I can jump over here."
 - id: 32314
-  examine: "I can jump off here."
 - id: 32315
 - id: 32316
-  examine: "I can walk across here."
 - id: 32317
-  examine: "I can walk across here."
 - id: 32318
 - id: 32319
-  examine: "I can jump to this."
 - id: 32320
-  examine: "I can jump to this."
 - id: 32321
-  examine: "I can climb up here."
 - id: 32322
-  examine: "I can climb up here."
 - id: 32323
-  examine: "I can climb up here."
 - id: 32324
-  examine: "I can climb up here."
 - id: 32325
-  examine: "I can climb up here."
 - id: 32326
-  examine: "I can climb up here."
 - id: 32327
-  examine: "I can climb this."
 - id: 32328
-  examine: "I can climb this."
 - id: 32329
 - id: 32330
 - id: 32331
@@ -50028,15 +41860,10 @@
 - id: 32372
 - id: 32373
 - id: 32374
-  examine: "I might be able to climb over this."
 - id: 32375
-  examine: "I might be able to climb over this."
 - id: 32376
-  examine: "It's part of a ship."
 - id: 32377
-  examine: "I might be able to climb over this."
 - id: 32378
-  examine: "Probably best if I don't go near it."
 - id: 32379
 - id: 32380
 - id: 32381
@@ -50051,74 +41878,41 @@
 - id: 32390
 - id: 32391
 - id: 32392
-  examine: "An old tomb that has fallen through the floor."
 - id: 32393
-  examine: "I can climb these stairs."
 - id: 32394
-  examine: "They go down."
 - id: 32395
-  examine: "Leads down."
 - id: 32396
-  examine: "Goes up."
 - id: 32397
-  examine: "Leads down."
 - id: 32398
-  examine: "Goes up."
 - id: 32399
-  examine: "Leads down."
 - id: 32400
-  examine: "Goes up."
 - id: 32401
-  examine: "The way out of here."
 - id: 32402
-  examine: "It's a little bit broken."
 - id: 32403
-  examine: "It looks rather dark down there."
 - id: 32404
-  examine: "An old set of doors."
 - id: 32405
-  examine: "An old set of doors."
 - id: 32406
-  examine: "An old set of doors."
 - id: 32407
-  examine: "An old set of doors."
 - id: 32408
 - id: 32409
 - id: 32410
-  examine: "An old tomb."
 - id: 32411
-  examine: "An old tomb."
 - id: 32412
-  examine: "An old tomb."
 - id: 32413
-  examine: "The bust of an ancient hero. The name Robert is inscribed beneath it."
 - id: 32414
-  examine: "The bust of an ancient hero. The name Robert is inscribed beneath it."
 - id: 32415
-  examine: "The bust of an ancient hero. The name Camorra is inscribed beneath it."
 - id: 32416
-  examine: "The bust of an ancient hero. The name Camorra is inscribed beneath it."
 - id: 32417
-  examine: "The bust of an ancient hero. The name Tristan is inscribed beneath it."
 - id: 32418
-  examine: "The bust of an ancient hero. The name Tristan is inscribed beneath it."
 - id: 32419
-  examine: "The bust of an ancient hero. The name Aivas is inscribed beneath it."
 - id: 32420
-  examine: "The bust of an ancient hero. The name Aivas is inscribed beneath it."
 - id: 32421
-  examine: "It's empty."
 - id: 32422
-  examine: "An empty plinth."
 - id: 32423
-  examine: "It has a bust of Robert sat upon it."
 - id: 32424
-  examine: "It has a bust of Camorra sat upon it."
 - id: 32425
-  examine: "It has a bust of Tristan sat upon it."
 - id: 32426
   depleted: 33400
-  examine: "It has a bust of Aivas sat upon it."
 - id: 32427
   depleted: 33401
 - id: 32428
@@ -50147,72 +41941,44 @@
   depleted: 33401
 - id: 32440
   depleted: 33402
-  examine: "Stores things"
 - id: 32441
   depleted: 33400
-  examine: "A grid of sorts. It seems to be missing most of the pieces."
 - id: 32442
   depleted: 33401
-  examine: "A map of Fossil Island and the surrounding areas. Most of the pieces are missing."
 - id: 32443
   depleted: 33402
-  examine: "A map of Fossil Island and the surrounding areas. Most of the pieces are missing."
 - id: 32444
   depleted: 33400
-  examine: "A map of Fossil Island and the surrounding areas."
 - id: 32445
   depleted: 33401
-  examine: "This chest has been looted recently."
 - id: 32446
   depleted: 33402
-  examine: "Maybe there's something in it."
 - id: 32447
-  examine: "This chest has been looted recently."
 - id: 32448
-  examine: "Maybe there's something in it."
 - id: 32449
   depleted: 32447
-  examine: "Is it safe to eat?"
 - id: 32450
   depleted: 32448
-  examine: "Maybe there's something hidden here."
 - id: 32451
   depleted: 32447
-  examine: "Wouldn't want to fall into that."
 - id: 32452
   depleted: 32448
-  examine: "Maybe there's something hidden here."
 - id: 32453
-  examine: "Looks to be surrounded by spores. Better not touch them."
 - id: 32454
-  examine: "Maybe there's something hidden here."
 - id: 32455
-  examine: "I could build a rowboat here."
 - id: 32456
-  examine: "A wooden rowboat."
 - id: 32457
-  examine: "A strange barrier."
 - id: 32458
-  examine: "The secrets of the past."
 - id: 32459
-  examine: "Hope it doesn't fall on anyone."
 - id: 32460
-  examine: "A short long boat!"
 - id: 32461
-  examine: "A short long boat!"
 - id: 32462
-  examine: "A mountain of knowledge."
 - id: 32463
 - id: 32464
-  examine: "The door is closed."
 - id: 32465
-  examine: "The door is closed."
 - id: 32466
-  examine: "Very rocky."
 - id: 32467
-  examine: "Here lies Bob. A hero, and a friend."
 - id: 32468
-  examine: "Here lies Bob. A hero, and a friend."
 - id: 32469
 - id: 32470
 - id: 32471
@@ -50224,33 +41990,19 @@
 - id: 32477
 - id: 32478
 - id: 32479
-  examine: "What secrets lie within?"
 - id: 32480
-  examine: "A staircase"
 - id: 32481
-  examine: "It's a trap!"
 - id: 32482
-  examine: "It's a trap!"
 - id: 32483
-  examine: "Could be dangerous."
 - id: 32484
-  examine: "Could be dangerous."
 - id: 32485
-  examine: "An empty plinth."
 - id: 32486
-  examine: "It has a key piece on it."
 - id: 32487
-  examine: "There's something magical about it."
 - id: 32488
-  examine: "I wonder how they died."
 - id: 32489
-  examine: "There is a powerful presence about these ruins..."
 - id: 32490
-  examine: "There is a powerful presence about these ruins..."
 - id: 32491
-  examine: "A portal from this mystical place."
 - id: 32492
-  examine: "A mysterious power emanates from this shrine."
 - id: 32493
 - id: 32494
 - id: 32495
@@ -50260,199 +42012,107 @@
 - id: 32499
 - id: 32500
 - id: 32501
-  examine: "It's a Glowing Orb"
 - id: 32502
-  examine: "Hot air circulates through these."
 - id: 32503
-  examine: "It's a Rockfall"
 - id: 32504
-  examine: "It's a Boulder"
 - id: 32505
-  examine: "Hot air circulates through these."
 - id: 32506
-  examine: "It's a Obelisk"
 - id: 32507
-  examine: "It's a Magic Gate"
 - id: 32508
-  examine: "It's a Unstable Altar"
 - id: 32509
-  examine: "A large vat of chocolate."
 - id: 32510
-  examine: "Chocolate on tap, what a life."
 - id: 32511
-  examine: "It's a Broken Bed"
 - id: 32512
 - id: 32513
-  examine: "Mine it to cause rubble to fall."
 - id: 32514
-  examine: "Chop it to cause rubble to fall."
 - id: 32515
-  examine: "A nesty gate."
 - id: 32516
-  examine: "Dare thee enter the domain of the Colossal Chocolate Chicken? Is it worth the whisk?"
 - id: 32517
-  examine: "Dare thee enter the domain of the Colossal Chocolate Chicken? Is it worth the whisk?"
 - id: 32518
-  examine: "A nest crafted from tree roots, a good source of kindling."
 - id: 32519
-  examine: "A nest crafted from tree roots, a good source of kindling."
 - id: 32520
-  examine: "A nest crafted from tree roots, a good source of kindling."
 - id: 32521
 - id: 32522
 - id: 32523
 - id: 32524
-  examine: "It's a Glowing Carving"
 - id: 32525
-  examine: "Full of chocolate, but unfortunately broken."
 - id: 32526
-  examine: "Full of chocolate, but unfortunately broken."
 - id: 32527
-  examine: "A storage shelf containing various sweeteners stored in jars."
 - id: 32528
-  examine: "Full of Saradomin toys."
 - id: 32529
-  examine: "Full of Guthix toys."
 - id: 32530
-  examine: "Full of Zamorak toys."
 - id: 32531
 - id: 32532
-  examine: "It's a Ball"
 - id: 32533
-  examine: "It's a Leaflet"
 - id: 32534
-  examine: "There was a platform here... it eggsploded."
 - id: 32535
-  examine: "An egg cup... probably to contain an egg."
 - id: 32536
-  examine: "An egg cup... containing a chocolate egg."
 - id: 32537
-  examine: "It's a Mounted Xeric's Guard"
 - id: 32538
-  examine: "It's a Mounted Xeric's Warrior"
 - id: 32539
-  examine: "It's a Mounted Xeric's Sentinel"
 - id: 32540
-  examine: "It's a Mounted Xeric's General"
 - id: 32541
-  examine: "It's a Mounted Xeric's Champion"
 - id: 32542
-  examine: "A platform of wood."
 - id: 32543
-  examine: "This will take me to where the egg landed."
 - id: 32544
-  examine: "Leads back to the top of the cave."
 - id: 32545
-  examine: "This leads back to the top of the cave."
 - id: 32546
-  examine: "This rope drops below into the maze like warrens."
 - id: 32547
-  examine: "Eggzactly where it needs to be."
 - id: 32548
-  examine: "Used to make chocolate eggs."
 - id: 32549
-  examine: "An appliance for cooking with."
 - id: 32550
-  examine: "Handy for mining."
 - id: 32551
-  examine: "Handy for woodcutting."
 - id: 32552
-  examine: "Useful for lighting a fire."
 - id: 32553
-  examine: "An enigmatic cabbage. Magically, it never disappears."
 - id: 32554
-  examine: "A puddle of vomit, smells sweet tho."
 - id: 32555
-  examine: "It's a Roof"
 - id: 32556
 - id: 32557
-  examine: "It's a Broken Fountain"
 - id: 32558
-  examine: "It's a Broken Fountain"
 - id: 32559
-  examine: "It's a Bed"
 - id: 32560
-  examine: "It's a Stairs"
 - id: 32561
-  examine: "It's a Stairs"
 - id: 32562
-  examine: "It's a Door"
 - id: 32563
 - id: 32564
-  examine: "It's a Barrel"
 - id: 32565
-  examine: "It's a Barrel"
 - id: 32566
-  examine: "It's a Crate"
 - id: 32567
-  examine: "It's a Crate"
 - id: 32568
-  examine: "It's a Crate"
 - id: 32569
-  examine: "It's a Crate"
 - id: 32570
-  examine: "It's a Crates"
 - id: 32571
-  examine: "It's a Crates"
 - id: 32572
-  examine: "It's a Chest"
 - id: 32573
-  examine: "It's a Chest"
 - id: 32574
-  examine: "It's a Crate"
 - id: 32575
-  examine: "It's a Crate"
 - id: 32576
-  examine: "It's a Crate"
 - id: 32577
-  examine: "It's a Trapdoor"
 - id: 32578
-  examine: "It's a Trapdoor"
 - id: 32579
-  examine: "It's a Ladder"
 - id: 32580
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32581
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32582
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32583
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32584
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32585
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32586
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32587
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32588
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32589
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32590
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32591
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32592
-  examine: "It's a <col=ffff00>Old Man Ral</col>"
 - id: 32593
-  examine: "It's a <col=ffff00>Kael Forshaw</col>"
 - id: 32594
-  examine: "It's a Theatre of Blood"
 - id: 32595
-  examine: "It's a Notice board"
 - id: 32596
-  examine: "It's a Chest"
 - id: 32597
 - id: 32598
 - id: 32599
 - id: 32600
-  examine: "It's a Ranis Drakan"
 - id: 32601
-  examine: "It's a Row boat"
 - id: 32602
-  examine: "It's a Row boat"
 - id: 32603
 - id: 32604
 - id: 32605
@@ -50470,90 +42130,54 @@
 - id: 32617
 - id: 32618
 - id: 32619
-  examine: "It's a Bell"
 - id: 32620
 - id: 32621
 - id: 32622
 - id: 32623
 - id: 32624
-  examine: "It's a Chest"
 - id: 32625
-  examine: "It's a Coffin"
 - id: 32626
-  examine: "It's a Cloak rack"
 - id: 32627
-  examine: "It's a Drapes"
 - id: 32628
-  examine: "It's a Portrait"
 - id: 32629
-  examine: "It's a Large grave"
 - id: 32630
-  examine: "It's a Altar of Zamorak"
 - id: 32631
-  examine: "It's a Simple stove"
 - id: 32632
-  examine: "It's a Hidden Statue"
 - id: 32633
-  examine: "It's a Zamorak's statue"
 - id: 32634
-  examine: "It's a Stone tablet"
 - id: 32635
-  examine: "It's a Church organ"
 - id: 32636
-  examine: "It's a Crate"
 - id: 32637
-  examine: "It's a Ladder"
 - id: 32638
-  examine: "It's a Ladder"
 - id: 32639
-  examine: "It's a Ladder"
 - id: 32640
-  examine: "It's a Ladder"
 - id: 32641
-  examine: "It's a Trapdoor"
 - id: 32642
-  examine: "It's a Ladder"
 - id: 32643
-  examine: "It's a Trapdoor"
 - id: 32644
-  examine: "It's a Ladder"
 - id: 32645
-  examine: "It's a Staircase"
 - id: 32646
-  examine: "It's a Staircase"
 - id: 32647
-  examine: "It's a Stairs"
 - id: 32648
-  examine: "It's a Stairs"
 - id: 32649
 - id: 32650
 - id: 32651
 - id: 32652
-  examine: "It's a <col=ffff00>Meiyerditch citizen</col>"
 - id: 32653
-  examine: "It's a Theatre of Blood"
 - id: 32654
-  examine: "It's a Vyre well"
 - id: 32655
-  examine: "It's a Notice board"
 - id: 32656
-  examine: "It's a Chest"
 - id: 32657
 - id: 32658
 - id: 32659
-  examine: "It's a Door"
 - id: 32660
-  examine: "It's a Door"
 - id: 32661
 - id: 32662
 - id: 32663
 - id: 32664
 - id: 32665
-  examine: "It's a Bank Deposit Box"
 - id: 32666
-  examine: "It's a Bank booth"
 - id: 32667
-  examine: "It's a Closed bank booth"
 - id: 32668
 - id: 32669
 - id: 32670
@@ -50572,15 +42196,11 @@
 - id: 32683
 - id: 32684
 - id: 32685
-  examine: "It's a Easel"
 - id: 32686
-  examine: "It's a Verzik's throne"
 - id: 32687
-  examine: "It's a Supporting Pillar"
 - id: 32688
 - id: 32689
 - id: 32690
-  examine: "It's a Verzik Vitur"
 - id: 32691
 - id: 32692
 - id: 32693
@@ -50626,23 +42246,15 @@
 - id: 32733
 - id: 32734
 - id: 32735
-  examine: "It's a Skeleton"
 - id: 32736
 - id: 32737
-  examine: "It's a Verzik's throne"
 - id: 32738
-  examine: "It's a Treasure room"
 - id: 32739
-  examine: "It's a Cooking range"
 - id: 32740
 - id: 32741
-  examine: "It's a Skeleton"
 - id: 32742
-  examine: "It's a Skeleton"
 - id: 32743
-  examine: "It's a Exhumed"
 - id: 32744
-  examine: "It's a Acidic miasma"
 - id: 32745
 - id: 32746
 - id: 32747
@@ -50650,21 +42262,14 @@
 - id: 32749
 - id: 32750
 - id: 32751
-  examine: "It's a Door"
 - id: 32752
 - id: 32753
 - id: 32754
-  examine: "It's a Mercenary"
 - id: 32755
-  examine: "It's a Barrier"
 - id: 32756
-  examine: "It's a <col=ffff00>Vyre Orator</col>"
 - id: 32757
-  examine: "It's a <col=ffff00>Vyre Orator</col>"
 - id: 32758
-  examine: "It's a Chest"
 - id: 32759
-  examine: "It's a Chest"
 - id: 32760
 - id: 32761
 - id: 32762
@@ -50768,11 +42373,8 @@
 - id: 32860
 - id: 32861
 - id: 32862
-  examine: "It's a Support"
 - id: 32863
-  examine: "It's a Support"
 - id: 32864
-  examine: "It's a Broken support"
 - id: 32865
 - id: 32866
 - id: 32867
@@ -50847,10 +42449,8 @@
 - id: 32936
 - id: 32937
 - id: 32938
-  examine: "It's a Mercenary"
 - id: 32939
 - id: 32940
-  examine: "It's a Twisted Bow"
 - id: 32941
 - id: 32942
 - id: 32943
@@ -50862,17 +42462,13 @@
 - id: 32949
 - id: 32950
 - id: 32951
-  examine: "It's a Hanging hand"
 - id: 32952
-  examine: "It's a Hanging hand"
 - id: 32953
 - id: 32954
 - id: 32955
 - id: 32956
 - id: 32957
-  examine: "It's a Chamber"
 - id: 32958
-  examine: "It's a Operating table"
 - id: 32959
 - id: 32960
 - id: 32961
@@ -50883,15 +42479,11 @@
 - id: 32966
 - id: 32967
 - id: 32968
-  examine: "It's a Mercenary"
 - id: 32969
-  examine: "It's a Corpse"
 - id: 32970
 - id: 32971
 - id: 32972
-  examine: "It's a The Maiden of Sugadinti"
 - id: 32973
-  examine: "It's a Pool of blood"
 - id: 32974
 - id: 32975
 - id: 32976
@@ -50904,38 +42496,24 @@
 - id: 32983
 - id: 32984
 - id: 32985
-  examine: "It's a Vyre well"
 - id: 32986
-  examine: "It's a <col=ff9040>Tatty toy</col>"
 - id: 32987
-  examine: "It's a Scoreboard"
 - id: 32988
 - id: 32989
 - id: 32990
-  examine: "It's a Monumental chest"
 - id: 32991
-  examine: "It's a Monumental chest"
 - id: 32992
-  examine: "It's a Monumental chest"
 - id: 32993
-  examine: "It's a Monumental chest"
 - id: 32994
-  examine: "It's a Monumental chest"
 - id: 32995
-  examine: "It's a Stairs"
 - id: 32996
-  examine: "It's a Teleport crystal"
 - id: 32997
 - id: 32998
 - id: 32999
 - id: 33000
-  examine: "It's a Grand bookshelf"
 - id: 33001
-  examine: "It's a Grand bookshelf"
 - id: 33002
-  examine: "It's a Grand bookshelf"
 - id: 33003
-  examine: "It's a Grand bookshelf"
 - id: 33004
 - id: 33005
 - id: 33006
@@ -50944,21 +42522,15 @@
 - id: 33009
 - id: 33010
 - id: 33011
-  examine: "It's a War table"
 - id: 33012
-  examine: "It's a Justiciar armour"
 - id: 33013
-  examine: "It's a Justiciar armour"
 - id: 33014
-  examine: "It's a Strategy table"
 - id: 33015
 - id: 33016
-  examine: "It's a Small chest"
 - id: 33017
 - id: 33018
 - id: 33019
 - id: 33020
-  examine: "It's a Weapon rack"
 - id: 33021
 - id: 33022
 - id: 33023
@@ -50972,15 +42544,10 @@
 - id: 33031
 - id: 33032
 - id: 33033
-  examine: "It's a Tile"
 - id: 33034
-  examine: "It's a Tile"
 - id: 33035
-  examine: "It's a Tile"
 - id: 33036
-  examine: "It's a Tile"
 - id: 33037
-  examine: "It's a Portal"
 - id: 33038
 - id: 33039
 - id: 33040
@@ -51027,11 +42594,8 @@
   depleted: 33401
 - id: 33080
 - id: 33081
-  examine: "It's a Vyre well"
 - id: 33082
-  examine: "It's a Vyre well"
 - id: 33083
-  examine: "It's a Grave"
 - id: 33084
 - id: 33085
 - id: 33086
@@ -51041,80 +42605,43 @@
 - id: 33090
 - id: 33091
 - id: 33092
-  examine: "It's a Varrock Portal"
 - id: 33093
-  examine: "It's a Grand Exchange Portal"
 - id: 33094
-  examine: "It's a Camelot Portal"
 - id: 33095
-  examine: "It's a Seers' Village Portal"
 - id: 33096
-  examine: "It's a Yanille Watchtower Portal"
 - id: 33097
-  examine: "It's a Yanille Portal"
 - id: 33098
-  examine: "It's a Varrock Portal"
 - id: 33099
-  examine: "It's a Grand Exchange Portal"
 - id: 33100
-  examine: "It's a Camelot Portal"
 - id: 33101
-  examine: "It's a Seers' Village Portal"
 - id: 33102
-  examine: "It's a Yanille Portal"
 - id: 33103
-  examine: "It's a Yanille Portal"
 - id: 33104
-  examine: "It's a Varrock Portal"
 - id: 33105
-  examine: "It's a Grand Exchange Portal"
 - id: 33106
-  examine: "It's a Camelot Portal"
 - id: 33107
-  examine: "It's a Seers' Village Portal"
 - id: 33108
-  examine: "It's a Yanille Watchtower Portal"
 - id: 33109
-  examine: "It's a Yanille Portal"
 - id: 33110
 - id: 33111
-  examine: "It's a Arena"
 - id: 33112
-  examine: "It's a Arena"
 - id: 33113
-  examine: "It's a Formidable passage"
 - id: 33114
-  examine: "It's a Deadman Supply Chest"
 - id: 33115
-  examine: "It's a Deadman Supply Chest"
 - id: 33116
-  examine: "It's a Deadman Supply Chest"
 - id: 33117
-  examine: "It's a Deadman Supply Chest"
 - id: 33118
-  examine: "It's a Deadman Supply Chest"
 - id: 33119
-  examine: "It's a Deadman Supply Chest"
 - id: 33120
-  examine: "It's a Deadman Supply Chest"
 - id: 33121
-  examine: "It's a Deadman Supply Chest"
 - id: 33122
-  examine: "It's a Deadman Supply Chest"
 - id: 33123
-  examine: "It's a Deadman Supply Chest"
 - id: 33124
-  examine: "It's a Deadman Supply Chest"
 - id: 33125
-  examine: "It's a Deadman Supply Chest"
 - id: 33126
-  examine: "It's a Blue banner"
 - id: 33127
-  examine: "It's a Red banner"
 - id: 33128
-  examine: "It's a Yellow banner"
 - id: 33129
-  examine: "It's a Green banner"
 - id: 33130
 - id: 33131
 - id: 33132
@@ -51129,19 +42656,12 @@
 - id: 33141
 - id: 33142
 - id: 33143
-  examine: "It's a Horn of Death"
 - id: 33144
-  examine: "It's a <col=ffff00>Drummer</col>"
 - id: 33145
-  examine: "It's a Crane"
 - id: 33146
-  examine: "It's a Ice crystal"
 - id: 33147
-  examine: "It's a Blood crystal"
 - id: 33148
-  examine: "It's a Shadow crystal"
 - id: 33149
-  examine: "It's a Smoke Crystal"
 - id: 33150
 - id: 33151
 - id: 33152
@@ -51170,165 +42690,95 @@
 - id: 33175
 - id: 33176
 - id: 33177
-  examine: "It's a Icy rocks"
 - id: 33178
 - id: 33179
-  examine: "It's a Troll Stronghold Portal"
 - id: 33180
-  examine: "It's a Troll Stronghold Portal"
 - id: 33181
-  examine: "It's a Troll Stronghold Portal"
 - id: 33182
-  examine: "It's a Boat"
 - id: 33183
 - id: 33184
-  examine: "It's a Rockslide"
 - id: 33185
-  examine: "It's a Rockslide"
 - id: 33186
-  examine: "It's a Tree"
 - id: 33187
-  examine: "It's a Roped tree"
 - id: 33188
-  examine: "It's a Rope"
 - id: 33189
-  examine: "It's a Cliff"
 - id: 33190
-  examine: "It's a Ledge"
 - id: 33191
-  examine: "It's a Rockslide"
 - id: 33192
-  examine: "It's a Fallen Tree"
 - id: 33193
-  examine: "It's a Cave entrance"
 - id: 33194
-  examine: "It's a Cave entrance"
 - id: 33195
-  examine: "It's a Wrecked boat"
 - id: 33196
-  examine: "It's a Skeleton"
 - id: 33197
 - id: 33198
-  examine: "It's a Flower"
 - id: 33199
-  examine: "It's a <col=ffff00>Mother</col>"
 - id: 33200
-  examine: "It's a <col=ffff00>Don't Know What</col>"
 - id: 33201
-  examine: "It's a <col=ffff00>Boulder</col>"
 - id: 33202
-  examine: "It's a <col=ffff00>Root</col>"
 - id: 33203
-  examine: "It's a <col=ffff00>Icicle</col>"
 - id: 33204
-  examine: "It's a <col=ffff00>Driftwood</col>"
 - id: 33205
-  examine: "It's a <col=ffff00>Pebble</col>"
 - id: 33206
-  examine: "It's a <col=ffff00>Goat Poo</col>"
 - id: 33207
-  examine: "It's a <col=ffff00>Yellow Snow</col>"
 - id: 33208
-  examine: "It's a <col=ffff00>Butterfly</col>"
 - id: 33209
-  examine: "It's a <col=ffff00>Odd Stone</col>"
 - id: 33210
-  examine: "It's a <col=ffff00>Squirrel</col>"
 - id: 33211
-  examine: "It's a <col=ffff00>Mountain goat</col>"
 - id: 33212
-  examine: "It's a <col=ffff00>Ice wolf</col>"
 - id: 33213
-  examine: "It's a <col=ffff00>Squirrel</col>"
 - id: 33214
-  examine: "It's a Goat poo"
 - id: 33215
 - id: 33216
 - id: 33217
 - id: 33218
 - id: 33219
-  examine: "It's a Fence"
 - id: 33220
 - id: 33221
   depleted: 33223
 - id: 33222
-  examine: "It's a Te salt"
 - id: 33223
-  examine: "It's a Urt salt"
 - id: 33224
-  examine: "It's a Efh salt"
 - id: 33225
 - id: 33226
 - id: 33227
-  examine: "It's a Hole"
 - id: 33228
 - id: 33229
 - id: 33230
 - id: 33231
 - id: 33232
-  examine: "It's a Throne of Weiss"
 - id: 33233
-  examine: "It's a Weiss banner"
 - id: 33234
-  examine: "It's a Stairs"
 - id: 33235
-  examine: "It's a Stone ladder"
 - id: 33236
-  examine: "It's a Ramp"
 - id: 33237
-  examine: "It's a Narrow gap"
 - id: 33238
-  examine: "It's a Water's edge"
 - id: 33239
-  examine: "It's a Water's edge"
 - id: 33240
-  examine: "It's a Stepping stone"
 - id: 33241
-  examine: "It's a Stepping stone"
 - id: 33242
-  examine: "It's a Stepping stone"
 - id: 33243
-  examine: "It's a Stepping stone"
 - id: 33244
-  examine: "It's a Stepping stone"
 - id: 33245
-  examine: "It's a Stepping stone"
 - id: 33246
-  examine: "It's a Cave exit"
 - id: 33247
-  examine: "It's a Cave exit"
 - id: 33248
 - id: 33249
 - id: 33250
 - id: 33251
 - id: 33252
-  examine: "It's a Danger sign"
 - id: 33253
-  examine: "It's a Rocks"
 - id: 33254
-  examine: "It's a Rocks"
 - id: 33255
-  examine: "It's a Rocks"
 - id: 33256
-  examine: "It's a Rocks"
 - id: 33257
-  examine: "It's a Rocks"
 - id: 33258
-  examine: "It's a Cell door"
 - id: 33259
-  examine: "It's a Mine door"
 - id: 33260
-  examine: "It's a Mine door"
 - id: 33261
-  examine: "It's a Steps"
 - id: 33262
-  examine: "It's a Smelly hole"
 - id: 33263
-  examine: "It's a Coffin hotspot"
 - id: 33264
-  examine: "It's a Coffin"
 - id: 33265
-  examine: "It's a <col=ff9040>Old man's coffin</col>"
 - id: 33266
 - id: 33267
 - id: 33268
@@ -51371,36 +42821,21 @@
 - id: 33305
 - id: 33306
 - id: 33307
-  examine: "It's a Old Shrine"
 - id: 33308
-  examine: "It's a Barrel of Water"
 - id: 33309
-  examine: "It's a Buckets"
 - id: 33310
-  examine: "It's a Fire pit"
 - id: 33311
-  examine: "It's a Fire"
 - id: 33312
-  examine: "It's a Little boulder"
 - id: 33313
 - id: 33314
-  examine: "It's a New farming patch"
 - id: 33315
-  examine: "It's a Hardy goutweed"
 - id: 33316
-  examine: "It's a Hardy goutweed"
 - id: 33317
-  examine: "It's a Old fire pit"
 - id: 33318
-  examine: "It's a Fire of Domination"
 - id: 33319
-  examine: "It's a Fire of Nourishment"
 - id: 33320
-  examine: "It's a Fire of Eternal Light"
 - id: 33321
-  examine: "It's a Fire of Unseasonal Warmth"
 - id: 33322
-  examine: "It's a Fire of Dehumidification"
 - id: 33323
 - id: 33324
 - id: 33325
@@ -51419,212 +42854,110 @@
 - id: 33338
 - id: 33339
 - id: 33340
-  examine: "It's a Pile of rubble"
 - id: 33341
-  examine: "It's a Pile of rubble"
 - id: 33342
 - id: 33343
-  examine: "It's a Hub portal"
 - id: 33344
-  examine: "It's a Broken wall"
 - id: 33345
 - id: 33346
-  examine: "It's a Portal Nexus space"
 - id: 33347
-  examine: "It's a Rug space"
 - id: 33348
-  examine: "It's a Big window"
 - id: 33349
-  examine: "It's a Rug space"
 - id: 33350
-  examine: "It's a Rug space"
 - id: 33351
-  examine: "It's a Curtain space"
 - id: 33352
-  examine: "It's a Amulet space"
 - id: 33353
-  examine: "It's a Amulet space"
 - id: 33354
-  examine: "It's a Portal Nexus"
 - id: 33355
-  examine: "It's a Portal Nexus"
 - id: 33356
-  examine: "It's a Portal Nexus"
 - id: 33357
-  examine: "It's a Portal Nexus"
 - id: 33358
-  examine: "It's a Portal Nexus"
 - id: 33359
-  examine: "It's a Portal Nexus"
 - id: 33360
-  examine: "It's a Portal Nexus"
 - id: 33361
-  examine: "It's a Portal Nexus"
 - id: 33362
-  examine: "It's a Portal Nexus"
 - id: 33363
-  examine: "It's a Portal Nexus"
 - id: 33364
-  examine: "It's a Portal Nexus"
 - id: 33365
-  examine: "It's a Portal Nexus"
 - id: 33366
-  examine: "It's a Portal Nexus"
 - id: 33367
-  examine: "It's a Portal Nexus"
 - id: 33368
-  examine: "It's a Portal Nexus"
 - id: 33369
-  examine: "It's a Portal Nexus"
 - id: 33370
-  examine: "It's a Portal Nexus"
 - id: 33371
-  examine: "It's a Portal Nexus"
 - id: 33372
-  examine: "It's a Portal Nexus"
 - id: 33373
-  examine: "It's a Portal Nexus"
 - id: 33374
-  examine: "It's a Portal Nexus"
 - id: 33375
-  examine: "It's a Portal Nexus"
 - id: 33376
-  examine: "It's a Portal Nexus"
 - id: 33377
-  examine: "It's a Portal Nexus"
 - id: 33378
-  examine: "It's a Portal Nexus"
 - id: 33379
-  examine: "It's a Portal Nexus"
 - id: 33380
-  examine: "It's a Portal Nexus"
 - id: 33381
-  examine: "It's a Portal Nexus"
 - id: 33382
-  examine: "It's a Portal Nexus"
 - id: 33383
-  examine: "It's a Portal Nexus"
 - id: 33384
-  examine: "It's a Portal Nexus"
 - id: 33385
-  examine: "It's a Portal Nexus"
 - id: 33386
-  examine: "It's a Portal Nexus"
 - id: 33387
-  examine: "It's a Portal Nexus"
 - id: 33388
-  examine: "It's a Portal Nexus"
 - id: 33389
-  examine: "It's a Portal Nexus"
 - id: 33390
-  examine: "It's a Portal Nexus"
 - id: 33391
-  examine: "It's a Portal Nexus"
 - id: 33392
-  examine: "It's a Portal Nexus"
 - id: 33393
-  examine: "It's a Portal Nexus"
 - id: 33394
-  examine: "It's a Portal Nexus"
 - id: 33395
-  examine: "It's a Portal Nexus"
 - id: 33396
-  examine: "It's a Portal Nexus"
 - id: 33397
-  examine: "It's a Portal Nexus"
 - id: 33398
-  examine: "It's a Portal Nexus"
 - id: 33399
-  examine: "It's a Portal Nexus"
 - id: 33400
-  examine: "It's a Portal Nexus"
 - id: 33401
-  examine: "It's a Portal Nexus"
 - id: 33402
-  examine: "It's a Portal Nexus"
 - id: 33403
-  examine: "It's a Portal Nexus"
 - id: 33404
-  examine: "It's a Portal Nexus"
 - id: 33405
-  examine: "It's a Portal Nexus"
 - id: 33406
-  examine: "It's a Portal Nexus"
 - id: 33407
-  examine: "It's a Portal Nexus"
 - id: 33408
-  examine: "It's a Portal Nexus"
 - id: 33409
-  examine: "It's a Portal Nexus"
 - id: 33410
-  examine: "It's a Portal Nexus"
 - id: 33411
-  examine: "It's a Xeric's Talisman"
 - id: 33412
-  examine: "It's a Xeric's Talisman"
 - id: 33413
-  examine: "It's a Xeric's Talisman"
 - id: 33414
-  examine: "It's a Xeric's Talisman"
 - id: 33415
-  examine: "It's a Xeric's Talisman"
 - id: 33416
-  examine: "It's a Digsite Pendant"
 - id: 33417
-  examine: "It's a Digsite Pendant"
 - id: 33418
-  examine: "It's a Digsite Pendant"
 - id: 33419
-  examine: "It's a Xeric's Talisman"
 - id: 33420
-  examine: "It's a Digsite Pendant"
 - id: 33421
 - id: 33422
-  examine: "It's a Rocks"
 - id: 33423
-  examine: "It's a Portal Nexus"
 - id: 33424
-  examine: "It's a Portal Nexus"
 - id: 33425
-  examine: "It's a Portal Nexus"
 - id: 33426
-  examine: "It's a Portal Nexus"
 - id: 33427
-  examine: "It's a Portal Nexus"
 - id: 33428
-  examine: "It's a Portal Nexus"
 - id: 33429
-  examine: "It's a Portal Nexus"
 - id: 33430
-  examine: "It's a Portal Nexus"
 - id: 33431
-  examine: "It's a Portal Nexus"
 - id: 33432
-  examine: "It's a Catherby Portal"
 - id: 33433
-  examine: "It's a Ghorrock Portal"
 - id: 33434
-  examine: "It's a Carrallangar Portal"
 - id: 33435
-  examine: "It's a Catherby Portal"
 - id: 33436
-  examine: "It's a Ghorrock Portal"
 - id: 33437
-  examine: "It's a Carrallangar Portal"
 - id: 33438
-  examine: "It's a Catherby Portal"
 - id: 33439
-  examine: "It's a Ghorrock Portal"
 - id: 33440
-  examine: "It's a Carrallangar Portal"
 - id: 33441
-  examine: "It's a Scrying orb"
 - id: 33442
-  examine: "It's a Supplies"
 - id: 33443
-  examine: "It's a Portal"
 - id: 33444
-  examine: "It's a Portal"
 - id: 33445
 - id: 33446
 - id: 33447
@@ -51635,11 +42968,8 @@
 - id: 33452
 - id: 33453
 - id: 33454
-  examine: "It's a Brazier"
 - id: 33455
-  examine: "It's a Heroic statue"
 - id: 33456
-  examine: "It's a Chalice"
 - id: 33457
 - id: 33458
 - id: 33459
@@ -51661,260 +42991,143 @@
 - id: 33475
 - id: 33476
 - id: 33477
-  examine: "It's a Ice Throne"
 - id: 33478
 - id: 33479
 - id: 33480
-  examine: "It's a Pear tree"
 - id: 33481
-  examine: "It's a Poll booth"
 - id: 33482
-  examine: "It's a Poll booth"
 - id: 33483
-  examine: "It's a Ladder"
 - id: 33484
-  examine: "It's a Ladder"
 - id: 33485
-  examine: "It's a Ladder"
 - id: 33486
-  examine: "It's a Ladder"
 - id: 33487
-  examine: "It's a Display Case"
 - id: 33488
-  examine: "It's a Display Case"
 - id: 33489
-  examine: "It's a Display Case"
 - id: 33490
-  examine: "It's a Display Case"
 - id: 33491
-  examine: "It's a Door"
 - id: 33492
 - id: 33493
-  examine: "It's a Steam Generator"
 - id: 33494
-  examine: "It's a Steam Generator"
 - id: 33495
-  examine: "It's a Steam Generator"
 - id: 33496
-  examine: "It's a Crate"
 - id: 33497
-  examine: "It's a Crates"
 - id: 33498
-  examine: "It's a Crate"
 - id: 33499
-  examine: "It's a Power Grid"
 - id: 33500
-  examine: "It's a Power Grid"
 - id: 33501
-  examine: "It's a Power Grid"
 - id: 33502
-  examine: "It's a Furnace"
 - id: 33503
-  examine: "It's a Furnace"
 - id: 33504
-  examine: "It's a Furnace"
 - id: 33505
 - id: 33506
-  examine: "It's a Coolant Dispenser"
 - id: 33507
-  examine: "It's a Coolant Dispenser"
 - id: 33508
-  examine: "It's a Furnace Coolant"
 - id: 33509
-  examine: "It's a Furnace Coolant"
 - id: 33510
-  examine: "It's a Furnace Coolant"
 - id: 33511
 - id: 33512
 - id: 33513
-  examine: "It's a Cupboard"
 - id: 33514
-  examine: "It's a Cupboard"
 - id: 33515
-  examine: "It's a Cupboard"
 - id: 33516
-  examine: "It's a Refinery"
 - id: 33517
-  examine: "It's a Refinery"
 - id: 33518
-  examine: "It's a Refinery"
 - id: 33519
-  examine: "It's a Refinery"
 - id: 33520
-  examine: "It's a Table"
 - id: 33521
-  examine: "It's a Table"
 - id: 33522
-  examine: "It's a Cupboard"
 - id: 33523
-  examine: "It's a Runic Altar"
 - id: 33524
-  examine: "It's a Runic Altar"
 - id: 33525
-  examine: "It's a Energy Pylon"
 - id: 33526
-  examine: "It's a Energy Pylon"
 - id: 33527
-  examine: "It's a Energy Pylon"
 - id: 33528
-  examine: "It's a Energy Pylon"
 - id: 33529
-  examine: "It's a Energy Pylon"
 - id: 33530
-  examine: "It's a Energy Pylon"
 - id: 33531
-  examine: "It's a Energy Pylon"
 - id: 33532
-  examine: "It's a Energy Pylon"
 - id: 33533
-  examine: "It's a Energy Pylon"
 - id: 33534
-  examine: "It's a Energy Pylon"
 - id: 33535
-  examine: "It's a Energy Pylon"
 - id: 33536
-  examine: "It's a Energy Pylon"
 - id: 33537
-  examine: "It's a Energy Pylon"
 - id: 33538
-  examine: "It's a Energy Pylon"
 - id: 33539
-  examine: "It's a Energy Pylon"
 - id: 33540
-  examine: "It's a Energy Pylon"
 - id: 33541
-  examine: "It's a Energy Pylon"
 - id: 33542
-  examine: "It's a Energy Pylon"
 - id: 33543
 - id: 33544
 - id: 33545
 - id: 33546
 - id: 33547
 - id: 33548
-  examine: "It's a Shelf"
 - id: 33549
-  examine: "It's a Staircase"
 - id: 33550
-  examine: "It's a Staircase"
 - id: 33551
-  examine: "It's a Staircase"
 - id: 33552
-  examine: "It's a Staircase"
 - id: 33553
 - id: 33554
 - id: 33555
 - id: 33556
-  examine: "It's a Door"
 - id: 33557
-  examine: "It's a Door"
 - id: 33558
-  examine: "It's a Crate"
 - id: 33559
-  examine: "It's a Crates"
 - id: 33560
-  examine: "It's a Table"
 - id: 33561
-  examine: "It's a Table"
 - id: 33562
-  examine: "It's a Table"
 - id: 33563
-  examine: "It's a Table"
 - id: 33564
 - id: 33565
-  examine: "It's a Crate"
 - id: 33566
 - id: 33567
-  examine: "It's a Dead Body"
 - id: 33568
-  examine: "It's a Thana"
 - id: 33569
-  examine: "It's a Bright crystal"
 - id: 33570
-  examine: "It's a Door"
 - id: 33571
-  examine: "It's a Door"
 - id: 33572
-  examine: "It's a Door"
 - id: 33573
-  examine: "It's a Door"
 - id: 33574
-  examine: "It's a Stairs"
 - id: 33575
-  examine: "It's a Stairs"
 - id: 33576
-  examine: "It's a Stairs"
 - id: 33577
-  examine: "It's a Stairs"
 - id: 33578
-  examine: "It's a Ancient Grave"
 - id: 33579
-  examine: "It's a Ancient Grave"
 - id: 33580
 - id: 33581
 - id: 33582
 - id: 33583
-  examine: "It's a Tree stump"
 - id: 33584
-  examine: "It's a Tree stump"
 - id: 33585
-  examine: "It's a Bush"
 - id: 33586
-  examine: "It's a Bush"
 - id: 33587
-  examine: "It's a Plant"
 - id: 33588
-  examine: "It's a Plant"
 - id: 33589
-  examine: "It's a Plant"
 - id: 33590
-  examine: "It's a Plant"
 - id: 33591
-  examine: "It's a Plant"
 - id: 33592
-  examine: "It's a Plant"
 - id: 33593
-  examine: "It's a Rocks"
 - id: 33594
-  examine: "It's a Rocks"
 - id: 33595
-  examine: "It's a Rocks"
 - id: 33596
-  examine: "It's a Rocks"
 - id: 33597
-  examine: "It's a Bookshelf"
 - id: 33598
-  examine: "It's a Bookshelf"
 - id: 33599
-  examine: "It's a Bookshelf"
 - id: 33600
-  examine: "It's a Bookshelf"
 - id: 33601
-  examine: "It's a Bookshelf"
 - id: 33602
-  examine: "It's a Bookshelf"
 - id: 33603
-  examine: "It's a Bookshelf"
 - id: 33604
-  examine: "It's a Bookshelf"
 - id: 33605
-  examine: "It's a Bookshelf"
 - id: 33606
-  examine: "It's a Bookshelf"
 - id: 33607
-  examine: "It's a Bookshelf"
 - id: 33608
-  examine: "It's a Machinery"
 - id: 33609
-  examine: "It's a Machinery"
 - id: 33610
 - id: 33611
 - id: 33612
-  examine: "It's a Unoccupied Cormorant perch"
 - id: 33613
-  examine: "It's a Occupied Cormorant perch"
 - id: 33614
-  examine: "It's a Boaty"
 - id: 33615
 - id: 33616
 - id: 33617
@@ -51939,11 +43152,8 @@
 - id: 33636
 - id: 33637
 - id: 33638
-  examine: "It's a Bush"
 - id: 33639
-  examine: "It's a Seed Stall"
 - id: 33640
-  examine: "It's a Swamp bubbles"
 - id: 33641
 - id: 33642
 - id: 33643
@@ -51954,797 +43164,406 @@
 - id: 33648
 - id: 33649
 - id: 33650
-  examine: "It's a White lily"
 - id: 33651
-  examine: "It's a White lily"
 - id: 33652
-  examine: "It's a White lily"
 - id: 33653
-  examine: "It's a White lily"
 - id: 33654
-  examine: "It's a White lily"
 - id: 33655
-  examine: "It's a White lily"
 - id: 33656
-  examine: "It's a White lily"
 - id: 33657
-  examine: "It's a White lily"
 - id: 33658
-  examine: "It's a White lily"
 - id: 33659
-  examine: "It's a Diseased White lily"
 - id: 33660
-  examine: "It's a Diseased White lily"
 - id: 33661
-  examine: "It's a Diseased White lily"
 - id: 33662
-  examine: "It's a Dead White lily"
 - id: 33663
-  examine: "It's a Dead White lily"
 - id: 33664
-  examine: "It's a Dead White lily"
 - id: 33665
-  examine: "It's a Dead White lily"
 - id: 33666
-  examine: "It's a Snape grass seedling"
 - id: 33667
-  examine: "It's a Snape grass plant"
 - id: 33668
-  examine: "It's a Snape grass plant"
 - id: 33669
-  examine: "It's a Snape grass plant"
 - id: 33670
-  examine: "It's a Snape grass plant"
 - id: 33671
-  examine: "It's a Snape grass plant"
 - id: 33672
-  examine: "It's a Snape grass plant"
 - id: 33673
-  examine: "It's a Snape grass plant"
 - id: 33674
-  examine: "It's a Snape grass seedling"
 - id: 33675
-  examine: "It's a Snape grass plant"
 - id: 33676
-  examine: "It's a Snape grass plant"
 - id: 33677
-  examine: "It's a Snape grass plant"
 - id: 33678
-  examine: "It's a Snape grass plant"
 - id: 33679
-  examine: "It's a Snape grass plant"
 - id: 33680
-  examine: "It's a Snape grass plant"
 - id: 33681
-  examine: "It's a Diseased Snape grass"
 - id: 33682
-  examine: "It's a Diseased Snape grass"
 - id: 33683
-  examine: "It's a Diseased Snape grass"
 - id: 33684
-  examine: "It's a Diseased Snape grass"
 - id: 33685
-  examine: "It's a Diseased Snape grass"
 - id: 33686
-  examine: "It's a Diseased Snape grass"
 - id: 33687
-  examine: "It's a Dead Snape grass"
 - id: 33688
-  examine: "It's a Dead Snape grass"
 - id: 33689
-  examine: "It's a Dead Snape grass"
 - id: 33690
-  examine: "It's a Dead Snape grass"
 - id: 33691
-  examine: "It's a Dead Snape grass"
 - id: 33692
-  examine: "It's a Dead Snape grass"
 - id: 33693
 - id: 33694
 - id: 33695
-  examine: "It's a Celastrus patch"
 - id: 33696
-  examine: "It's a Celastrus patch"
 - id: 33697
-  examine: "It's a Celastrus patch"
 - id: 33698
-  examine: "It's a Celastrus patch"
 - id: 33699
-  examine: "It's a Celastrus tree"
 - id: 33700
-  examine: "It's a Celastrus tree"
 - id: 33701
-  examine: "It's a Celastrus tree"
 - id: 33702
-  examine: "It's a Celastrus tree"
 - id: 33703
-  examine: "It's a Celastrus tree"
 - id: 33704
-  examine: "It's a Celastrus tree"
 - id: 33705
-  examine: "It's a Diseased celastrus tree"
 - id: 33706
-  examine: "It's a Diseased celastrus tree"
 - id: 33707
-  examine: "It's a Diseased celastrus tree"
 - id: 33708
-  examine: "It's a Diseased celastrus tree"
 - id: 33709
-  examine: "It's a Diseased celastrus tree"
 - id: 33710
-  examine: "It's a Diseased celastrus tree"
 - id: 33711
-  examine: "It's a Dead celastrus tree"
 - id: 33712
-  examine: "It's a Dead celastrus tree"
 - id: 33713
-  examine: "It's a Dead celastrus tree"
 - id: 33714
-  examine: "It's a Dead celastrus tree"
 - id: 33715
-  examine: "It's a Dead celastrus tree"
 - id: 33716
-  examine: "It's a Dead celastrus tree"
 - id: 33717
-  examine: "It's a Celastrus tree"
 - id: 33718
-  examine: "It's a Celastrus tree"
 - id: 33719
-  examine: "It's a Celastrus tree"
 - id: 33720
-  examine: "It's a Harvested Celastrus tree"
 - id: 33721
-  examine: "It's a Celastrus tree stump"
 - id: 33722
-  examine: "It's a Hespori patch"
 - id: 33723
-  examine: "It's a Hespori patch"
 - id: 33724
-  examine: "It's a Hespori patch"
 - id: 33725
-  examine: "It's a Hespori patch"
 - id: 33726
-  examine: "It's a Hespori"
 - id: 33727
-  examine: "It's a Hespori"
 - id: 33728
-  examine: "It's a Hespori"
 - id: 33729
-  examine: "It's a Hespori"
 - id: 33730
-  examine: "It's a Hespori"
 - id: 33731
 - id: 33732
 - id: 33733
 - id: 33734
-  examine: "It's a Potato cactus"
 - id: 33735
-  examine: "It's a Potato cactus"
 - id: 33736
-  examine: "It's a Potato cactus"
 - id: 33737
-  examine: "It's a Potato cactus"
 - id: 33738
-  examine: "It's a Potato cactus"
 - id: 33739
-  examine: "It's a Potato cactus"
 - id: 33740
-  examine: "It's a Potato cactus"
 - id: 33741
-  examine: "It's a Potato cactus"
 - id: 33742
-  examine: "It's a Potato cactus"
 - id: 33743
-  examine: "It's a Potato cactus"
 - id: 33744
-  examine: "It's a Potato cactus"
 - id: 33745
-  examine: "It's a Potato cactus"
 - id: 33746
-  examine: "It's a Potato cactus"
 - id: 33747
-  examine: "It's a Potato cactus"
 - id: 33748
-  examine: "It's a Potato cactus"
 - id: 33749
-  examine: "It's a Diseased Potato cactus"
 - id: 33750
-  examine: "It's a Diseased Potato cactus"
 - id: 33751
-  examine: "It's a Diseased Potato cactus"
 - id: 33752
-  examine: "It's a Diseased Potato cactus"
 - id: 33753
-  examine: "It's a Diseased Potato cactus"
 - id: 33754
-  examine: "It's a Diseased Potato cactus"
 - id: 33755
-  examine: "It's a Dead Potato cactus"
 - id: 33756
-  examine: "It's a Dead Potato cactus"
 - id: 33757
-  examine: "It's a Dead Potato cactus"
 - id: 33758
-  examine: "It's a Dead Potato cactus"
 - id: 33759
-  examine: "It's a Dead Potato cactus"
 - id: 33760
-  examine: "It's a Dead Potato cactus"
 - id: 33761
 - id: 33762
-  examine: "It's a Big Compost Bin"
 - id: 33763
-  examine: "It's a Big Compost Bin"
 - id: 33764
-  examine: "It's a Big Compost Bin"
 - id: 33765
-  examine: "It's a Big Compost Bin"
 - id: 33766
-  examine: "It's a Big Compost Bin"
 - id: 33767
-  examine: "It's a Big Compost Bin"
 - id: 33768
-  examine: "It's a Big Compost Bin"
 - id: 33769
-  examine: "It's a Big Compost Bin"
 - id: 33770
-  examine: "It's a Big Compost Bin"
 - id: 33771
-  examine: "It's a Big Compost Bin"
 - id: 33772
-  examine: "It's a Big Compost Bin"
 - id: 33773
-  examine: "It's a Big Compost Bin"
 - id: 33774
-  examine: "It's a Big Compost Bin"
 - id: 33775
-  examine: "It's a Big Compost Bin"
 - id: 33776
-  examine: "It's a Big Compost Bin"
 - id: 33777
-  examine: "It's a Big Compost Bin"
 - id: 33778
-  examine: "It's a Big Compost Bin"
 - id: 33779
-  examine: "It's a Big Compost Bin"
 - id: 33780
-  examine: "It's a Big Compost Bin"
 - id: 33781
-  examine: "It's a Big Compost Bin"
 - id: 33782
-  examine: "It's a Big Compost Bin"
 - id: 33783
-  examine: "It's a Big Compost Bin"
 - id: 33784
-  examine: "It's a Big Compost Bin"
 - id: 33785
-  examine: "It's a Big Compost Bin"
 - id: 33786
-  examine: "It's a Big Compost Bin"
 - id: 33787
-  examine: "It's a Big Compost Bin"
 - id: 33788
-  examine: "It's a Big Compost Bin"
 - id: 33789
-  examine: "It's a Big Compost Bin"
 - id: 33790
-  examine: "It's a Big Compost Bin"
 - id: 33791
-  examine: "It's a Big Compost Bin"
 - id: 33792
-  examine: "It's a Big Compost Bin"
 - id: 33793
-  examine: "It's a Big Compost Bin"
 - id: 33794
-  examine: "It's a Big Compost Bin"
 - id: 33795
-  examine: "It's a Big Compost Bin"
 - id: 33796
-  examine: "It's a Big Compost Bin"
 - id: 33797
-  examine: "It's a Big Compost Bin"
 - id: 33798
-  examine: "It's a Big Compost Bin"
 - id: 33799
-  examine: "It's a Big Compost Bin"
 - id: 33800
-  examine: "It's a Big Compost Bin"
 - id: 33801
-  examine: "It's a Big Compost Bin"
 - id: 33802
-  examine: "It's a Big Compost Bin"
 - id: 33803
-  examine: "It's a Big Compost Bin"
 - id: 33804
-  examine: "It's a Big Compost Bin"
 - id: 33805
-  examine: "It's a Big Compost Bin"
 - id: 33806
-  examine: "It's a Big Compost Bin"
 - id: 33807
-  examine: "It's a Big Compost Bin"
 - id: 33808
-  examine: "It's a Big Compost Bin"
 - id: 33809
-  examine: "It's a Big Compost Bin"
 - id: 33810
-  examine: "It's a Big Compost Bin"
 - id: 33811
-  examine: "It's a Big Compost Bin"
 - id: 33812
-  examine: "It's a Big Compost Bin"
 - id: 33813
-  examine: "It's a Big Compost Bin"
 - id: 33814
-  examine: "It's a Big Compost Bin"
 - id: 33815
-  examine: "It's a Big Compost Bin"
 - id: 33816
-  examine: "It's a Big Compost Bin"
 - id: 33817
-  examine: "It's a Big Compost Bin"
 - id: 33818
-  examine: "It's a Big Compost Bin"
 - id: 33819
-  examine: "It's a Big Compost Bin"
 - id: 33820
-  examine: "It's a Big Compost Bin"
 - id: 33821
-  examine: "It's a Big Compost Bin"
 - id: 33822
-  examine: "It's a Big Compost Bin"
 - id: 33823
-  examine: "It's a Big Compost Bin"
 - id: 33824
-  examine: "It's a Big Compost Bin"
 - id: 33825
-  examine: "It's a Big Compost Bin"
 - id: 33826
-  examine: "It's a Big Compost Bin"
 - id: 33827
-  examine: "It's a Big Compost Bin"
 - id: 33828
-  examine: "It's a Big Compost Bin"
 - id: 33829
-  examine: "It's a Big Compost Bin"
 - id: 33830
-  examine: "It's a Big Compost Bin"
 - id: 33831
-  examine: "It's a Big Compost Bin"
 - id: 33832
-  examine: "It's a Big Compost Bin"
 - id: 33833
-  examine: "It's a Big Compost Bin"
 - id: 33834
-  examine: "It's a Big Compost Bin"
 - id: 33835
-  examine: "It's a Big Compost Bin"
 - id: 33836
-  examine: "It's a Big Compost Bin"
 - id: 33837
-  examine: "It's a Big Compost Bin"
 - id: 33838
-  examine: "It's a Big Compost Bin"
 - id: 33839
-  examine: "It's a Big Compost Bin"
 - id: 33840
-  examine: "It's a Big Compost Bin"
 - id: 33841
-  examine: "It's a Big Compost Bin"
 - id: 33842
-  examine: "It's a Big Compost Bin"
 - id: 33843
-  examine: "It's a Big Compost Bin"
 - id: 33844
-  examine: "It's a Big Compost Bin"
 - id: 33845
-  examine: "It's a Big Compost Bin"
 - id: 33846
-  examine: "It's a Big Compost Bin"
 - id: 33847
-  examine: "It's a Big Compost Bin"
 - id: 33848
-  examine: "It's a Big Compost Bin"
 - id: 33849
-  examine: "It's a Big Compost Bin"
 - id: 33850
-  examine: "It's a Big Compost Bin"
 - id: 33851
-  examine: "It's a Big Compost Bin"
 - id: 33852
-  examine: "It's a Big Compost Bin"
 - id: 33853
-  examine: "It's a Big Compost Bin"
 - id: 33854
-  examine: "It's a Big Compost Bin"
 - id: 33855
-  examine: "It's a Big Compost Bin"
 - id: 33856
-  examine: "It's a Big Compost Bin"
 - id: 33857
-  examine: "It's a Big Compost Bin"
 - id: 33858
-  examine: "It's a Big Compost Bin"
 - id: 33859
-  examine: "It's a Big Compost Bin"
 - id: 33860
-  examine: "It's a Big Compost Bin"
 - id: 33861
-  examine: "It's a Big Compost Bin"
 - id: 33862
-  examine: "It's a Big Compost Bin"
 - id: 33863
-  examine: "It's a Big Compost Bin"
 - id: 33864
-  examine: "It's a Big Compost Bin"
 - id: 33865
-  examine: "It's a Big Compost Bin"
 - id: 33866
-  examine: "It's a Big Compost Bin"
 - id: 33867
-  examine: "It's a Big Compost Bin"
 - id: 33868
-  examine: "It's a Big Compost Bin"
 - id: 33869
-  examine: "It's a Big Compost Bin"
 - id: 33870
-  examine: "It's a Big Compost Bin"
 - id: 33871
-  examine: "It's a Big Compost Bin"
 - id: 33872
-  examine: "It's a Big Compost Bin"
 - id: 33873
-  examine: "It's a Big Compost Bin"
 - id: 33874
-  examine: "It's a Big Compost Bin"
 - id: 33875
-  examine: "It's a Big Compost Bin"
 - id: 33876
-  examine: "It's a Big Compost Bin"
 - id: 33877
-  examine: "It's a Big Compost Bin"
 - id: 33878
-  examine: "It's a Big Compost Bin"
 - id: 33879
-  examine: "It's a Big Compost Bin"
 - id: 33880
-  examine: "It's a Big Compost Bin"
 - id: 33881
-  examine: "It's a Big Compost Bin"
 - id: 33882
-  examine: "It's a Big Compost Bin"
 - id: 33883
-  examine: "It's a Big Compost Bin"
 - id: 33884
-  examine: "It's a Big Compost Bin"
 - id: 33885
-  examine: "It's a Big Compost Bin"
 - id: 33886
-  examine: "It's a Big Compost Bin"
 - id: 33887
-  examine: "It's a Big Compost Bin"
 - id: 33888
-  examine: "It's a Big Compost Bin"
 - id: 33889
-  examine: "It's a Big Compost Bin"
 - id: 33890
-  examine: "It's a Big Compost Bin"
 - id: 33891
-  examine: "It's a Big Compost Bin"
 - id: 33892
-  examine: "It's a Big Compost Bin"
 - id: 33893
-  examine: "It's a Big Compost Bin"
 - id: 33894
-  examine: "It's a Big Compost Bin"
 - id: 33895
-  examine: "It's a Big Compost Bin"
 - id: 33896
-  examine: "It's a Big Compost Bin"
 - id: 33897
-  examine: "It's a Big Compost Bin"
 - id: 33898
-  examine: "It's a Big Compost Bin"
 - id: 33899
-  examine: "It's a Big Compost Bin"
 - id: 33900
-  examine: "It's a Big Compost Bin"
 - id: 33901
-  examine: "It's a Big Compost Bin"
 - id: 33902
-  examine: "It's a Big Compost Bin"
 - id: 33903
-  examine: "It's a Big Compost Bin"
 - id: 33904
-  examine: "It's a Big Compost Bin"
 - id: 33905
-  examine: "It's a Big Compost Bin"
 - id: 33906
-  examine: "It's a Big Compost Bin"
 - id: 33907
-  examine: "It's a Big Compost Bin"
 - id: 33908
-  examine: "It's a Big Compost Bin"
 - id: 33909
-  examine: "It's a Big Compost Bin"
 - id: 33910
-  examine: "It's a Big Compost Bin"
 - id: 33911
-  examine: "It's a Big Compost Bin"
 - id: 33912
-  examine: "It's a Big Compost Bin"
 - id: 33913
-  examine: "It's a Big Compost Bin"
 - id: 33914
-  examine: "It's a Big Compost Bin"
 - id: 33915
-  examine: "It's a Big Compost Bin"
 - id: 33916
-  examine: "It's a Big Compost Bin"
 - id: 33917
-  examine: "It's a Big Compost Bin"
 - id: 33918
-  examine: "It's a Big Compost Bin"
 - id: 33919
-  examine: "It's a Big Compost Bin"
 - id: 33920
-  examine: "It's a Big Compost Bin"
 - id: 33921
-  examine: "It's a Big Compost Bin"
 - id: 33922
-  examine: "It's a Big Compost Bin"
 - id: 33923
-  examine: "It's a Big Compost Bin"
 - id: 33924
-  examine: "It's a Big Compost Bin"
 - id: 33925
-  examine: "It's a Big Compost Bin"
 - id: 33926
-  examine: "It's a Big Compost Bin"
 - id: 33927
-  examine: "It's a Big Compost Bin"
 - id: 33928
-  examine: "It's a Big Compost Bin"
 - id: 33929
-  examine: "It's a Big Compost Bin"
 - id: 33930
-  examine: "It's a Big Compost Bin"
 - id: 33931
-  examine: "It's a Big Compost Bin"
 - id: 33932
-  examine: "It's a Big Compost Bin"
 - id: 33933
-  examine: "It's a Big Compost Bin"
 - id: 33934
-  examine: "It's a Big Compost Bin"
 - id: 33935
-  examine: "It's a Big Compost Bin"
 - id: 33936
-  examine: "It's a Big Compost Bin"
 - id: 33937
-  examine: "It's a Big Compost Bin"
 - id: 33938
-  examine: "It's a Big Compost Bin"
 - id: 33939
-  examine: "It's a Big Compost Bin"
 - id: 33940
-  examine: "It's a Big Compost Bin"
 - id: 33941
-  examine: "It's a Big Compost Bin"
 - id: 33942
-  examine: "It's a Big Compost Bin"
 - id: 33943
-  examine: "It's a Big Compost Bin"
 - id: 33944
-  examine: "It's a Big Compost Bin"
 - id: 33945
-  examine: "It's a Big Compost Bin"
 - id: 33946
-  examine: "It's a Big Compost Bin"
 - id: 33947
-  examine: "It's a Big Compost Bin"
 - id: 33948
-  examine: "It's a Big Compost Bin"
 - id: 33949
-  examine: "It's a Big Compost Bin"
 - id: 33950
-  examine: "It's a Big Compost Bin"
 - id: 33951
-  examine: "It's a Big Compost Bin"
 - id: 33952
-  examine: "It's a Big Compost Bin"
 - id: 33953
-  examine: "It's a Big Compost Bin"
 - id: 33954
-  examine: "It's a Big Compost Bin"
 - id: 33955
-  examine: "It's a Big Compost Bin"
 - id: 33956
-  examine: "It's a Big Compost Bin"
 - id: 33957
-  examine: "It's a Big Compost Bin"
 - id: 33958
-  examine: "It's a Big Compost Bin"
 - id: 33959
-  examine: "It's a Big Compost Bin"
 - id: 33960
-  examine: "It's a Big Compost Bin"
 - id: 33961
-  examine: "It's a Big Compost Bin"
 - id: 33962
-  examine: "It's a Big Compost Bin"
 - id: 33963
-  examine: "It's a Big Compost Bin"
 - id: 33964
-  examine: "It's a Big Compost Bin"
 - id: 33965
-  examine: "It's a Big Compost Bin"
 - id: 33966
-  examine: "It's a Big Compost Bin"
 - id: 33967
-  examine: "It's a Big Compost Bin"
 - id: 33968
-  examine: "It's a Big Compost Bin"
 - id: 33969
-  examine: "It's a Big Compost Bin"
 - id: 33970
-  examine: "It's a Big Compost Bin"
 - id: 33971
-  examine: "It's a Big Compost Bin"
 - id: 33972
-  examine: "It's a Big Compost Bin"
 - id: 33973
-  examine: "It's a Big Compost Bin"
 - id: 33974
-  examine: "It's a Big Compost Bin"
 - id: 33975
-  examine: "It's a Big Compost Bin"
 - id: 33976
-  examine: "It's a Big Compost Bin"
 - id: 33977
-  examine: "It's a Big Compost Bin"
 - id: 33978
-  examine: "It's a Big Compost Bin"
 - id: 33979
 - id: 33980
-  examine: "It's a Anima patch"
 - id: 33981
-  examine: "It's a Anima patch"
 - id: 33982
-  examine: "It's a Anima patch"
 - id: 33983
-  examine: "It's a Anima patch"
 - id: 33984
-  examine: "It's a Iasor plant"
 - id: 33985
-  examine: "It's a Iasor plant"
 - id: 33986
-  examine: "It's a Iasor plant"
 - id: 33987
-  examine: "It's a Iasor plant"
 - id: 33988
-  examine: "It's a Iasor plant"
 - id: 33989
-  examine: "It's a Withering Iasor plant"
 - id: 33990
-  examine: "It's a Dead Iasor plant"
 - id: 33991
-  examine: "It's a Attas plant"
 - id: 33992
-  examine: "It's a Attas plant"
 - id: 33993
-  examine: "It's a Attas plant"
 - id: 33994
-  examine: "It's a Attas plant"
 - id: 33995
-  examine: "It's a Attas plant"
 - id: 33996
-  examine: "It's a Withering Attas plant"
 - id: 33997
-  examine: "It's a Dead Attas plant"
 - id: 33998
 - id: 33999
-  examine: "It's a Kronos plant"
 - id: 34000
-  examine: "It's a Kronos plant"
 - id: 34001
-  examine: "It's a Kronos plant"
 - id: 34002
-  examine: "It's a Kronos plant"
 - id: 34003
-  examine: "It's a Kronos plant"
 - id: 34004
-  examine: "It's a Withering Kronos plant"
 - id: 34005
-  examine: "It's a Dead Kronos plant"
 - id: 34006
 - id: 34007
 - id: 34008
-  examine: "It's a Dragonfruit tree"
 - id: 34009
-  examine: "It's a Dragonfruit tree"
 - id: 34010
-  examine: "It's a Dragonfruit tree"
 - id: 34011
-  examine: "It's a Dragonfruit tree"
 - id: 34012
-  examine: "It's a Dragonfruit tree"
 - id: 34013
-  examine: "It's a Dragonfruit tree"
 - id: 34014
-  examine: "It's a Dragonfruit tree"
 - id: 34015
-  examine: "It's a Dragonfruit tree"
 - id: 34016
-  examine: "It's a Dragonfruit tree"
 - id: 34017
-  examine: "It's a Dragonfruit tree"
 - id: 34018
-  examine: "It's a Dragonfruit tree"
 - id: 34019
-  examine: "It's a Dragonfruit tree"
 - id: 34020
-  examine: "It's a Dragonfruit tree"
 - id: 34021
-  examine: "It's a Dragonfruit tree"
 - id: 34022
-  examine: "It's a Diseased dragonfruit plant"
 - id: 34023
-  examine: "It's a Diseased dragonfruit plant"
 - id: 34024
-  examine: "It's a Diseased dragonfruit plant"
 - id: 34025
-  examine: "It's a Diseased dragonfruit plant"
 - id: 34026
-  examine: "It's a Diseased dragonfruit plant"
 - id: 34027
-  examine: "It's a Diseased dragonfruit plant"
 - id: 34028
-  examine: "It's a Dead dragonfruit plant"
 - id: 34029
-  examine: "It's a Dead dragonfruit plant"
 - id: 34030
-  examine: "It's a Dead dragonfruit plant"
 - id: 34031
-  examine: "It's a Dead dragonfruit plant"
 - id: 34032
-  examine: "It's a Dead dragonfruit plant"
 - id: 34033
-  examine: "It's a Dead dragonfruit plant"
 - id: 34034
-  examine: "It's a Dragonfruit tree stump"
 - id: 34035
-  examine: "It's a Redwood tree patch"
 - id: 34036
-  examine: "It's a Redwood tree patch"
 - id: 34037
-  examine: "It's a Redwood tree patch"
 - id: 34038
-  examine: "It's a Redwood tree patch"
 - id: 34039
-  examine: "It's a Redwood tree patch"
 - id: 34040
-  examine: "It's a Redwood tree patch"
 - id: 34041
-  examine: "It's a Redwood tree patch"
 - id: 34042
-  examine: "It's a Redwood tree patch"
 - id: 34043
-  examine: "It's a Redwood tree patch"
 - id: 34044
-  examine: "It's a Redwood tree patch"
 - id: 34045
-  examine: "It's a Redwood tree patch"
 - id: 34046
-  examine: "It's a Redwood tree patch"
 - id: 34047
-  examine: "It's a Redwood tree patch"
 - id: 34048
-  examine: "It's a Redwood tree patch"
 - id: 34049
-  examine: "It's a Redwood tree patch"
 - id: 34050
-  examine: "It's a Redwood tree patch"
 - id: 34051
 - id: 34052
 - id: 34053
@@ -52755,523 +43574,265 @@
 - id: 34058
 - id: 34059
 - id: 34060
-  examine: "It's a Dead Redwood tree"
 - id: 34061
-  examine: "It's a Dead Redwood tree"
 - id: 34062
-  examine: "It's a Dead Redwood tree"
 - id: 34063
-  examine: "It's a Dead Redwood tree"
 - id: 34064
-  examine: "It's a Dead Redwood tree"
 - id: 34065
-  examine: "It's a Dead Redwood tree"
 - id: 34066
-  examine: "It's a Dead Redwood tree"
 - id: 34067
-  examine: "It's a Dead Redwood tree"
 - id: 34068
-  examine: "It's a Dead Redwood tree"
 - id: 34069
-  examine: "It's a Dead Redwood tree"
 - id: 34070
-  examine: "It's a Dead Redwood tree"
 - id: 34071
-  examine: "It's a Dead Redwood tree"
 - id: 34072
-  examine: "It's a Dead Redwood tree"
 - id: 34073
-  examine: "It's a Dead Redwood tree"
 - id: 34074
-  examine: "It's a Dead Redwood tree"
 - id: 34075
-  examine: "It's a Dead Redwood tree"
 - id: 34076
-  examine: "It's a Dead Redwood tree"
 - id: 34077
-  examine: "It's a Dead Redwood tree"
 - id: 34078
-  examine: "It's a Dead Redwood tree"
 - id: 34079
-  examine: "It's a Dead Redwood tree"
 - id: 34080
-  examine: "It's a Dead Redwood tree"
 - id: 34081
-  examine: "It's a Dead Redwood tree"
 - id: 34082
-  examine: "It's a Dead Redwood tree"
 - id: 34083
-  examine: "It's a Dead Redwood tree"
 - id: 34084
-  examine: "It's a Dead Redwood tree"
 - id: 34085
-  examine: "It's a Dead Redwood tree"
 - id: 34086
-  examine: "It's a Dead Redwood tree"
 - id: 34087
-  examine: "It's a Dead Redwood tree"
 - id: 34088
-  examine: "It's a Dead Redwood tree"
 - id: 34089
-  examine: "It's a Dead Redwood tree"
 - id: 34090
-  examine: "It's a Dead Redwood tree"
 - id: 34091
-  examine: "It's a Dead Redwood tree"
 - id: 34092
-  examine: "It's a Dead Redwood tree"
 - id: 34093
-  examine: "It's a Dead Redwood tree"
 - id: 34094
-  examine: "It's a Dead Redwood tree"
 - id: 34095
-  examine: "It's a Dead Redwood tree"
 - id: 34096
-  examine: "It's a Dead Redwood tree"
 - id: 34097
-  examine: "It's a Dead Redwood tree"
 - id: 34098
-  examine: "It's a Dead Redwood tree"
 - id: 34099
-  examine: "It's a Dead Redwood tree"
 - id: 34100
-  examine: "It's a Dead Redwood tree"
 - id: 34101
-  examine: "It's a Dead Redwood tree"
 - id: 34102
-  examine: "It's a Dead Redwood tree"
 - id: 34103
-  examine: "It's a Dead Redwood tree"
 - id: 34104
-  examine: "It's a Dead Redwood tree"
 - id: 34105
-  examine: "It's a Dead Redwood tree"
 - id: 34106
-  examine: "It's a Dead Redwood tree"
 - id: 34107
-  examine: "It's a Dead Redwood tree"
 - id: 34108
-  examine: "It's a Dead Redwood tree"
 - id: 34109
-  examine: "It's a Dead Redwood tree"
 - id: 34110
-  examine: "It's a Dead Redwood tree"
 - id: 34111
-  examine: "It's a Dead Redwood tree"
 - id: 34112
-  examine: "It's a Dead Redwood tree"
 - id: 34113
-  examine: "It's a Dead Redwood tree"
 - id: 34114
-  examine: "It's a Dead Redwood tree"
 - id: 34115
-  examine: "It's a Dead Redwood tree"
 - id: 34116
-  examine: "It's a Dead Redwood tree"
 - id: 34117
-  examine: "It's a Dead Redwood tree"
 - id: 34118
-  examine: "It's a Dead Redwood tree"
 - id: 34119
-  examine: "It's a Dead Redwood tree"
 - id: 34120
-  examine: "It's a Dead Redwood tree"
 - id: 34121
-  examine: "It's a Dead Redwood tree"
 - id: 34122
-  examine: "It's a Dead Redwood tree"
 - id: 34123
-  examine: "It's a Dead Redwood tree"
 - id: 34124
-  examine: "It's a Dead Redwood tree"
 - id: 34125
-  examine: "It's a Dead Redwood tree"
 - id: 34126
-  examine: "It's a Dead Redwood tree"
 - id: 34127
-  examine: "It's a Dead Redwood tree"
 - id: 34128
-  examine: "It's a Dead Redwood tree"
 - id: 34129
-  examine: "It's a Diseased Redwood tree"
 - id: 34130
-  examine: "It's a Diseased Redwood tree"
 - id: 34131
-  examine: "It's a Diseased Redwood tree"
 - id: 34132
-  examine: "It's a Diseased Redwood tree"
 - id: 34133
-  examine: "It's a Diseased Redwood tree"
 - id: 34134
-  examine: "It's a Diseased Redwood tree"
 - id: 34135
-  examine: "It's a Diseased Redwood tree"
 - id: 34136
-  examine: "It's a Diseased Redwood tree"
 - id: 34137
-  examine: "It's a Diseased Redwood tree"
 - id: 34138
-  examine: "It's a Diseased Redwood tree"
 - id: 34139
-  examine: "It's a Diseased Redwood tree"
 - id: 34140
-  examine: "It's a Diseased Redwood tree"
 - id: 34141
-  examine: "It's a Diseased Redwood tree"
 - id: 34142
-  examine: "It's a Diseased Redwood tree"
 - id: 34143
-  examine: "It's a Diseased Redwood tree"
 - id: 34144
-  examine: "It's a Diseased Redwood tree"
 - id: 34145
-  examine: "It's a Diseased Redwood tree"
 - id: 34146
-  examine: "It's a Diseased Redwood tree"
 - id: 34147
-  examine: "It's a Diseased Redwood tree"
 - id: 34148
-  examine: "It's a Diseased Redwood tree"
 - id: 34149
-  examine: "It's a Diseased Redwood tree"
 - id: 34150
-  examine: "It's a Diseased Redwood tree"
 - id: 34151
-  examine: "It's a Diseased Redwood tree"
 - id: 34152
-  examine: "It's a Diseased Redwood tree"
 - id: 34153
-  examine: "It's a Diseased Redwood tree"
 - id: 34154
-  examine: "It's a Diseased Redwood tree"
 - id: 34155
-  examine: "It's a Diseased Redwood tree"
 - id: 34156
-  examine: "It's a Diseased Redwood tree"
 - id: 34157
-  examine: "It's a Diseased Redwood tree"
 - id: 34158
-  examine: "It's a Diseased Redwood tree"
 - id: 34159
-  examine: "It's a Diseased Redwood tree"
 - id: 34160
-  examine: "It's a Diseased Redwood tree"
 - id: 34161
-  examine: "It's a Diseased Redwood tree"
 - id: 34162
-  examine: "It's a Diseased Redwood tree"
 - id: 34163
-  examine: "It's a Diseased Redwood tree"
 - id: 34164
-  examine: "It's a Diseased Redwood tree"
 - id: 34165
-  examine: "It's a Diseased Redwood tree"
 - id: 34166
-  examine: "It's a Diseased Redwood tree"
 - id: 34167
-  examine: "It's a Diseased Redwood tree"
 - id: 34168
-  examine: "It's a Diseased Redwood tree"
 - id: 34169
-  examine: "It's a Diseased Redwood tree"
 - id: 34170
-  examine: "It's a Diseased Redwood tree"
 - id: 34171
-  examine: "It's a Diseased Redwood tree"
 - id: 34172
-  examine: "It's a Diseased Redwood tree"
 - id: 34173
-  examine: "It's a Diseased Redwood tree"
 - id: 34174
-  examine: "It's a Diseased Redwood tree"
 - id: 34175
-  examine: "It's a Diseased Redwood tree"
 - id: 34176
-  examine: "It's a Diseased Redwood tree"
 - id: 34177
-  examine: "It's a Diseased Redwood tree"
 - id: 34178
-  examine: "It's a Diseased Redwood tree"
 - id: 34179
-  examine: "It's a Diseased Redwood tree"
 - id: 34180
-  examine: "It's a Diseased Redwood tree"
 - id: 34181
-  examine: "It's a Diseased Redwood tree"
 - id: 34182
-  examine: "It's a Diseased Redwood tree"
 - id: 34183
-  examine: "It's a Diseased Redwood tree"
 - id: 34184
-  examine: "It's a Diseased Redwood tree"
 - id: 34185
-  examine: "It's a Diseased Redwood tree"
 - id: 34186
-  examine: "It's a Diseased Redwood tree"
 - id: 34187
-  examine: "It's a Diseased Redwood tree"
 - id: 34188
-  examine: "It's a Diseased Redwood tree"
 - id: 34189
-  examine: "It's a Diseased Redwood tree"
 - id: 34190
-  examine: "It's a Diseased Redwood tree"
 - id: 34191
-  examine: "It's a Diseased Redwood tree"
 - id: 34192
-  examine: "It's a Diseased Redwood tree"
 - id: 34193
-  examine: "It's a Diseased Redwood tree"
 - id: 34194
-  examine: "It's a Diseased Redwood tree"
 - id: 34195
-  examine: "It's a Diseased Redwood tree"
 - id: 34196
-  examine: "It's a Diseased Redwood tree"
 - id: 34197
-  examine: "It's a Diseased Redwood tree"
 - id: 34198
-  examine: "It's a Redwood tree"
 - id: 34199
-  examine: "It's a Redwood tree"
 - id: 34200
-  examine: "It's a Diseased Redwood tree"
 - id: 34201
-  examine: "It's a Dead Redwood tree"
 - id: 34202
-  examine: "It's a Redwood tree"
 - id: 34203
-  examine: "It's a Diseased Redwood tree"
 - id: 34204
-  examine: "It's a Dead Redwood tree"
 - id: 34205
-  examine: "It's a Redwood tree"
 - id: 34206
-  examine: "It's a Redwood tree"
 - id: 34207
-  examine: "It's a Redwood tree"
 - id: 34208
-  examine: "It's a Redwood tree"
 - id: 34209
-  examine: "It's a Redwood tree"
 - id: 34210
-  examine: "It's a Redwood tree"
 - id: 34211
-  examine: "It's a Redwood tree"
 - id: 34212
-  examine: "It's a Redwood tree"
 - id: 34213
-  examine: "It's a Redwood tree"
 - id: 34214
-  examine: "It's a Redwood tree"
 - id: 34215
-  examine: "It's a Redwood tree"
 - id: 34216
-  examine: "It's a Redwood tree"
 - id: 34217
-  examine: "It's a Redwood tree"
 - id: 34218
-  examine: "It's a Redwood tree"
 - id: 34219
-  examine: "It's a Redwood tree"
 - id: 34220
-  examine: "It's a Redwood tree"
 - id: 34221
-  examine: "It's a Redwood tree"
 - id: 34222
-  examine: "It's a Redwood tree"
 - id: 34223
-  examine: "It's a Redwood tree"
 - id: 34224
-  examine: "It's a Redwood tree"
 - id: 34225
-  examine: "It's a Redwood tree"
 - id: 34226
-  examine: "It's a Redwood tree"
 - id: 34227
-  examine: "It's a Redwood tree"
 - id: 34228
-  examine: "It's a Redwood tree"
 - id: 34229
-  examine: "It's a Redwood tree"
 - id: 34230
-  examine: "It's a Redwood tree"
 - id: 34231
-  examine: "It's a Redwood tree"
 - id: 34232
-  examine: "It's a Redwood tree"
 - id: 34233
-  examine: "It's a Redwood tree"
 - id: 34234
-  examine: "It's a Redwood tree"
 - id: 34235
-  examine: "It's a Redwood tree"
 - id: 34236
-  examine: "It's a Redwood tree"
 - id: 34237
-  examine: "It's a Redwood tree"
 - id: 34238
-  examine: "It's a Redwood tree"
 - id: 34239
-  examine: "It's a Redwood tree"
 - id: 34240
-  examine: "It's a Redwood tree"
 - id: 34241
-  examine: "It's a Redwood tree"
 - id: 34242
-  examine: "It's a Redwood tree"
 - id: 34243
-  examine: "It's a Redwood tree"
 - id: 34244
-  examine: "It's a Redwood tree"
 - id: 34245
-  examine: "It's a Redwood tree"
 - id: 34246
-  examine: "It's a Redwood tree"
 - id: 34247
-  examine: "It's a Redwood tree"
 - id: 34248
-  examine: "It's a Redwood tree"
 - id: 34249
-  examine: "It's a Redwood tree"
 - id: 34250
-  examine: "It's a Redwood tree"
 - id: 34251
-  examine: "It's a Redwood tree"
 - id: 34252
-  examine: "It's a Redwood tree"
 - id: 34253
-  examine: "It's a Redwood tree"
 - id: 34254
-  examine: "It's a Redwood tree"
 - id: 34255
-  examine: "It's a Redwood tree"
 - id: 34256
-  examine: "It's a Redwood tree"
 - id: 34257
-  examine: "It's a Redwood tree"
 - id: 34258
-  examine: "It's a Redwood tree"
 - id: 34259
-  examine: "It's a Redwood tree"
 - id: 34260
-  examine: "It's a Redwood tree"
 - id: 34261
-  examine: "It's a Redwood tree"
 - id: 34262
-  examine: "It's a Redwood tree"
 - id: 34263
-  examine: "It's a Redwood tree"
 - id: 34264
-  examine: "It's a Redwood tree"
 - id: 34265
-  examine: "It's a Redwood tree"
 - id: 34266
-  examine: "It's a Redwood tree"
 - id: 34267
-  examine: "It's a Redwood tree"
 - id: 34268
-  examine: "It's a Redwood tree"
 - id: 34269
-  examine: "It's a Redwood tree"
 - id: 34270
-  examine: "It's a Redwood tree"
 - id: 34271
-  examine: "It's a Redwood tree"
 - id: 34272
-  examine: "It's a Redwood tree"
 - id: 34273
-  examine: "It's a Redwood tree"
 - id: 34274
-  examine: "It's a Redwood tree"
 - id: 34275
-  examine: "It's a Redwood tree"
 - id: 34276
-  examine: "It's a Redwood tree"
 - id: 34277
-  examine: "It's a Redwood tree"
 - id: 34278
-  examine: "It's a Redwood tree"
 - id: 34279
-  examine: "It's a Redwood tree"
 - id: 34280
-  examine: "It's a Redwood tree"
 - id: 34281
-  examine: "It's a Redwood tree"
 - id: 34282
-  examine: "It's a Redwood tree"
 - id: 34283
-  examine: "It's a Redwood tree"
 - id: 34284
-  examine: "It's a Redwood tree"
 - id: 34285
-  examine: "It's a Redwood tree"
 - id: 34286
-  examine: "It's a Redwood tree"
 - id: 34287
-  examine: "It's a Redwood tree"
 - id: 34288
-  examine: "It's a Redwood tree"
 - id: 34289
-  examine: "It's a Redwood tree"
 - id: 34290
-  examine: "It's a Redwood tree"
 - id: 34291
-  examine: "It's a Redwood tree"
 - id: 34292
-  examine: "It's a Redwood tree"
 - id: 34293
-  examine: "It's a Redwood tree"
 - id: 34294
-  examine: "It's a Redwood tree"
 - id: 34295
-  examine: "It's a Redwood tree"
 - id: 34296
-  examine: "It's a Redwood tree"
 - id: 34297
-  examine: "It's a Redwood tree"
 - id: 34298
-  examine: "It's a Redwood tree"
 - id: 34299
-  examine: "It's a Redwood tree"
 - id: 34300
-  examine: "It's a Redwood tree"
 - id: 34301
-  examine: "It's a Redwood tree"
 - id: 34302
-  examine: "It's a Redwood tree"
 - id: 34303
-  examine: "It's a Redwood tree"
 - id: 34304
-  examine: "It's a Redwood tree"
 - id: 34305
-  examine: "It's a Redwood tree"
 - id: 34306
-  examine: "It's a Redwood tree"
 - id: 34307
-  examine: "It's a Redwood tree"
 - id: 34308
-  examine: "It's a Redwood tree"
 - id: 34309
-  examine: "It's a Redwood tree"
 - id: 34310
-  examine: "It's a Redwood tree"
 - id: 34311
-  examine: "It's a Redwood tree"
 - id: 34312
-  examine: "It's a Redwood tree"
 - id: 34313
-  examine: "It's a Redwood tree"
 - id: 34314
-  examine: "It's a Redwood tree"
 - id: 34315
-  examine: "It's a Redwood tree"
 - id: 34316
-  examine: "It's a Spike defence"
 - id: 34317
 - id: 34318
 - id: 34319
-  examine: "It's a Glass table"
 - id: 34320
 - id: 34321
 - id: 34322
@@ -53287,7 +43848,6 @@
 - id: 34332
 - id: 34333
 - id: 34335
-  examine: "It's a Sulphur Vent"
 - id: 34336
 - id: 34337
 - id: 34338
@@ -53295,29 +43855,21 @@
 - id: 34340
 - id: 34341
 - id: 34342
-  examine: "It's a Volcanic Furnace"
 - id: 34343
-  examine: "It's a Bank chest"
 - id: 34344
-  examine: "It's a Bank Deposit Box"
 - id: 34347
 - id: 34348
 - id: 34349
-  examine: "It's a Empty chest"
 - id: 34350
-  examine: "It's a Barrel of Mud"
 - id: 34351
-  examine: "It's a Barrel of Spears"
 - id: 34352
 - id: 34353
 - id: 34354
 - id: 34355
 - id: 34356
-  examine: "It's a Elevator controls"
 - id: 34357
 - id: 34358
 - id: 34359
-  examine: "It's a Elevator"
 - id: 34360
 - id: 34361
 - id: 34362
@@ -53355,24 +43907,16 @@
 - id: 34394
 - id: 34395
 - id: 34396
-  examine: "It's a Rocks"
 - id: 34397
-  examine: "It's a Rocks"
 - id: 34398
 - id: 34399
 - id: 34400
 - id: 34401
-  examine: "It's a Olmic pillar"
 - id: 34402
-  examine: "It's a Lizard dwelling"
 - id: 34403
-  examine: "It's a Lizard dwelling"
 - id: 34404
-  examine: "It's a Lizard dwelling"
 - id: 34405
-  examine: "It's a Lizard dwelling"
 - id: 34406
-  examine: "It's a Stone table"
 - id: 34407
 - id: 34408
 - id: 34409
@@ -53384,47 +43928,26 @@
 - id: 34415
 - id: 34416
 - id: 34417
-  examine: "It's a Drip"
 - id: 34418
-  examine: "It's a Drips"
 - id: 34419
-  examine: "It's a Lizardman eggs"
 - id: 34420
-  examine: "It's a Lizardman eggs"
 - id: 34421
-  examine: "It's a Light"
 - id: 34422
-  examine: "It's a Strange hole"
 - id: 34423
-  examine: "It's a Cat"
 - id: 34424
-  examine: "It's a Stone chest"
 - id: 34425
-  examine: "It's a Stone chest"
 - id: 34426
-  examine: "It's a Stone chest"
 - id: 34427
-  examine: "It's a Vase"
 - id: 34428
-  examine: "It's a Vase"
 - id: 34429
-  examine: "It's a Stone chest"
 - id: 34430
-  examine: "It's a Stone chest"
 - id: 34431
-  examine: "It's a Stone chest"
 - id: 34432
-  examine: "It's a Mystical barrier"
 - id: 34433
-  examine: "It's a Mystical barrier (orange)"
 - id: 34434
-  examine: "It's a Mystical barrier (red)"
 - id: 34435
-  examine: "It's a Cave"
 - id: 34436
-  examine: "It's a Cave"
 - id: 34437
-  examine: "It's a Hespori"
 - id: 34438
 - id: 34439
 - id: 34440
@@ -53433,9 +43956,7 @@
 - id: 34443
 - id: 34444
 - id: 34445
-  examine: "It's a Water tap"
 - id: 34446
-  examine: "It's a Chest"
 - id: 34447
 - id: 34448
 - id: 34449
@@ -53453,49 +43974,32 @@
 - id: 34461
 - id: 34462
 - id: 34463
-  examine: "It's a Door"
 - id: 34464
-  examine: "It's a Door"
 - id: 34465
 - id: 34466
 - id: 34467
 - id: 34468
 - id: 34469
-  examine: "It's a Gate"
 - id: 34470
-  examine: "It's a Gate"
 - id: 34471
 - id: 34472
 - id: 34473
-  examine: "It's a Gate"
 - id: 34474
-  examine: "It's a Gate"
 - id: 34475
 - id: 34476
 - id: 34477
-  examine: "It's a Rope ladder"
 - id: 34478
-  examine: "It's a Rope ladder"
 - id: 34479
 - id: 34480
 - id: 34481
-  examine: "It's a Bluebells"
 - id: 34482
-  examine: "It's a Bluebells"
 - id: 34483
-  examine: "It's a Marigold"
 - id: 34484
-  examine: "It's a Marigold"
 - id: 34485
-  examine: "It's a Roses"
 - id: 34486
-  examine: "It's a Tree"
 - id: 34487
-  examine: "It's a Tree"
 - id: 34488
-  examine: "It's a Tree"
 - id: 34489
-  examine: "It's a Tree"
 - id: 34490
 - id: 34491
 - id: 34492
@@ -53504,45 +44008,25 @@
 - id: 34495
 - id: 34496
 - id: 34497
-  examine: "It's a Tall Reeds"
 - id: 34498
-  examine: "It's a Statue"
 - id: 34499
-  examine: "It's a Cave"
 - id: 34500
-  examine: "It's a Chicken coop"
 - id: 34501
-  examine: "It's a Bed"
 - id: 34502
-  examine: "It's a Staircase"
 - id: 34503
-  examine: "It's a Staircase"
 - id: 34504
-  examine: "It's a Crate"
 - id: 34505
-  examine: "It's a Shelves"
 - id: 34506
-  examine: "It's a Shelves"
 - id: 34507
-  examine: "It's a Shelves"
 - id: 34508
-  examine: "It's a Crate"
 - id: 34509
-  examine: "It's a Crate"
 - id: 34510
-  examine: "It's a Crate"
 - id: 34511
-  examine: "It's a Chemical pool"
 - id: 34512
-  examine: "It's a Chemical pool"
 - id: 34513
-  examine: "It's a Elevator controls"
 - id: 34514
-  examine: "It's a Cave exit"
 - id: 34515
-  examine: "It's a Lava gap"
 - id: 34516
-  examine: "It's a Tunnel"
 - id: 34517
 - id: 34518
 - id: 34519
@@ -53557,9 +44041,7 @@
 - id: 34528
 - id: 34529
 - id: 34530
-  examine: "It's a Steps"
 - id: 34531
-  examine: "It's a Steps"
 - id: 34532
 - id: 34533
 - id: 34534
@@ -53573,20 +44055,16 @@
 - id: 34542
 - id: 34543
 - id: 34544
-  examine: "It's a Rocks"
 - id: 34545
 - id: 34546
 - id: 34547
 - id: 34548
-  examine: "It's a Rocks"
 - id: 34549
 - id: 34550
 - id: 34551
 - id: 34552
 - id: 34553
-  examine: "It's a Alchemical door"
 - id: 34554
-  examine: "It's a Alchemical door"
 - id: 34555
 - id: 34556
 - id: 34557
@@ -53595,20 +44073,14 @@
 - id: 34560
 - id: 34561
 - id: 34562
-  examine: "It's a Blue chemical"
 - id: 34563
-  examine: "It's a Green chemical"
 - id: 34564
-  examine: "It's a Red chemical"
 - id: 34565
 - id: 34566
 - id: 34567
 - id: 34568
-  examine: "It's a Chemical vent (red)"
 - id: 34569
-  examine: "It's a Chemical vent (green)"
 - id: 34570
-  examine: "It's a Chemical vent (blue)"
 - id: 34571
 - id: 34572
 - id: 34573
@@ -53619,21 +44091,13 @@
 - id: 34578
 - id: 34579
 - id: 34580
-  examine: "It's a Stone chest"
 - id: 34581
-  examine: "It's a Stone chest"
 - id: 34582
-  examine: "It's a Stone chest"
 - id: 34583
-  examine: "It's a Stone chest"
 - id: 34584
-  examine: "It's a Stone chest"
 - id: 34585
-  examine: "It's a Stone chest"
 - id: 34586
-  examine: "It's a Stone chest"
 - id: 34587
-  examine: "It's a Broken machinery"
 - id: 34588
 - id: 34589
 - id: 34590
@@ -53695,74 +44159,46 @@
 - id: 34646
 - id: 34647
 - id: 34648
-  examine: "It's a <col=ff9040>King worm</col>"
 - id: 34649
-  examine: "It's a Machinery"
 - id: 34650
 - id: 34651
 - id: 34652
 - id: 34653
-  examine: "It's a Alchemical Hydra display"
 - id: 34654
-  examine: "It's a Alchemical Topiary"
 - id: 34655
-  examine: "It's a Mysterious pipe"
 - id: 34656
-  examine: "It's a Chemical waste pipe"
 - id: 34657
 - id: 34658
 - id: 34659
-  examine: "It's a The Sheared Ram"
 - id: 34660
-  examine: "It's a Brimstone chest"
 - id: 34661
-  examine: "It's a Brimstone chest"
 - id: 34662
 - id: 34663
-  examine: "It's a Rubble"
 - id: 34664
-  examine: "It's a Rubble"
 - id: 34665
-  examine: "It's a Rubble"
 - id: 34666
-  examine: "It's a Rubble"
 - id: 34667
-  examine: "It's a Gangplank"
 - id: 34668
-  examine: "It's a Gangplank"
 - id: 34669
-  examine: "It's a Gangplank"
 - id: 34670
-  examine: "It's a Gangplank"
 - id: 34671
-  examine: "It's a Gangplank"
 - id: 34672
-  examine: "It's a Gangplank"
 - id: 34673
 - id: 34674
 - id: 34675
 - id: 34676
 - id: 34677
-  examine: "It's a Verzik Vitur display"
 - id: 34678
 - id: 34679
 - id: 34680
 - id: 34681
-  examine: "It's a Making Friends with My Arm display"
 - id: 34682
-  examine: "It's a Fire"
 - id: 34683
-  examine: "It's a Magic Mirror"
 - id: 34684
-  examine: "It's a Alchemical Hydra display"
 - id: 34685
-  examine: "It's a Attas plant display"
 - id: 34686
-  examine: "It's a Leather shields"
 - id: 34687
-  examine: "It's a Bryophyta display"
 - id: 34688
-  examine: "It's a Banner"
 - id: 34689
 - id: 34690
 - id: 34691
@@ -54626,13 +45062,9 @@
 - id: 35547
 - id: 35548
 - id: 35549
-  examine: "The toll gate from Lumbridge to Al Kharid."
 - id: 35550
-  examine: "The toll gate from Lumbridge to Al Kharid."
 - id: 35551
-  examine: "The toll gate from Lumbridge to Al Kharid."
 - id: 35552
-  examine: "The toll gate from Lumbridge to Al Kharid."
 - id: 35553
 - id: 35554
 - id: 35555


### PR DESCRIPTION
## What has been done?

Most object examine messages were incorrect. For example, the examine message for the ID 2647 was "A picture of a fruit bowl." However, the ID 2647 matches to the door of the Crafting Guild. Now, the message for the ID 2647 is "The door to the Crafting Guild." From what I understand, the old examine messages were from OSRS and a lot of the object IDs do not match those from the revision 667 of RS. The new examine messages are from a revision 377 cache, which is the last RS revision that I could find that included them locally in the cache. After that, they were server-sided only and nobody seems to have a dump of them, at least publicly. For this reason, I used a revision 377 cache which contains the examine messages for the IDs 0 - 14973. This explains why I also removed all examine messages after this ID, as they were from OSRS and therefore probably mostly incorrect. If the maintainers of the project prefer to keep the examine messages after the ID 14973, please let me know.