### PR TITLE
feat: added advanced gnome agility course stage attribute

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
@@ -49,6 +49,10 @@ val FACING_PAWN_ATTR = AttributeKey<WeakReference<Pawn>>()
  */
 val GNOME_AGILITY_STAGE = AttributeKey<Int>()
 
+/**
+ * The gnome agility stage
+ */
+val ADVANCED_GNOME_AGILITY_STAGE = AttributeKey<Int>()
 
 /**
  * An [Npc] that has us as their [FACING_PAWN_ATTR].


### PR DESCRIPTION
## What has been done?
- added missing stafe attribute for advanced gnome agility course.