### PR TITLE
fix: allow dungeoneering to have a target level above 99

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/skillguides/skill_guides.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/skillguides/skill_guides.plugin.kts
@@ -92,11 +92,16 @@ fun setTarget(player: Player, guide: SkillGuide, usingLevel: Boolean) {
 
 fun canSetTarget(player: Player, skillId: Int, value: Int, usingLevel: Boolean): Boolean {
     if (usingLevel) {
-        if (value > SkillSet.MAX_LVL) {
+        if (value > SkillSet.MAX_LVL && skillId != Skills.DUNGEONEERING) {
             player.queue {
                 messageBox("You cannot set a level target higher than 99.")
             }
             return false
+        }
+        else if (value > SkillSet.MAX_LVL_DUNGEONEERING) {
+            player.queue {
+                messageBox("You cannot set a level target higher than 120.")
+            }
         }
         if (value <= player.skills.getMaxLevel(skillId)) {
             player.queue {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/skillguides/skill_guides.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/skillguides/skill_guides.plugin.kts
@@ -102,6 +102,7 @@ fun canSetTarget(player: Player, skillId: Int, value: Int, usingLevel: Boolean):
             player.queue {
                 messageBox("You cannot set a level target higher than 120.")
             }
+            return false
         }
         if (value <= player.skills.getMaxLevel(skillId)) {
             player.queue {

--- a/game/src/main/kotlin/gg/rsmod/game/model/skill/SkillSet.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/skill/SkillSet.kt
@@ -205,9 +205,14 @@ class SkillSet(val maxSkills: Int) {
         const val MAX_XP = 200_000_000
 
         /**
-         * The maximum level a skill can reach.
+         * The maximum level a skill (except Dungeoneering) can reach.
          */
         const val MAX_LVL = 99
+
+        /**
+         * The maximum level the Dungeoneering skill can reach
+         */
+        const val MAX_LVL_DUNGEONEERING = 120
 
         /**
          * The default amount of trainable skills by players.


### PR DESCRIPTION
## What has been done?
Attempting to set a target level for dungeoneering over level 99 would result in a message saying you cannot do so. This PR fixes that and allows a target level of up to 120.

- Add `SkillSet.MAX_LVL_DUNGEONEERING = 120`
- Update skill guides plugin `canSetTarget()` logic to account for dungeoneering's max level

## Has your code been documented?
Yes, where needed