### PR TITLE
feat: slayer rewards shop and drill demon random event adjustment

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_14415.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_14415.plugin.kts
@@ -32,12 +32,12 @@ spawn_npc(npc = Npcs.ROCK_CRITTER, x = 3630, z = 5089, walkRadius = 5, direction
 
 spawn_npc(npc = Npcs.ROCK_CRITTER, x = 3645, z = 5090, walkRadius = 5, direction = Direction.NORTH_EAST)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3633, z = 5081, direction = Direction.SOUTH)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3633, z = 5081, direction = Direction.SOUTH, static = true)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3629, z = 5083, direction = Direction.SOUTH)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3629, z = 5083, direction = Direction.SOUTH, static = true)
 
-spawn_npc(npc = Npcs.ROCKTAIL_SHOAL, x = 3616, z = 5088, direction = Direction.SOUTH)
+spawn_npc(npc = Npcs.ROCKTAIL_SHOAL, x = 3616, z = 5088, direction = Direction.SOUTH, static = true)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3614, z = 5111, direction = Direction.SOUTH)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3614, z = 5111, direction = Direction.SOUTH, static = true)
 
-spawn_npc(npc = Npcs.ROCKTAIL_SHOAL, x = 3645, z = 5082, direction = Direction.EAST)
+spawn_npc(npc = Npcs.ROCKTAIL_SHOAL, x = 3645, z = 5082, direction = Direction.EAST, static = true)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_14416.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_14416.plugin.kts
@@ -16,14 +16,14 @@ spawn_npc(npc = Npcs.ROCK_CRITTER, x = 3643, z = 5142, walkRadius = 5, direction
 
 spawn_npc(npc = Npcs.ROCK_CRITTER, x = 3628, z = 5122, walkRadius = 5, direction = Direction.NORTH_EAST)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3616, z = 5120, direction = Direction.NORTH)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3616, z = 5120, direction = Direction.NORTH, static = true)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3615, z = 5127, direction = Direction.NORTH)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3615, z = 5127, direction = Direction.NORTH, static = true)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3621, z = 5130, direction = Direction.EAST)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3621, z = 5130, direction = Direction.EAST, static = true)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3625, z = 5129, direction = Direction.NORTH_EAST)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3625, z = 5129, direction = Direction.NORTH_EAST, static = true)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3637, z = 5138, direction = Direction.WEST)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3637, z = 5138, direction = Direction.WEST, static = true)
 
-spawn_npc(npc = Npcs.ROCKTAIL_SHOAL, x = 3632, z = 5146, direction = Direction.SOUTH)
+spawn_npc(npc = Npcs.ROCKTAIL_SHOAL, x = 3632, z = 5146, direction = Direction.SOUTH, static = true)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_14671.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_14671.plugin.kts
@@ -34,8 +34,8 @@ spawn_npc(npc = Npcs.ROCK_CRITTER, x = 3670, z = 5090, walkRadius = 5, direction
 
 spawn_npc(npc = Npcs.ROCK_CRITTER, x = 3678, z = 5101, walkRadius = 5, direction = Direction.WEST)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3653, z = 5085, direction = Direction.SOUTH)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3653, z = 5085, direction = Direction.SOUTH, static = true)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3674, z = 5115, direction = Direction.NORTH)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3674, z = 5115, direction = Direction.NORTH, static = true)
 
-spawn_npc(npc = Npcs.ROCKTAIL_SHOAL, x = 3684, z = 5109, direction = Direction.EAST)
+spawn_npc(npc = Npcs.ROCKTAIL_SHOAL, x = 3684, z = 5109, direction = Direction.EAST, static = true)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_14672.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_14672.plugin.kts
@@ -46,10 +46,10 @@ spawn_npc(npc = Npcs.ROCK_CRITTER, x = 3669, z = 5150, walkRadius = 5, direction
 
 spawn_npc(npc = Npcs.ROCK_CRITTER, x = 3653, z = 5136, walkRadius = 5, direction = Direction.SOUTH_WEST)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3652, z = 5146, direction = Direction.EAST)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3652, z = 5146, direction = Direction.EAST, static = true)
 
-spawn_npc(npc = Npcs.ROCKTAIL_SHOAL, x = 3652, z = 5140, direction = Direction.SOUTH)
+spawn_npc(npc = Npcs.ROCKTAIL_SHOAL, x = 3652, z = 5140, direction = Direction.SOUTH, static = true)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3658, z = 5144, direction = Direction.EAST)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3658, z = 5144, direction = Direction.EAST, static = true)
 
-spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3696, z = 5141, direction = Direction.EAST)
+spawn_npc(npc = Npcs.CAVEFISH_SHOAL, x = 3696, z = 5141, direction = Direction.EAST, static = true)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -117,6 +117,21 @@ on_command("addloyalty", Privilege.ADMIN_POWER) {
     }
 }
 
