### PR TITLE
feat: fixed players command and added locate command

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -1300,6 +1300,10 @@ fun getAreaName(player: Player): String {
             "Dwarven Mine"
         12444, 12443, 12442, 12186, 12441, 12698, 12954, 13210 ->
             "Edgeville Dungeon"
+        11831, 11832, 11833, 11834, 11835, 11836, 11837, 12087, 12089, 12090, 12091, 12092, 12093, 12343, 12344, 12345,
+            12346, 12347, 12348, 12349, 12599, 12600, 12601, 12602, 12603, 12604, 12605, 12855, 12856, 12857, 12858, 12859,
+                12860, 12861, 13111, 13112, 13113, 13114, 13115, 13116, 13117, 13367, 13368, 13369, 13370, 13371, 13372, 13373 ->
+            "the Wilderness"
         // End Region Mapping
         else -> "Unknown Area, Region ID: " + player.tile.regionId
             //if region ID returns any value not in this mapping, displays this string.

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -75,57 +75,82 @@ on_command("objanim", Privilege.ADMIN_POWER) {
 
 
 on_command("players") {
+    // Count the total number of players online
     val count = world.players.count()
+    // Map to store player IDs and their corresponding Player objects
     val playersMap = mutableMapOf<Int, Player>()
+    // Populate playersMap with player IDs and their Player objects
     world.players.forEach { p ->
         playersMap[playersMap.size] = p
     }
-    if (!player.timers.has(ACTIVE_COMBAT_TIMER) && player.interfaces.currentModal == -1) { //checks if player is in combat
+    // Check if the player initiating the command is not in combat and not interacting with an interface
+    if (!player.timers.has(ACTIVE_COMBAT_TIMER) && player.interfaces.currentModal == -1) {
+        // Open a specific interface to display player information
         player.openInterface(dest = InterfaceDestination.MAIN_SCREEN_FULL, interfaceId = 275)
+
+        // Hide a specific component in the interface
         player.setComponentHidden(interfaceId = 275, component = 14, hidden = true)
+
+        // Set the count of online players in a specific component of the interface
         player.setComponentText(interfaceId = 275, component = 2, "Players Online: $count")
+
+        // Clear components 16 to 315 to prepare for displaying player information
         for (i in 16..315) {
             player.setComponentText(interfaceId = 275, component = i, "")
         }
+        // Display player information in the interface for each player
         playersMap.forEach { (i, p) ->
-            val icon = when (p.privilege.id) { //checks for player privilege level and displays a crown when admin
-                1 -> "<img=0>"
-                2 -> "<img=1>"
-                else -> ""
+            // Determine privilege icon based on player's privilege level
+            val icon = when (p.privilege.id) {
+                1 -> "<img=0>" // Represents a specific privilege level (e.g., admin)
+                2 -> "<img=1>" // Represents another privilege level (e.g., moderator)
+                else -> ""       // Default case (no icon)
             }
+            // Set player information in the interface
             player.setComponentText(interfaceId = 275, component = 17 + i,  "$icon ${Misc.formatForDisplay(p.username)}")
         }
-    }
-    if (count == 1) {
-        player.message("There is currently 1 player online.")
     } else {
-        player.message("There are currently $count players online.")
-        playersMap.values.take(10).forEach { p ->
-            val icon = when (p.privilege.id) { //checks for player privilege level and displays a crown when admin
-                1 -> "<img=0>"
-                2 -> "<img=1>"
-                else -> ""
+        // If the player is in combat or interacting with an interface
+        if (count == 1) {
+            // Display the count of players when only one player is online
+            player.message("There is currently 1 player online.")
+        } else {
+            // Display the count of players and show information for the first 5 players
+            player.message("There are currently $count players online. Showing first 5 players.")
+            playersMap.values.take(10).forEach { p ->
+                // Determine privilege icon for each player and display their username
+                val icon = when (p.privilege.id) {
+                    1 -> "<img=0>"
+                    2 -> "<img=1>"
+                    else -> ""
+                }
+                player.message(" - $icon ${Misc.formatForDisplay(p.username)}")
             }
-            player.message(" - $icon ${Misc.formatForDisplay(p.username)}")
         }
     }
 }
 
-on_command("locate") {//locates a player
+on_command("locate") {
+    // Get command arguments
     val args = player.getCommandArgs()
-    tryWithUsage(player, args, "Invalid format! Example of proper command <col=42C66C>::locate username</col>"
-    ) { values ->
+    // Validate command usage and arguments
+    tryWithUsage(player, args, "Invalid format! Example of proper command <col=42C66C>::locate username</col>") { values ->
+        // Find the player object based on the provided username
         val p = world.getPlayerForName(values[0].replace("_", " ")) ?: return@tryWithUsage
+        // Get the area name where the player is located
         val areaName = getAreaName(p)
-        val icon = when (p.privilege.id) { //checks for player privilege level and displays a crown when admin
-            1 -> "<img=0>"
-            2 -> "<img=1>"
-            else -> ""
+        // Determine privilege icon based on player's privilege level
+        val icon = when (p.privilege.id) {
+            1 -> "<img=0>" // Represents a specific privilege level (e.g., admin)
+            2 -> "<img=1>" // Represents another privilege level (e.g., moderator)
+            else -> ""       // Default case (no icon)
         }
+        // Check if the located player has privacy mode enabled
         if (p.attr.getOrDefault(PRIVACY_MODE, 1) == 1){
-        player.message("Unable to locate player $icon<col=42C66C>${p.username}</col>, as they have privacy mode enabled!")
-        }
-        else {
+            // Inform the requesting player about the privacy mode of the located player
+            player.message("Unable to locate player $icon<col=42C66C>${p.username}</col>, as they have privacy mode enabled!")
+        } else {
+            // Display the located player's username, privilege icon, and their area name
             player.message("Player $icon<col=42C66C>${p.username}</col> is in: $areaName.")
         }
     }
@@ -1160,75 +1185,141 @@ fun getArgumentLine(args: Array<String>, offset: Int, length: Int): String {
     }
     return sb.toString()
 }
-
-fun getAreaName(player: Player): String { //returns the player's area name based on region ID
-    val regionID = player.tile.regionId
-    return when (regionID) {
-        9270 -> "Eagles' Peak"
-        9526, 9782, 9525, 9781, 9780 -> "Tree Gnome Stronghold"
-        10039 -> "Barbarian Outpost"
-        10038, 10036, 10037, 10294 -> "Kandarin"
-        10293, -> "Fishing Guild"
-        9779, 10035 -> "West Ardougne"
-        10291, 10547, 10292, 10548 -> "East Ardougne"
-        10803 -> "Witchaven"
-        10804 -> "Legends' Guild"
-        10549 -> "Ranging Guild"
-        10550 -> "McGrubor's Wood"
-        10806, 10805 -> "Seers' Village"
-        11061, 11062, 11317 -> "Catherby"
-        10033 -> "Tree Gnome Village"
-        10032, 10288 -> "Yanille"
-        10545 -> "Port Khazard"
-        10802, 10801, 11058, 11057, 11313, 11569, 10645, 10644, 10900, 10899, 10901 -> "Brimhaven"
-        11056, 11312, 11568, 11055, 11311, 11567, 11823, 11054, 11566, 11822, 11053, 11309, 11565, 11821 -> "Karamja"
-        11310 -> "Shilo Village"
-        11318 -> "White Wolf Mountain"
-        11319, 11575 -> "Burthorpe"
-        11574, 11573 -> "Taverley"
-        11830 -> "Near Goblin Village"
-        12086 -> "Edgeville Monastery"
-        12342 -> "Edgeville"
-        12598 -> "Grand Exchange"
-        12854 -> "Near Varrock Palace"
-        13110 -> "Lumber Yard"
-        11829 -> "North of Falador"
-        11828, 12084, 11827 -> "Falador"
-        12083 -> "Falador Farm"
-        11570, 11826 -> "Rimmington"
-        12082, 12081 -> "Port Sarim"
-        11825, 11824 -> "Mudskipper Point"
-        12337 -> "Wizards' Tower"
-        12085 -> "Near Dwarven Mine"
-        12341 -> "Barbarian Village"
-        12597 -> "West Varrock"
-        12853 -> "East Varrock"
-        13109 -> "East of Varrock"
-        12596 -> "Near Champions' Guild"
-        12852 -> "South of Varrock"
-        13108 -> "South east of Varrock"
-        12593, 12849, 12693, 12949 -> "Lumbridge Swamp"
-        12850, 12851, 12595, 12950, 13206 -> "Lumbridge"
-        12594 -> "Behind Lumbridge Castle"
-        12338, 12339 -> "Draynor Village"
-        12340 -> "Near Draynor Manor"
-        13107 -> "Al Kharid Mine"
-        13363 -> "Mage Training Arena"
-        13362 -> "Duel Arena"
-        13106, 13105, 13361 -> "Al Kharid"
+// Function to retrieve the player's area name based on region ID
+fun getAreaName(player: Player): String {
+    // Get the region ID of the player's current tile
+    return when (player.tile.regionId) {
+        // Begin Region Mapping
+        9270 ->
+            "Eagles' Peak"
+        9526, 9782, 9525, 9781, 9780 ->
+            "Tree Gnome Stronghold"
+        10039 ->
+            "Barbarian Outpost"
+        10038, 10036, 10037, 10294 ->
+            "Kandarin"
+        10293, ->
+            "Fishing Guild"
+        9779, 10035 ->
+            "West Ardougne"
+        10291, 10547, 10292, 10548 ->
+            "East Ardougne"
+        10803 ->
+            "Witchaven"
+        10804 ->
+            "Legends' Guild"
+        10549 ->
+            "Ranging Guild"
+        10550 ->
+            "McGrubor's Wood"
+        10806, 10805 ->
+            "Seers' Village"
+        11061, 11062, 11317 ->
+            "Catherby"
+        10033 ->
+            "Tree Gnome Village"
+        10032, 10288 ->
+            "Yanille"
+        10545 ->
+            "Port Khazard"
+        10802, 10801, 11058, 11057, 11313, 11569, 10645, 10644, 10900, 10899, 10901 ->
+            "Brimhaven"
+        11056, 11312, 11568, 11055, 11311, 11567, 11823, 11054, 11566, 11822, 11053, 11309, 11565, 11821 ->
+            "Karamja"
+        11310 ->
+            "Shilo Village"
+        11318 ->
+            "White Wolf Mountain"
+        11319, 11575 ->
+            "Burthorpe"
+        11574, 11573 ->
+            "Taverley"
+        11830 ->
+            "Near Goblin Village"
+        12086 ->
+            "Edgeville Monastery"
+        12342 ->
+            "Edgeville"
+        12598 ->
+            "Grand Exchange"
+        12854 ->
+            "Near Varrock Palace"
+        13110 ->
+            "Lumber Yard"
+        11829 ->
+            "North of Falador"
+        11828, 12084, 11827 ->
+            "Falador"
+        12083 ->
+            "Falador Farm"
+        11570, 11826 ->
+            "Rimmington"
+        12082, 12081 ->
+            "Port Sarim"
+        11825, 11824 ->
+            "Mudskipper Point"
+        12337 ->
+            "Wizards' Tower"
+        12085 ->
+            "Near Dwarven Mine"
+        12341 ->
+            "Barbarian Village"
+        12597 ->
+            "West Varrock"
+        12853 ->
+            "East Varrock"
+        13109 ->
+            "East of Varrock"
+        12596 ->
+            "Near Champions' Guild"
+        12852 ->
+            "South of Varrock"
+        13108 ->
+            "South east of Varrock"
+        12593, 12849, 12693, 12949 ->
+            "Lumbridge Swamp"
+        12850, 12851, 12595, 12950, 13206 ->
+            "Lumbridge"
+        12594 ->
+            "Behind Lumbridge Castle"
+        12338, 12339 ->
+            "Draynor Village"
+        12340 ->
+            "Near Draynor Manor"
+        13107 ->
+            "Al Kharid Mine"
+        13363 ->
+            "Mage Training Arena"
+        13362 ->
+            "Duel Arena"
+        13106, 13105, 13361 ->
+            "Al Kharid"
         12591, 12590, 12589, 12588, 12587, 12848, 12847, 12846, 12845, 12844, 12843, 13104, 13103, 13102, 13101, 13100,
-            13099, 13355, 13356, 13357, 13358, 13359, 13360, 13872, 13871, 13870 -> "Kharidian Desert"
-        13366, 13622 -> "Paterdomus"
-        13623 -> "Slayer Tower"
-        13878 -> "Canifis"
+            13099, 13355, 13356, 13357, 13358, 13359, 13360, 13872, 13871, 13870 ->
+            "Kharidian Desert"
+        13366, 13622 ->
+            "Paterdomus"
+        13623 ->
+            "Slayer Tower"
+        13878 ->
+            "Canifis"
         13879, 13621, 13877, 13620, 13876, 13619, 13875, 13618, 13874, 13873, 14129, 14130, 14133, 14134, 14135, 14389,
-            14390, 14391 -> "Morytania"
-        14131, 14231 -> "Barrows"
-        14385, 14386, 14387, 14388, 14132, 14642, 14644 -> "Meiyerditch"
-        14647, 14646, 14645 -> "Port Phasmatys"
-        11417, 11673, 11416, 11672, 11671, 11928 -> "Taverley Dungeon"
-        11929, 12185, 12184, 12183, 11927 -> "Dwarven Mine"
-        12444, 12443, 12442, 12186, 12441, 12698, 12954, 13210 -> "Edgeville Dungeon"
+            14390, 14391 ->
+            "Morytania"
+        14131, 14231 ->
+            "Barrows"
+        14385, 14386, 14387, 14388, 14132, 14642, 14644 ->
+            "Meiyerditch"
+        14647, 14646, 14645 ->
+            "Port Phasmatys"
+        11417, 11673, 11416, 11672, 11671, 11928 ->
+            "Taverley Dungeon"
+        11929, 12185, 12184, 12183, 11927 ->
+            "Dwarven Mine"
+        12444, 12443, 12442, 12186, 12441, 12698, 12954, 13210 ->
+            "Edgeville Dungeon"
+        // End Region Mapping
         else -> "Unknown Area, Region ID: " + player.tile.regionId
+            //if region ID returns any value not in this mapping, displays this string.
     }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -87,7 +87,7 @@ on_command("players") {
     } else {
         player.message("There are currently $count players online.")
         playersMap.values.take(10).forEach { p ->
-            val icon = when (p.privilege.id) {
+            val icon = when (p.privilege.id) { //checks for player privilege level and displays a crown when admin
                 1 -> "<img=0>"
                 2 -> "<img=1>"
                 else -> ""
@@ -97,7 +97,7 @@ on_command("players") {
     }
 }
 
-on_command("locate") {
+on_command("locate") {//locates a player
     val args = player.getCommandArgs()
     tryWithUsage(player, args, "Invalid format! Example of proper command <col=42C66C>::locate username</col>"
     ) { values ->
@@ -1126,7 +1126,7 @@ fun getArgumentLine(args: Array<String>, offset: Int, length: Int): String {
     return sb.toString()
 }
 
-fun getAreaName(player: Player): String {
+fun getAreaName(player: Player): String { //returns the player's area name based on region ID
     val regionID = player.tile.regionId
     return when (regionID) {
         9270 -> "Eagles' Peak"

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -85,7 +85,7 @@ on_command("players") {
     }
     // Check if the player initiating the command is not in combat and not interacting with an interface
     if (!player.timers.has(ACTIVE_COMBAT_TIMER) && player.interfaces.currentModal == -1) {
-        // Open a specific interface to display player information
+        // Open scroll interface to display player information
         player.openInterface(dest = InterfaceDestination.MAIN_SCREEN_FULL, interfaceId = 275)
 
         // Hide a specific component in the interface
@@ -145,30 +145,12 @@ on_command("locate") {
             2 -> "<img=1>" // Represents another privilege level (e.g., moderator)
             else -> ""       // Default case (no icon)
         }
-        // Check if the located player has privacy mode enabled
-        if (p.attr.getOrDefault(PRIVACY_MODE, 1) == 1){
-            // Inform the requesting player about the privacy mode of the located player
-            player.message("Unable to locate player $icon<col=42C66C>${p.username}</col>, as they have privacy mode enabled!")
-        } else {
-            // Display the located player's username, privilege icon, and their area name
-            player.message("Player $icon<col=42C66C>${Misc.formatForDisplay(p.username)}</col> is in: $areaName.")
-        }
+        player.message("Player $icon<col=42C66C>${Misc.formatForDisplay(p.username)}</col> is in: $areaName.")
     }
 }
 
 on_command("yell") {
     player.message("To talk in the global chat, start your message in public chat with a period (.)", ChatMessageType.CONSOLE)
-}
-
-on_command("privacy") {
-    val isPrivacyEnabled = player.attr.getOrDefault(PRIVACY_MODE, 1)
-    if (isPrivacyEnabled == 0) {
-        player.attr[PRIVACY_MODE] = 1
-        player.message("Privacy mode: Enabled")
-    } else {
-        player.attr[PRIVACY_MODE] = 0
-        player.message("Privacy mode: Disabled")
-    }
 }
 
 on_command("addloyalty", Privilege.ADMIN_POWER) {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -3,18 +3,17 @@ package gg.rsmod.plugins.content.cmd
 import de.mkammerer.argon2.Argon2Factory
 import gg.rsmod.game.message.impl.LocAnimMessage
 import gg.rsmod.game.message.impl.LogoutFullMessage
-import gg.rsmod.game.model.attr.*
+import gg.rsmod.game.model.attr.LAST_TOTAL_LEVEL
+import gg.rsmod.game.model.attr.LEVEL_UP_INCREMENT
+import gg.rsmod.game.model.attr.LEVEL_UP_SKILL_ID
+import gg.rsmod.game.model.attr.NO_CLIP_ATTR
 import gg.rsmod.game.model.bits.INFINITE_VARS_STORAGE
 import gg.rsmod.game.model.bits.InfiniteVarsType
 import gg.rsmod.game.model.collision.ObjectType
-import gg.rsmod.game.model.entity.Player
 import gg.rsmod.game.model.priv.Privilege
 import gg.rsmod.game.model.region.ChunkCoords
-import gg.rsmod.game.model.timer.ACTIVE_COMBAT_TIMER
 import gg.rsmod.game.service.serializer.PlayerSerializerService
 import gg.rsmod.game.sync.block.UpdateBlockType
-import gg.rsmod.plugins.api.InterfaceDestination
-import gg.rsmod.plugins.api.Skills
 import gg.rsmod.plugins.content.combat.dealHit
 import gg.rsmod.plugins.content.inter.attack.AttackTab
 import gg.rsmod.plugins.content.inter.bank.openBank
@@ -79,24 +78,33 @@ on_command("objanim", Privilege.ADMIN_POWER) {
 
 on_command("players") {
     val count = world.players.count()
-    if (!player.timers.has(ACTIVE_COMBAT_TIMER) && player.interfaces.currentModal == -1) {
-        player.openInterface(dest = InterfaceDestination.MAIN_SCREEN_FULL, interfaceId = 275)
-        player.setComponentHidden(interfaceId = 275, component = 14, hidden = true)
-        player.setComponentText(interfaceId = 275, component = 2, "Players Online: $count")
-        for (i in 16..315) {
-            player.setComponentText(interfaceId = 275, component = i, "")
-        }
-
-        val playersMap = mutableMapOf<Int, Player>()
-        world.players.forEach { p ->
-            playersMap[playersMap.size] = p
-        }
-
-        playersMap.forEach { (i, p) ->
-            player.setComponentText(interfaceId = 275, component = 17 + i,  Misc.formatForDisplay(p.username))
+    val playersMap = mutableMapOf<Int, Player>()
+    world.players.forEach { p ->
+        playersMap[playersMap.size] = p
+    }
+    if (count == 1) {
+        player.message("There is currently 1 player online.")
+    } else {
+        player.message("There are currently $count players online.")
+        playersMap.values.take(10).forEach { p ->
+            val icon = when (p.privilege.id) {
+                1 -> "<img=0>"
+                2 -> "<img=1>"
+                else -> ""
+            }
+            player.message(" - $icon ${Misc.formatForDisplay(p.username)}")
         }
     }
-    player.message("There is currently $count ${if (count > 1) "players" else "player"} online.")
+}
+
+on_command("locate") {
+    val args = player.getCommandArgs()
+    tryWithUsage(player, args, "Invalid format! Example of proper command <col=42C66C>::locate username</col>"
+    ) { values ->
+        val p = world.getPlayerForName(values[0].replace("_", " ")) ?: return@tryWithUsage
+        val areaName = getAreaName(p)
+        player.message("Player '${p.username}' is in $areaName")
+    }
 }
 
 on_command("yell") {
@@ -1116,4 +1124,76 @@ fun getArgumentLine(args: Array<String>, offset: Int, length: Int): String {
         sb.append(args[i])
     }
     return sb.toString()
+}
+
+fun getAreaName(player: Player): String {
+    val regionID = player.tile.regionId
+    return when (regionID) {
+        9270 -> "Eagles' Peak"
+        9526, 9782, 9525, 9781, 9780 -> "Tree Gnome Stronghold"
+        10039 -> "Barbarian Outpost"
+        10038, 10036, 10037, 10294 -> "Kandarin"
+        10293, -> "Fishing Guild"
+        9779, 10035 -> "West Ardougne"
+        10291, 10547, 10292, 10548 -> "East Ardougne"
+        10803 -> "Witchaven"
+        10804 -> "Legends' Guild"
+        10549 -> "Ranging Guild"
+        10550 -> "McGrubor's Wood"
+        10806, 10805 -> "Seers' Village"
+        11061, 11062, 11317 -> "Catherby"
+        10033 -> "Tree Gnome Village"
+        10032, 10288 -> "Yanille"
+        10545 -> "Port Khazard"
+        10802, 10801, 11058, 11057, 11313, 11569, 10645, 10644, 10900, 10899, 10901 -> "Brimhaven"
+        11056, 11312, 11568, 11055, 11311, 11567, 11823, 11054, 11566, 11822, 11053, 11309, 11565, 11821 -> "Karamja"
+        11310 -> "Shilo Village"
+        11318 -> "White Wolf Mountain"
+        11319, 11575 -> "Burthorpe"
+        11574, 11573 -> "Taverley"
+        11830 -> "Near Goblin Village"
+        12086 -> "Edgeville Monastery"
+        12342 -> "Edgeville"
+        12598 -> "Grand Exchange"
+        12854 -> "Near Varrock Palace"
+        13110 -> "Lumber Yard"
+        11829 -> "North of Falador"
+        11828, 12084, 11827 -> "Falador"
+        12083 -> "Falador Farm"
+        11570, 11826 -> "Rimmington"
+        12082, 12081 -> "Port Sarim"
+        11825, 11824 -> "Mudskipper Point"
+        12337 -> "Wizards' Tower"
+        12085 -> "Near Dwarven Mine"
+        12341 -> "Barbarian Village"
+        12597 -> "West Varrock"
+        12853 -> "East Varrock"
+        13109 -> "East of Varrock"
+        12596 -> "Near Champions' Guild"
+        12852 -> "South of Varrock"
+        13108 -> "South east of Varrock"
+        12593, 12849, 12693, 12949 -> "Lumbridge Swamp"
+        12850, 12851, 12595, 12950, 13206 -> "Lumbridge"
+        12594 -> "Behind Lumbridge Castle"
+        12338, 12339 -> "Draynor Village"
+        12340 -> "Near Draynor Manor"
+        13107 -> "Al Kharid Mine"
+        13363 -> "Mage Training Arena"
+        13362 -> "Duel Arena"
+        13106, 13105, 13361 -> "Al Kharid"
+        12591, 12590, 12589, 12588, 12587, 12848, 12847, 12846, 12845, 12844, 12843, 13104, 13103, 13102, 13101, 13100,
+            13099, 13355, 13356, 13357, 13358, 13359, 13360, 13872, 13871, 13870 -> "Kharidian Desert"
+        13366, 13622 -> "Paterdomus"
+        13623 -> "Slayer Tower"
+        13878 -> "Canifis"
+        13879, 13621, 13877, 13620, 13876, 13619, 13875, 13618, 13874, 13873, 14129, 14130, 14133, 14134, 14135, 14389,
+            14390, 14391 -> "Morytania"
+        14131, 14231 -> "Barrows"
+        14385, 14386, 14387, 14388, 14132, 14642, 14644 -> "Meiyerditch"
+        14647, 14646, 14645 -> "Port Phasmatys"
+        11417, 11673, 11416, 11672, 11671, 11928 -> "Taverley Dungeon"
+        11929, 12185, 12184, 12183, 11927 -> "Dwarven Mine"
+        12444, 12443, 12442, 12186, 12441, 12698, 12954, 13210 -> "Edgeville Dungeon"
+        else -> "Unknown Area, Region ID: " + player.tile.regionId
+    }
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -151,7 +151,7 @@ on_command("locate") {
             player.message("Unable to locate player $icon<col=42C66C>${p.username}</col>, as they have privacy mode enabled!")
         } else {
             // Display the located player's username, privilege icon, and their area name
-            player.message("Player $icon<col=42C66C>${p.username}</col> is in: $areaName.")
+            player.message("Player $icon<col=42C66C>${Misc.formatForDisplay(p.username)}</col> is in: $areaName.")
         }
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
@@ -525,3 +525,8 @@ val LAST_MAP_BUILD_TIME = AttributeKey<Int>(persistenceKey = "last_map_build")
  * The last slot the player has selected for the random event gift interface
  */
 val RANDOM_EVENT_GIFT_SLOT = AttributeKey<Int>()
+
+/**
+ * Privacy Mode
+ */
+val PRIVACY_MODE = AttributeKey<Int>(persistenceKey = "privacy_mode")

--- a/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/attr/Attributes.kt
@@ -525,8 +525,3 @@ val LAST_MAP_BUILD_TIME = AttributeKey<Int>(persistenceKey = "last_map_build")
  * The last slot the player has selected for the random event gift interface
  */
 val RANDOM_EVENT_GIFT_SLOT = AttributeKey<Int>()
-
-/**
- * Privacy Mode
- */
-val PRIVACY_MODE = AttributeKey<Int>(persistenceKey = "privacy_mode")


### PR DESCRIPTION
## What has been done?
- added "locate" command (searches region id and matches that to a list in a function)
- fixed "players" command to not have an interface pop up and to show a list of the first 10 players the game finds online. also fixed grammar when calling this command

## Media
![image](https://github.com/2011Scape/game/assets/52549792/4989d022-d286-4a24-a2f2-327d79caf27b)
![image2](https://github.com/2011Scape/game/assets/52549792/227a25b8-a3b8-4d4f-8452-cd327b050ff9)