+on_command("addslayerpoints", Privilege.ADMIN_POWER) {
+    val args = player.getCommandArgs()
+    tryWithUsage(
+        player,
+        args,
+        "Invalid format! Example of proper command <col=42C66C>::addslayerpoints alycia 1</col>"
+    ) { values ->
+        val p = world.getPlayerForName(values[0].replace("_", " ")) ?: return@tryWithUsage
+        val amount = if (values.size > 1) Math.min(Int.MAX_VALUE.toLong(), values[1].parseAmount()).toInt() else 1
+        p.addSlayerPoints(amount)
+        p.message("You have been given ${Misc.formatWithIndefiniteArticle("slayer point", amount)}.")
+    }
+}
+
+
 on_command("damage", Privilege.ADMIN_POWER) {
     val args = player.getCommandArgs()
     tryWithUsage(

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_rewards.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_rewards.plugin.kts
@@ -109,7 +109,6 @@ fun refreshBlockedTasks(player: Player) {
             // If there's a blocked task for this slot, display its identifier
             blockedTasks[slot].identifier
         } else {
-            // Otherwise, display "Slot X" where X is the slot number starting from 1
             "Empty"
         }
         player.setComponentText(ASSIGNMENT_INTERFACE, component = textComponentId, text = taskText)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_rewards.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_rewards.plugin.kts
@@ -110,7 +110,7 @@ fun refreshBlockedTasks(player: Player) {
             blockedTasks[slot].identifier
         } else {
             // Otherwise, display "Slot X" where X is the slot number starting from 1
-            "Slot ${slot + 1}"
+            "Empty"
         }
         player.setComponentText(ASSIGNMENT_INTERFACE, component = textComponentId, text = taskText)
     }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_rewards.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_rewards.plugin.kts
@@ -16,7 +16,7 @@ val ASSIGNMENT_INTERFACE = 161
 val masters = arrayOf(Npcs.TURAEL, Npcs.VANNAKA, Npcs.MAZCHNA)
 
 /**
- * Initializes rewards shop  option for the slayer masters.
+ * Initializes rewards shop option for the slayer masters.
  */
 masters.forEach {
     on_npc_option(npc = it, option = "rewards") {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_shop.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_shop.plugin.kts
@@ -4,6 +4,10 @@ import gg.rsmod.game.model.attr.*
 import gg.rsmod.plugins.content.skills.slayer.getSlayerAssignment
 import gg.rsmod.plugins.content.skills.slayer.removeSlayerAssignment
 
+/**
+ * @author Harley <github.com/HarleyGilpin>
+ */
+
 val BUY_INTERFACE = 164
 val LEARN_INTERFACE = 378
 val ASSIGNMENT_INTERFACE = 161

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_shop.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_shop.plugin.kts
@@ -27,17 +27,13 @@ fun openBuyInterface(p: Player) {
 
 fun openLearnInterface(p: Player) {
     p.openInterface(LEARN_INTERFACE, InterfaceDestination.MAIN_SCREEN)
-//    for (componentId in 1..20) {
-//        p.setComponentText(LEARN_INTERFACE, component = componentId, text = "Test $componentId")
-//    }
-    p.setComponentText(BUY_INTERFACE, component = 18, text = getSlayerPointsText(p))
+    p.setComponentText(LEARN_INTERFACE, component = 79, text = getSlayerPointsText(p))
     updateLearnedComponents(p)
 }
 
-
 fun openAssignmentInterface(p: Player) {
     p.openInterface(ASSIGNMENT_INTERFACE, InterfaceDestination.MAIN_SCREEN)
-    p.setComponentText(BUY_INTERFACE, component = 19, text = getSlayerPointsText(p))
+    p.setComponentText(ASSIGNMENT_INTERFACE, component = 19, text = getSlayerPointsText(p))
     refreshBlockedTasks(p)
 
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_shop.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_shop.plugin.kts
@@ -1,6 +1,8 @@
 package gg.rsmod.plugins.content.inter.slayer
 
 import gg.rsmod.game.model.attr.*
+import gg.rsmod.plugins.content.skills.slayer.getSlayerAssignment
+import gg.rsmod.plugins.content.skills.slayer.removeSlayerAssignment
 
 val BUY_INTERFACE = 164
 val LEARN_INTERFACE = 378
@@ -33,9 +35,19 @@ fun openLearnInterface(p: Player) {
 
 fun openAssignmentInterface(p: Player) {
     p.openInterface(ASSIGNMENT_INTERFACE, InterfaceDestination.MAIN_SCREEN)
-    p.setComponentText(ASSIGNMENT_INTERFACE, component = 19, text = getSlayerPointsText(p))
+    p.setComponentText(ASSIGNMENT_INTERFACE, component = 19, text = getSlayerPointsText(p).format())
     refreshBlockedTasks(p)
 
+}
+
+fun refreshPoints(player: Player, interfaceId: Int) {
+    val slayerPoints = getSlayerPointsText(player)
+    when (interfaceId) {
+        BUY_INTERFACE -> player.setComponentText(BUY_INTERFACE, component = 20, text = slayerPoints)
+        LEARN_INTERFACE -> player.setComponentText(LEARN_INTERFACE, component = 79, text = slayerPoints)
+        ASSIGNMENT_INTERFACE -> player.setComponentText(ASSIGNMENT_INTERFACE, component = 19, text = slayerPoints)
+        else -> {} // No default action
+    }
 }
 
 /**
@@ -45,7 +57,29 @@ fun getSlayerPointsText(player: Player): String =
     player.attr[SLAYER_POINTS]?.format() ?: "0"
 
 fun refreshBlockedTasks(p: Player) {
-    //TODO: Add block tasks text for assignment Interface
+    if(p.attr.has(SLAYER_ASSIGNMENT)) {
+        p.setComponentText(
+            ASSIGNMENT_INTERFACE,
+            component = 23,
+            text = "Cancel task of ${p.getSlayerAssignment()!!.identifier}"
+        )
+        p.setComponentText(
+            ASSIGNMENT_INTERFACE,
+            component = 24,
+            text = "Never assign ${p.getSlayerAssignment()!!.identifier} again"
+        )
+    } else {
+        p.setComponentText(
+            ASSIGNMENT_INTERFACE,
+            component = 23,
+            text = "Reassign current mission"
+        )
+        p.setComponentText(
+            ASSIGNMENT_INTERFACE,
+            component = 24,
+            text = "Permanently remove current"
+        )
+    }
 }
 
 fun updateLearnedComponents(player: Player) {
@@ -63,70 +97,197 @@ fun updateLearnedComponents(player: Player) {
     }
 }
 
+
 /**
- * Buy IF buttons
+ * Slayer Point Shop Interface: Buy Tab
  */
 
-val buyButtonIds = arrayOf(16, 17, 32, 33, 34, 35, 36)
+val buyButtonIds = arrayOf(16, 17, 24, 26, 28, 32, 33, 34, 35, 36, 37, 39 )
 
-buyButtonIds.forEach {
-    on_button(BUY_INTERFACE, component = it) {
-        when(it) {
-            16 -> openLearnInterface(player)
-            17 -> openAssignmentInterface(player)
-            /**
-            32 -> TODO: Buy Slayer XP
-            33 -> TODO: Ring of slaying
-            34 -> TODO: Runes for slayer dart
-            35 -> TODO: Broad bolts
-            36 -> TODO: Broad arrows
-            **/
+val NOT_ENOUGH_SPACE = "Not enough space in your inventory!"
+
+
+buyButtonIds.forEach { buttonId ->
+    on_button(BUY_INTERFACE, component = buttonId) {
+        handleBuyInterface(player, buttonId)
+    }
+}
+
+fun handleBuyInterface(player: Player, buttonId: Int) {
+    when (buttonId) {
+        16 -> openLearnInterface(player)
+        17 -> openAssignmentInterface(player)
+        24, 32 -> handleSlayerXpPurchase(player)
+        26, 33 -> handleRingOfSlayingPurchase(player)
+        28, 36 -> handleSlayerDartRunesPurchase(player)
+        37, 34 -> handleBroadBoltsPurchase(player)
+        39, 35 -> handleBroadArrowsPurchase(player)
+    }
+}
+
+fun handleSlayerXpPurchase(player: Player) {
+    if (player.getSlayerPointsCount() >= 400) {
+        player.addXp(Skills.SLAYER, 10_000.00) // Slayer XP
+        player.subtractSlayerPoints(400)
+        refreshPoints(player, BUY_INTERFACE)
+    } else {
+        player.message("You need 400 points for 10,000 Slayer experience.")
+    }
+}
+
+fun handleRingOfSlayingPurchase(player: Player) {
+    if (player.getSlayerPointsCount() < 75) {
+        player.message("You need 75 points for Ring of Slaying (8).")
+        return
+    }
+    if (player.inventory.hasSpace && player.getSlayerPointsCount() >= 75) {
+        player.inventory.add(Items.RING_OF_SLAYING_8, 1)
+        player.subtractSlayerPoints(75)
+        refreshPoints(player, BUY_INTERFACE)
+    } else {
+        player.message(NOT_ENOUGH_SPACE)
+    }
+}
+
+fun handleSlayerDartRunesPurchase(player: Player) {
+    if (player.getSlayerPointsCount() < 35) {
+        player.message("You need 35 points for 250 slayer dart runes.")
+        return
+    }
+    if (player.inventory.freeSlotCount < 2) {
+        player.message(NOT_ENOUGH_SPACE)
+        return
+    }
+    if (player.getSlayerPointsCount() >= 35 && player.inventory.freeSlotCount >= 2) {
+        player.inventory.add(Items.MIND_RUNE, 1000)
+        player.inventory.add(Items.DEATH_RUNE, 250)
+        player.subtractSlayerPoints(35)
+        refreshPoints(player, BUY_INTERFACE)
+    }
+}
+
+fun handleBroadBoltsPurchase(player: Player) {
+    if (player.getSlayerPointsCount() < 35) {
+        player.message("You need 35 points for 250 broad bolts")
+        return
+    }
+    if (player.inventory.hasSpace && player.getSlayerPointsCount() >= 35) {
+        player.inventory.add(Items.BROADTIPPED_BOLTS, 250)
+        player.subtractSlayerPoints(35)
+        refreshPoints(player, BUY_INTERFACE)
+    } else {
+        player.message(NOT_ENOUGH_SPACE)
+    }
+}
+
+
+fun handleBroadArrowsPurchase(player: Player) {
+    if (player.getSlayerPointsCount() < 35) {
+        player.message("You need 35 points for 250 broad arrows")
+        return
+    }
+    if (player.inventory.hasSpace && player.getSlayerPointsCount() >= 35) {
+        player.inventory.add(Items.BROAD_ARROW, 250)
+        player.subtractSlayerPoints(35)
+        refreshPoints(player, BUY_INTERFACE)
+    } else {
+        player.message(NOT_ENOUGH_SPACE)
+    }
+}
+
+/**
+ * Slayer Point Shop Interface: Learn Tab
+ */
+
+data class Ability(val id: Int, val cost: Int, val attribute: AttributeKey<Boolean>)
+
+on_button(LEARN_INTERFACE, 14) {
+    openAssignmentInterface(player)
+}
+
+on_button(LEARN_INTERFACE, 15) {
+    openBuyInterface(player)
+}
+
+val abilities = mapOf(
+    73 to Ability(73, 50, AQUANTIES),
+    74 to Ability(74, 400, QUICK_BLOWS),
+    75 to Ability(75, 2000, ICE_STRYKER_NO_CAPE),
+    76 to Ability(76, 300, BROAD_FLETCHING),
+    77 to Ability(77, 300, CRAFT_ROS),
+    78 to Ability(78, 400, SLAYER_HELM_CREATION),
+)
+
+val learnButtonIds = abilities.keys.toIntArray()
+
+learnButtonIds.forEach { buttonId ->
+    on_button(LEARN_INTERFACE, component = buttonId) {
+        abilities[buttonId]?.let { ability ->
+            purchaseAbility(player, ability.cost, ability.attribute)
         }
     }
 }
 
 /**
- * Learn IF buttons
+ * Handles the purchasing of an ability, given its cost and attribute key.
  */
 
-val learnButtonIds = arrayOf(14, 15, 73, 74, 75, 76, 77, 78)
-
-learnButtonIds.forEach {
-    on_button(LEARN_INTERFACE, component = it) {
-        when(it) {
-            14 -> openAssignmentInterface(player)
-            15 -> openBuyInterface(player)
-            /**
-            73 -> TODO: Aquanites
-            74 -> TODO: Quick blow
-            75 -> TODO: Ice Strykerwyrm technique
-            76 -> TODO: Broad bolts
-            77 -> TODO: ROS
-            78 -> TODO: Slayer Helm
-             **/
-        }
+fun purchaseAbility(player: Player, abilityCost: Int, abilityAttribute: AttributeKey<Boolean>) {
+    if (player.hasAbility(abilityAttribute)) {
+        player.message("You have already learned this ability.")
+        return
     }
+
+    if (!player.canAffordAbility(abilityCost)) {
+        player.message("You need $abilityCost points to learn this ability.")
+        return
+    }
+
+    player.learnAbility(abilityCost, abilityAttribute)
+}
+
+fun Player.hasAbility(abilityAttribute: AttributeKey<Boolean>) =
+    attr.has(abilityAttribute)
+
+fun Player.canAffordAbility(abilityCost: Int) =
+    getSlayerPointsCount() >= abilityCost
+
+fun Player.learnAbility(abilityCost: Int, abilityAttribute: AttributeKey<Boolean>) {
+    subtractSlayerPoints(abilityCost)
+    attr[abilityAttribute] = true
+    refreshPoints(this, LEARN_INTERFACE)
+    message("You have successfully learned the new ability!")
+    updateLearnedComponents(this)
 }
 
 /**
- * Learn IF buttons
+ * Slayer Point Shop Interface: Assignment Tab
  */
 
-val assignmentButtonIds = arrayOf(14, 15, 73, 74, 75, 76, 77, 78)
+val assignmentButtonIds = arrayOf(14, 15, 23, 26)
 
 assignmentButtonIds.forEach {
     on_button(ASSIGNMENT_INTERFACE, component = it) {
         when(it) {
             14 -> openLearnInterface(player)
             15 -> openBuyInterface(player)
-            /**
-            73 -> TODO: Aquanites
-            74 -> TODO: Quick blow
-            75 -> TODO: Ice Strykerwyrm technique
-            76 -> TODO: Broad bolts
-            77 -> TODO: ROS
-            78 -> TODO: Slayer Helm
-             **/
+            23, 26 -> cancelSlayerTask(player)
         }
     }
+}
+
+fun cancelSlayerTask(player: Player) {
+    if (player.getSlayerPointsCount() < 30) {
+        player.message("You need 30 points to cancel your current mission.")
+        return
+    }
+    if (player.getSlayerPointsCount() >= 30 && player.attr.has(SLAYER_ASSIGNMENT)) {
+        player.removeSlayerAssignment()
+        player.subtractSlayerPoints(30)
+        refreshPoints(player, ASSIGNMENT_INTERFACE)
+        refreshBlockedTasks(player)
+    } else {
+        player.message("You must have a slayer task assigned to cancel it.")
+    }
+
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_shop.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/inter/slayer/slayer_shop.plugin.kts
@@ -1,0 +1,136 @@
+package gg.rsmod.plugins.content.inter.slayer
+
+import gg.rsmod.game.model.attr.*
+
+val BUY_INTERFACE = 164
+val LEARN_INTERFACE = 378
+val ASSIGNMENT_INTERFACE = 161
+
+val masters = arrayOf(Npcs.TURAEL, Npcs.VANNAKA, Npcs.MAZCHNA)
+
+/**
+ * Initializes rewards shop  option for the slayer masters.
+ */
+masters.forEach {
+    on_npc_option(npc = it, option = "rewards") {
+        openBuyInterface(player)
+    }
+}
+
+/**
+ * Slayer Points Shop Interface
+ */
+fun openBuyInterface(p: Player) {
+    p.openInterface(BUY_INTERFACE, InterfaceDestination.MAIN_SCREEN)
+    p.setComponentText(BUY_INTERFACE, component = 20, text = getSlayerPointsText(p))
+}
+
+fun openLearnInterface(p: Player) {
+    p.openInterface(LEARN_INTERFACE, InterfaceDestination.MAIN_SCREEN)
+//    for (componentId in 1..20) {
+//        p.setComponentText(LEARN_INTERFACE, component = componentId, text = "Test $componentId")
+//    }
+    p.setComponentText(BUY_INTERFACE, component = 18, text = getSlayerPointsText(p))
+    updateLearnedComponents(p)
+}
+
+
+fun openAssignmentInterface(p: Player) {
+    p.openInterface(ASSIGNMENT_INTERFACE, InterfaceDestination.MAIN_SCREEN)
+    p.setComponentText(BUY_INTERFACE, component = 19, text = getSlayerPointsText(p))
+    refreshBlockedTasks(p)
+
+}
+
+/**
+ * Get players slayer points as string value.
+ */
+fun getSlayerPointsText(player: Player): String =
+    player.attr[SLAYER_POINTS]?.format() ?: "0"
+
+fun refreshBlockedTasks(p: Player) {
+    //TODO: Add block tasks text for assignment Interface
+}
+
+fun updateLearnedComponents(player: Player) {
+    listOf(
+        BROAD_FLETCHING to 90,
+        AQUANTIES to 91,
+        QUICK_BLOWS to 97,
+        ICE_STRYKER_NO_CAPE to 98,
+        CRAFT_ROS to 99,
+        SLAYER_HELM_CREATION to 100
+    ).forEach { (attribute, component) ->
+        if (player.attr.has(attribute)) {
+            player.setComponentText(LEARN_INTERFACE, component = component, text = "Learned")
+        }
+    }
+}
+
+/**
+ * Buy IF buttons
+ */
+
+val buyButtonIds = arrayOf(16, 17, 32, 33, 34, 35, 36)
+
+buyButtonIds.forEach {
+    on_button(BUY_INTERFACE, component = it) {
+        when(it) {
+            16 -> openLearnInterface(player)
+            17 -> openAssignmentInterface(player)
+            /**
+            32 -> TODO: Buy Slayer XP
+            33 -> TODO: Ring of slaying
+            34 -> TODO: Runes for slayer dart
+            35 -> TODO: Broad bolts
+            36 -> TODO: Broad arrows
+            **/
+        }
+    }
+}
+
+/**
+ * Learn IF buttons
+ */
+
+val learnButtonIds = arrayOf(14, 15, 73, 74, 75, 76, 77, 78)
+
+learnButtonIds.forEach {
+    on_button(LEARN_INTERFACE, component = it) {
+        when(it) {
+            14 -> openAssignmentInterface(player)
+            15 -> openBuyInterface(player)
+            /**
+            73 -> TODO: Aquanites
+            74 -> TODO: Quick blow
+            75 -> TODO: Ice Strykerwyrm technique
+            76 -> TODO: Broad bolts
+            77 -> TODO: ROS
+            78 -> TODO: Slayer Helm
+             **/
+        }
+    }
+}
+
+/**
+ * Learn IF buttons
+ */
+
+val assignmentButtonIds = arrayOf(14, 15, 73, 74, 75, 76, 77, 78)
+
+assignmentButtonIds.forEach {
+    on_button(ASSIGNMENT_INTERFACE, component = it) {
+        when(it) {
+            14 -> openLearnInterface(player)
+            15 -> openBuyInterface(player)
+            /**
+            73 -> TODO: Aquanites
+            74 -> TODO: Quick blow
+            75 -> TODO: Ice Strykerwyrm technique
+            76 -> TODO: Broad bolts
+            77 -> TODO: ROS
+            78 -> TODO: Slayer Helm
+             **/
+        }
+    }
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/prayer/Prayers.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/prayer/Prayers.kt
@@ -112,7 +112,7 @@ object Prayers {
         }
     }
 
-    public fun deactivate(p: Player, prayer: Prayer) {
+    fun deactivate(p: Player, prayer: Prayer) {
         if (isActive(p, prayer)) {
             p.setVarbit(prayer.varbit, 0)
             p.playSound(DEACTIVATE_PRAYER_SOUND)
@@ -142,7 +142,6 @@ object Prayers {
         }
         p.attr.put(PRAYER_DRAIN_COUNTER, prayerDrainCounter)
 
-        // Check if prayer skill level is 0 and not just the prayer points
         if (p.getVarp(PRAYER_POINTS_VARP) == 0) {
             deactivateAll(p)
             p.message("You have run out of prayer points, you can recharge at an altar.")

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/prayer/Prayers.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/prayer/Prayers.kt
@@ -238,6 +238,8 @@ object Prayers {
             return false
         }
 
+        //TODO: Add requirement back after adding King's Ransom quest.
+        /**
         if (prayer == Prayer.CHIVALRY && p.getVarbit(KING_RANSOMS_QUEST_VARBIT) < 8) {
             p.syncVarp(ACTIVE_PRAYERS_VARP)
             it.messageBox("You have not unlocked this prayer.")
@@ -261,6 +263,7 @@ object Prayers {
             it.messageBox("You have not unlocked this prayer.")
             return false
         }
+        **/
 
         return true
     }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/random_event_handler.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/randoms/random_event_handler.plugin.kts
@@ -75,8 +75,13 @@ on_timer(ANTI_CHEAT_TIMER) {
 
 on_logout {
     if(player.tile.regionId == 12619 || player.attr[ANTI_CHEAT_EVENT_ACTIVE] == true) {
+        val lastKnownPosition: Tile? = player.attr[LAST_KNOWN_POSITION]
         player.timers.remove(LOGOUT_TIMER)
-        player.moveTo(3222, 3222, 0)
+        if (lastKnownPosition != null) {
+            player.moveTo(lastKnownPosition)
+        } else {
+            player.moveTo(3222, 3222, 0)
+        }
         player.attr[ANTI_CHEAT_EVENT_ACTIVE] = false
         player.attr[BOTTING_SCORE] = (player.attr[BOTTING_SCORE] ?: 0) + 1
     }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/fishing/fishing.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/fishing/fishing.plugin.kts
@@ -8,12 +8,25 @@ FishingSpot.values().forEach { spot ->
                 val fishingSpot = player.getInteractingNpc()
                 player.queue {
                     var attempts = 0
-                    while (player.tile.getDistance(fishingSpot.tile) > 1) {
+                    // If the spot is a Rocktail shoal, check all four tiles
+                    val isRocktailShoal = fishingSpot.id == Npcs.ROCKTAIL_SHOAL
+                    val tilesToCheck = if (isRocktailShoal) {
+                        listOf(
+                            fishingSpot.tile, // Assuming this is the bottom-left tile
+                            fishingSpot.tile.transform(1, 0), // Bottom-right tile
+                            fishingSpot.tile.transform(0, 1), // Top-left tile
+                            fishingSpot.tile.transform(1, 1)  // Top-right tile
+                        )
+                    } else {
+                        listOf(fishingSpot.tile) // For other spots, just check the NPC's tile
+                    }
+
+                    while (tilesToCheck.none { player.tile.getDistance(it) <= 1 }) {
                         if (attempts++ >= 10) {
                             player.message(Entity.YOU_CANT_REACH_THAT)
                             return@queue
                         }
-                        wait(1) // This should be an appropriate delay function in your context
+                        wait(1)
                     }
                     Fishing.fish(this, fishingSpot, tool)
                 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/SlayerExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/SlayerExt.kt
@@ -1,12 +1,17 @@
 package gg.rsmod.plugins.content.skills.slayer
 
+import gg.rsmod.game.model.attr.CONSECUTIVE_SLAYER_TASKS
 import gg.rsmod.game.model.attr.SLAYER_AMOUNT
 import gg.rsmod.game.model.attr.SLAYER_ASSIGNMENT
+import gg.rsmod.game.model.attr.SLAYER_MASTER
 import gg.rsmod.game.model.combat.SlayerAssignment
 import gg.rsmod.game.model.entity.Npc
 import gg.rsmod.game.model.entity.Player
 import gg.rsmod.plugins.api.Skills
 import gg.rsmod.plugins.api.ext.message
+import gg.rsmod.plugins.api.ext.playJingle
+import gg.rsmod.plugins.content.skills.slayer.data.SlayerMaster
+
 
 /**
  * @author Alycia <https://github.com/alycii>
@@ -40,7 +45,47 @@ fun Player.handleDecrease(npc: Npc) {
         attr.put(SLAYER_AMOUNT, amount - 1)
     }
     if (attr.getOrDefault(SLAYER_AMOUNT, 0) <= 0) {
-        message("You've completed your slayer task; return to a Slayer master.")
+        // Increment the consecutive slayer tasks counter
+        val consecutiveTasks = attr.getOrDefault(CONSECUTIVE_SLAYER_TASKS, 0) + 1
+        attr.put(CONSECUTIVE_SLAYER_TASKS, consecutiveTasks)
+
+        // Retrieve the slayer master id from player's attributes
+        val slayerMasterId = attr.getOrDefault(SLAYER_MASTER, 0)
+
+        // Check that the master exists for the given id
+        val getMaster = SlayerMaster.getMaster(slayerMasterId)
+        if (getMaster != null) {
+            // Determine the amount of slayer points to award
+            val pointsAmount = when {
+                consecutiveTasks % 50 == 0 -> getMaster.getPoints50()
+                consecutiveTasks % 10 == 0 -> getMaster.getPoints10()
+                else -> getMaster.getPoints()
+            }
+
+            // Add the slayer points to the player
+            addSlayerPoints(pointsAmount)
+
+            // Send messages to the player
+            message("You have completed $consecutiveTasks tasks in a row and receive $pointsAmount slayer points!")
+            message("You've completed your slayer task; return to a Slayer master.")
+        } else {
+            message("Slayer master not found for id $slayerMasterId")
+        }
+        playJingle(61)
         attr.remove(SLAYER_ASSIGNMENT, SLAYER_AMOUNT)
+    }
+}
+
+/**
+ * Removes the current slayer task from the player by deleting the slayer assignment
+ * and slayer amount attributes. If the player has no slayer task, no action is taken.
+ */
+fun Player.removeSlayerAssignment() {
+    if (attr.has(SLAYER_ASSIGNMENT)) {
+        message("Your slayer assignment has been removed.")
+        attr.remove(SLAYER_ASSIGNMENT)
+    }
+    if (attr.has(SLAYER_AMOUNT)) {
+        attr.remove(SLAYER_AMOUNT)
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
@@ -47,9 +47,6 @@ enum class SlayerMaster(
             return SLAYER_MASTERS[id]
         }
 
-        fun getMasterForId(npcId: Int): SlayerMaster? {
-            return values().find { it.id == npcId }
-        }
     }
 
     fun getPoints(): Int {
@@ -66,7 +63,6 @@ enum class SlayerMaster(
 }
 
 // TODO: Note, I only added data for monsters that we currently have definitions for.
-//TODO: We will also need to add weights so some tasks occur more frequently than others.
 val slayerData = SlayerData(
     mapOf(
         SlayerMaster.TURAEL to listOf(
@@ -105,6 +101,7 @@ val slayerData = SlayerData(
             Assignment(assignment = SlayerAssignment.ZOMBIE, weight = 2.82),
         ),
         SlayerMaster.VANNAKA to listOf(
+
             Assignment(
                 assignment = SlayerAssignment.COCKATRICE,
                 requirement = listOf(
@@ -119,6 +116,7 @@ val slayerData = SlayerData(
                 requirement = listOf(
                     QuestPointRequirement(points = Quest.quests.sumOf { it.pointReward })
                 ),
+                amount = 30..60,
                 weight = 2.17
             ),
             Assignment(assignment = SlayerAssignment.HILL_GIANT, weight = 2.17),

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
@@ -20,10 +20,47 @@ data class Assignment(
     val requirement: List<Requirement> = emptyList()
 )
 
-enum class SlayerMaster(val id: Int, val identifier: String, val defaultAmount: IntRange) {
-    TURAEL(Npcs.TURAEL, identifier = "Turael", defaultAmount = 15..50),
-    VANNAKA(Npcs.VANNAKA, identifier = "Vannaka", defaultAmount = 60..120),
-    MAZCHNA(Npcs.MAZCHNA, identifier = "Mazchna", defaultAmount = 40..70),
+enum class SlayerMaster(
+    val id: Int,
+    val identifier: String,
+    val defaultAmount: IntRange,
+    val requiredCombatLevel: Int,
+    val reqSlayerLevel: Int,
+    private val points: Int,
+    private val points10: Int,
+    private val points50: Int
+) {
+    TURAEL(Npcs.TURAEL, "Turael", 15..50, 3, 1, 1, 3, 10),
+    MAZCHNA(Npcs.MAZCHNA, "Mazchna", 40..70, 20, 1, 2, 5, 15),
+    VANNAKA(Npcs.VANNAKA, "Vannaka", 60..120, 40, 1, 4, 20, 60),
+    CHAELDAR(Npcs.CHAELDAR, "Chaeldar", 70..120, 70, 1, 10, 50, 150),
+    SUMONA(Npcs.SUMONA, "Sumona", 120..180, 85, 35, 12, 60, 180),
+    DURADEL(Npcs.DURADEL, "Duradel", 130..200, 100, 50, 15, 75, 225),
+    KURADAL(Npcs.KURADAL, "Kuradal", 150..250, 110, 75, 18, 90, 270);
+
+    companion object {
+        private val SLAYER_MASTERS = values().associateBy(SlayerMaster::id)
+
+        fun getMaster(id: Int): SlayerMaster? {
+            return SLAYER_MASTERS[id]
+        }
+
+        fun getMasterForId(npcId: Int): SlayerMaster? {
+            return values().find { it.id == npcId }
+        }
+    }
+
+    fun getPoints(): Int {
+        return points
+    }
+
+    fun getPoints10(): Int {
+        return points10
+    }
+
+    fun getPoints50(): Int {
+        return points50
+    }
 }
 
 // TODO: Note, I only added data for monsters that we currently have definitions for.

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
@@ -17,7 +17,9 @@ class SlayerData(private val assignmentsByMaster: Map<SlayerMaster, List<Assignm
 data class Assignment(
     val assignment: SlayerAssignment,
     val amount: IntRange = 0..0,
-    val requirement: List<Requirement> = emptyList()
+    val requirement: List<Requirement> = emptyList(),
+    val questRequirement: QuestRequirement? = null,
+    val weight: Double = 1.0
 )
 
 enum class SlayerMaster(
@@ -68,37 +70,39 @@ enum class SlayerMaster(
 val slayerData = SlayerData(
     mapOf(
         SlayerMaster.TURAEL to listOf(
-            //Assignment(assignment = SlayerAssignment.BANSHEE),
-            Assignment(assignment = SlayerAssignment.BAT),
-            Assignment(assignment = SlayerAssignment.BIRD),
-            Assignment(assignment = SlayerAssignment.BEAR),
+            Assignment(assignment = SlayerAssignment.BANSHEE, weight = 8.45),
+            Assignment(assignment = SlayerAssignment.BAT, weight = 2.82),
+            Assignment(assignment = SlayerAssignment.BIRD, weight = 2.82),
+            Assignment(assignment = SlayerAssignment.BEAR, weight = 2.82),
             Assignment(
                 assignment = SlayerAssignment.CAVE_BUG,
                 requirement = listOf(
                     SkillRequirement(skill = Skills.SLAYER, level = 7)
-                )
+                ),
+                weight = 2.82
             ),
             Assignment(
                 assignment = SlayerAssignment.CAVE_SLIME,
                 requirement = listOf(
                     SkillRequirement(skill = Skills.SLAYER, level = 17)
-                )
+                ),
+                weight = 8.45
             ),
-            Assignment(assignment = SlayerAssignment.COW),
-            // Assignment(assignment = SlayerAssignment.CRAWLING_HAND),
-            // Assignment(assignment = SlayerAssignment.DESERT_LIZARD),
-            // Assignment(assignment = SlayerAssignment.DOG),
-            Assignment(assignment = SlayerAssignment.DWARF),
-            Assignment(assignment = SlayerAssignment.GHOST),
-            Assignment(assignment = SlayerAssignment.GOBLIN),
-            // Assignment(assignment = SlayerAssignment.ICEFIEND, amount = 10..20),
-            // Assignment(assignment = SlayerAssignment.MINOTAUR),
-            // Assignment(assignment = SlayerAssignment.MONKEY),
-            Assignment(assignment = SlayerAssignment.SCORPION),
-            Assignment(assignment = SlayerAssignment.SKELETON),
-            Assignment(assignment = SlayerAssignment.SPIDER),
-            Assignment(assignment = SlayerAssignment.WOLF),
-            Assignment(assignment = SlayerAssignment.ZOMBIE),
+            Assignment(assignment = SlayerAssignment.COW, weight = 2.82),
+            Assignment(assignment = SlayerAssignment.CRAWLING_HAND, weight = 8.45),
+            // Assignment(assignment = SlayerAssignment.DESERT_LIZARD, weight = 8.45),
+            // Assignment(assignment = SlayerAssignment.DOG, weight = 4.23),
+            Assignment(assignment = SlayerAssignment.DWARF, weight = 2.82),
+            Assignment(assignment = SlayerAssignment.GHOST, weight = 4.23),
+            Assignment(assignment = SlayerAssignment.GOBLIN, weight = 2.82),
+            Assignment(assignment = SlayerAssignment.ICEFIEND, amount = 10..20, weight = 2.82),
+            Assignment(assignment = SlayerAssignment.MINOTAUR, weight = 2.82),
+            // Assignment(assignment = SlayerAssignment.MONKEY, weight = 2.82),
+            Assignment(assignment = SlayerAssignment.SCORPION, weight = 2.82),
+            Assignment(assignment = SlayerAssignment.SKELETON, weight = 4.23),
+            Assignment(assignment = SlayerAssignment.SPIDER, weight = 2.82),
+            Assignment(assignment = SlayerAssignment.WOLF, weight = 4.23),
+            Assignment(assignment = SlayerAssignment.ZOMBIE, weight = 2.82),
         ),
         SlayerMaster.VANNAKA to listOf(
             Assignment(
@@ -106,27 +110,29 @@ val slayerData = SlayerData(
                 requirement = listOf(
                     SkillRequirement(skill = Skills.SLAYER, level = 25),
                     SkillRequirement(skill = Skills.DEFENCE, level = 20),
-                )
+                ),
+                weight = 2.17
             ),
             // TODO: have this require dragon slayer
             Assignment(
                 assignment = SlayerAssignment.GREEN_DRAGON,
                 requirement = listOf(
                     QuestPointRequirement(points = Quest.quests.sumOf { it.pointReward })
-                )
+                ),
+                weight = 2.17
             ),
-            Assignment(assignment = SlayerAssignment.HILL_GIANT),
-            Assignment(assignment = SlayerAssignment.LESSER_DEMON),
-            Assignment(assignment = SlayerAssignment.MOSS_GIANT),
+            Assignment(assignment = SlayerAssignment.HILL_GIANT, weight = 2.17),
+            Assignment(assignment = SlayerAssignment.LESSER_DEMON, weight = 2.17),
+            Assignment(assignment = SlayerAssignment.MOSS_GIANT, weight = 2.17),
             Assignment(
                 assignment = SlayerAssignment.PYREFIEND,
                 requirement = listOf(
                     SkillRequirement(skill = Skills.SLAYER, level = 30)
-                )
+                ),
+                weight = 2.17
             ),
-            Assignment(assignment = SlayerAssignment.ICE_WARRIOR),
-            Assignment(assignment = SlayerAssignment.ICE_GIANT),
-
+            Assignment(assignment = SlayerAssignment.ICE_WARRIOR, weight = 2.17),
+            Assignment(assignment = SlayerAssignment.ICE_GIANT, weight = 2.17),
             // TODO: these are filler tasks until Morytania is unlocked
             Assignment(assignment = SlayerAssignment.ROCK_SLUG),
             Assignment(

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
@@ -37,8 +37,8 @@ enum class SlayerMaster(
     VANNAKA(Npcs.VANNAKA, "Vannaka", 60..120, 40, 1, 4, 20, 60),
     CHAELDAR(Npcs.CHAELDAR, "Chaeldar", 70..120, 70, 1, 10, 50, 150),
     SUMONA(Npcs.SUMONA, "Sumona", 120..180, 85, 35, 12, 60, 180),
-    DURADEL(Npcs.DURADEL, "Duradel", 130..200, 100, 50, 15, 75, 225),
-    KURADAL(Npcs.KURADAL, "Kuradal", 150..250, 110, 75, 18, 90, 270);
+    DURADEL(Npcs.DURADEL_8466, "Duradel", 130..200, 100, 50, 15, 75, 225),
+    KURADAL(Npcs.KURADAL_9085, "Kuradal", 150..250, 110, 75, 18, 90, 270);
 
     companion object {
         private val SLAYER_MASTERS = values().associateBy(SlayerMaster::id)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/slayer_equipment_shop.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/slayer_equipment_shop.plugin.kts
@@ -37,6 +37,7 @@ create_shop(
 }
 
 val masters = arrayOf(Npcs.TURAEL, Npcs.VANNAKA, Npcs.MAZCHNA)
+
 masters.forEach {
     on_npc_option(npc = it, option = "trade") {
         player.openShop("Slayer Equipment")

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/slayer_masters_dialogue.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/slayer_masters_dialogue.plugin.kts
@@ -9,64 +9,67 @@ import gg.rsmod.plugins.content.skills.slayer.data.slayerData
  * @author Alycia <https://github.com/alycii>
  */
 
-val masters = listOf(Npcs.TURAEL, Npcs.VANNAKA, Npcs.MAZCHNA)
-masters.forEach { npcId ->
+val npcIds = arrayOf(Npcs.TURAEL, Npcs.VANNAKA, Npcs.MAZCHNA, /**Npcs.CHAELDAR, Npcs.SUMONA, Npcs.DURADEL_8466, Npcs.KURADAL_9085**/)
 
-    val slayerMaster = SlayerMaster.values().firstOrNull { it.id == npcId } ?: return@forEach
+npcIds.forEach { npcId ->
+    val slayerMaster = SlayerMaster.getMaster(npcId)
+    slayerMaster?.let {
 
+    //TODO: Add back once we fix NPC Option 3.
     /**
     on_npc_option(npc = Npcs.VANNAKA, option = "get-task") {
-        player.queue {
-            giveTask(this, slayerMaster)
-        }
+    player.queue {
+    giveTask(this, slayerMaster)
+    }
     }**/
 
+        on_npc_option(npc = npcId, option = "talk-to") {
+            player.queue {
+                chatNpc("'Ello, and what are you after then?")
+                val firstOption = when (player.attr.has(STARTED_SLAYER)) {
+                    true -> "I need another assignment"
+                    false -> "Who are you?"
+                }
 
-    on_npc_option(npc = npcId, option = "talk-to") {
-        player.queue {
-            chatNpc("'Ello, and what are you after then?")
-            val firstOption = when (player.attr.has(STARTED_SLAYER)) {
-                true -> "I need another assignment"
-                false -> "Who are you?"
-            }
+                when (options(firstOption, "Do you have anything for trade?", "Er... Nothing...")) {
+                    FIRST_OPTION -> {
+                        if (player.attr.has(STARTED_SLAYER)) {
+                            giveTask(this, slayerMaster)
+                        } else {
+                            chatPlayer("Who are you?")
+                            chatNpc("I'm one of the elite Slayer Masters.")
+                            when (options("What's a slayer?", "Never heard of you...")) {
+                                FIRST_OPTION -> {
+                                    chatPlayer("What's a slayer?")
+                                    chatNpc("Oh dear, what do they teach you in school?")
+                                    chatPlayer("Well.. er...")
+                                    chatNpc(
+                                        "I suppose I'll have to educate you then. A slayer is",
+                                        "someone who is trained to fight specific creatures. They",
+                                        "know these creatures' every weakness and strength. As",
+                                        "you can guess it makes killing them a lot easier."
+                                    )
+                                    tutorialDialogue(this, slayerMaster)
+                                }
 
-            when (options(firstOption, "Do you have anything for trade?", "Er... Nothing...")) {
-                FIRST_OPTION -> {
-                    if (player.attr.has(STARTED_SLAYER)) {
-                        giveTask(this, slayerMaster)
-                    } else {
-                        chatPlayer("Who are you?")
-                        chatNpc("I'm one of the elite Slayer Masters.")
-                        when (options("What's a slayer?", "Never heard of you...")) {
-                            FIRST_OPTION -> {
-                                chatPlayer("What's a slayer?")
-                                chatNpc("Oh dear, what do they teach you in school?")
-                                chatPlayer("Well.. er...")
-                                chatNpc(
-                                    "I suppose I'll have to educate you then. A slayer is",
-                                    "someone who is trained to fight specific creatures. They",
-                                    "know these creatures' every weakness and strength. As",
-                                    "you can guess it makes killing them a lot easier."
-                                )
-                                tutorialDialogue(this, slayerMaster)
-                            }
+                                SECOND_OPTION -> {
+                                    chatPlayer("Never heard of you...")
+                                    chatNpc(
+                                        "That's because my foe never lives to tell of me. We",
+                                        "slayers are a dangerous bunch."
+                                    )
+                                    tutorialDialogue(this, slayerMaster)
 
-                            SECOND_OPTION -> {
-                                chatPlayer("Never heard of you...")
-                                chatNpc(
-                                    "That's because my foe never lives to tell of me. We",
-                                    "slayers are a dangerous bunch."
-                                )
-                                tutorialDialogue(this, slayerMaster)
-
+                                }
                             }
                         }
                     }
-                }
-                SECOND_OPTION -> {
-                    chatPlayer("Do you have anything for trade?")
-                    chatNpc("I have a wide selection of Slayer equipment; take a look!")
-                    player.openShop("Slayer Equipment")
+
+                    SECOND_OPTION -> {
+                        chatPlayer("Do you have anything for trade?")
+                        chatNpc("I have a wide selection of Slayer equipment; take a look!")
+                        player.openShop("Slayer Equipment")
+                    }
                 }
             }
         }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/slayer_masters_dialogue.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/slayer_masters_dialogue.plugin.kts
@@ -16,6 +16,14 @@ masters.forEach { npcId ->
 
     val slayerMaster = SlayerMaster.values().firstOrNull { it.id == npcId } ?: return@forEach
 
+    /**
+    on_npc_option(npc = Npcs.VANNAKA, option = "get-task") {
+        player.queue {
+            giveTask(this, slayerMaster)
+        }
+    }**/
+
+
     on_npc_option(npc = npcId, option = "talk-to") {
         player.queue {
             chatNpc("'Ello, and what are you after then?")
@@ -106,6 +114,11 @@ suspend fun giveTask(it: QueueTask, slayerMaster: SlayerMaster) {
 
     if(player.getSlayerAssignment() != null) {
         it.chatNpc("You're still hunting ${player.getSlayerAssignment()!!.identifier.lowercase()}, you have ${player.attr[SLAYER_AMOUNT]} to go. Come", "back when you've finished your task.")
+        return
+    }
+
+    if(player.skills.getMaxLevel(Skills.SLAYER) < slayerMaster.reqSlayerLevel || player.combatLevel < slayerMaster.requiredCombatLevel) {
+        it.chatNpc("You are not yet experienced enough to receive my tasks. Come back when you're stronger.", facialExpression = FacialExpression.CHEERFUL, wrap = true)
         return
     }
 

--- a/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
@@ -485,9 +485,19 @@ val CANOE_VARBIT = AttributeKey<Int>()
 val LOYALTY_POINTS = AttributeKey<Int>(persistenceKey = "loyalty_points")
 
 /**
- * If the player has unlocked the ability to fletch broad arrows/bolts
+ * The amount of slayer points the player has
+ */
+val SLAYER_POINTS = AttributeKey<Int>(persistenceKey = "slayer_points")
+
+/**
+ * Slayer shop ability unlocks
  */
 val BROAD_FLETCHING = AttributeKey<Boolean>(persistenceKey = "broad_fletching")
+val SLAYER_HELM_CREATION = AttributeKey<Boolean>(persistenceKey = "slayer_helm_creation")
+val CRAFT_ROS = AttributeKey<Boolean>(persistenceKey = "craft_ros")
+val QUICK_BLOWS = AttributeKey<Boolean>(persistenceKey = "quick_blows")
+val AQUANTIES = AttributeKey<Boolean>(persistenceKey = "aquanites")
+val ICE_STRYKER_NO_CAPE = AttributeKey<Boolean>(persistenceKey = "ice_stryker_no_cape")
 
 /**
  * The last time a map was built for the player

--- a/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
@@ -472,6 +472,12 @@ val SLAYER_AMOUNT = AttributeKey<Int>(persistenceKey = "slayer_amount")
 /**
  * The amount of Slayer monsters left to kill
  */
+val CONSECUTIVE_SLAYER_TASKS = AttributeKey<Int>(persistenceKey = "consecutive_slayer_tasks")
+
+
+/**
+ * The amount of Slayer monsters left to kill
+ */
 val STARTED_SLAYER = AttributeKey<Boolean>(persistenceKey = "started_slayer")
 
 /**

--- a/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
@@ -1,6 +1,7 @@
 package gg.rsmod.game.model.attr
 
 import gg.rsmod.game.model.Tile
+import gg.rsmod.game.model.combat.SlayerAssignment
 import gg.rsmod.game.model.container.ItemTransaction
 import gg.rsmod.game.model.entity.*
 import gg.rsmod.game.model.item.Item
@@ -474,6 +475,11 @@ val SLAYER_AMOUNT = AttributeKey<Int>(persistenceKey = "slayer_amount")
  */
 val CONSECUTIVE_SLAYER_TASKS = AttributeKey<Int>(persistenceKey = "consecutive_slayer_tasks")
 
+
+/**
+ * The list of block monsters from slayer assignments
+ */
+val BLOCKED_TASKS = AttributeKey<MutableList<SlayerAssignment>>("blocked_tasks")
 
 /**
  * The amount of Slayer monsters left to kill

--- a/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
@@ -868,6 +868,20 @@ abstract class Player(world: World) : Pawn(world) {
     }
 
     /**
+     * Add slayer points to this player
+     */
+    fun addSlayerPoints(amount: Int) {
+        attr[SLAYER_POINTS] = (attr[SLAYER_POINTS] ?: 0) + amount
+    }
+
+    /**
+     * Remove slayer points from this player
+     */
+    fun subtractSlayerPoints(amount: Int) {
+        attr[SLAYER_POINTS] = (attr[SLAYER_POINTS] ?: 0) - amount
+    }
+
+    /**
      * @see largeViewport
      */
     fun hasLargeViewport(): Boolean = largeViewport

--- a/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
@@ -882,6 +882,13 @@ abstract class Player(world: World) : Pawn(world) {
     }
 
     /**
+     * Get the current count of slayer points for this player
+     */
+    fun getSlayerPointsCount(): Int {
+        return attr[SLAYER_POINTS] ?: 0
+    }
+
+    /**
      * @see largeViewport
      */
     fun hasLargeViewport(): Boolean = largeViewport


### PR DESCRIPTION
## What has been done?
- added slayer points reward for completing slayer assignments. (bonus for completing consecutive tasks.)
- added slayer rewards shop to buy slayer supplies, learn new abilities, and manage your task assignments.
- added weights to slayer task assignment frequency.
- drill demon will no longer teleport you to Lumbridge as a punishment for failing the event.
- fixed bug with rocktail fishing spots

## Has your code been documented?
Yes.