### PR TITLE
feat: Added basic kebab eating

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Food.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Food.kt
@@ -82,7 +82,8 @@ enum class Food(
     COOKED_FISHCAKE(item = Items.COOKED_FISHCAKE, heal = 110),
 
 
-    /** Kebabs */ //TODO
+    /** Kebabs */ 
+    KEBAB(item = Items.KEBAB, heal = 0, message = ""),
 
     /** Pies */
     REDBERRY_PIE(item = Items.REDBERRY_PIE, heal = 50, replacement = Items.HALF_A_REDBERRY_PIE),

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Foods.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Foods.kt
@@ -15,6 +15,7 @@ import gg.rsmod.plugins.api.ext.hasEquipped
 import gg.rsmod.plugins.api.ext.heal
 import gg.rsmod.plugins.api.ext.playSound
 import kotlin.math.floor
+import kotlin.math.max
 import kotlin.random.Random
 
 /**
@@ -30,8 +31,16 @@ object Foods {
     fun eat(p: Player, food: Food) {
         val delay = if (food.comboFood) COMBO_FOOD_DELAY else FOOD_DELAY
         val anim = if (p.hasEquipped(EquipmentType.WEAPON, Items.SLED)) EAT_FOOD_ON_SLED_ANIM else EAT_FOOD_ANIM
+        
+        val kebabEffect: Pair<Int, String>? = when {
+          food == Food.KEBAB -> calculateKebabEffect(p)
+          else -> null
+        }
 
-        val heal = food.heal
+        val heal = when {
+            food == Food.KEBAB -> kebabEffect?.first ?: 0
+            else -> food.heal
+        }
 
         val overHeal = when (food) {
             Food.ROCKTAIL -> p.skills.getCurrentLevel(Skills.CONSTITUTION) + 10
@@ -73,10 +82,50 @@ object Foods {
         if(food.message.isNotEmpty()) {
             message = food.message
         }
+        
+        if (food == Food.KEBAB) {
+            p.filterableMessage("You eat the kebab.")
+            message = kebabEffect?.second ?: ""
+        }
 
         p.filterableMessage(message)
-        if (p.skills.getCurrentLevel(Skills.CONSTITUTION) > oldHp) {
+        if (p.skills.getCurrentLevel(Skills.CONSTITUTION) > oldHp && food != Food.KEBAB) {
             p.filterableMessage("It heals some health.")
+        }
+    }
+    
+    //Effect source from RS Wiki October 2011: https://runescape.wiki/w/Kebab?oldid=4868155
+    fun calculateKebabEffect(player: Player): Pair<Int, String> {
+        val randomNumber = Random.nextDouble(100.0)
+        return when {
+            randomNumber < 8.71 -> {
+                // Rare: No effect
+                Pair(0, "That kebab didn't seem to do a lot.")
+            }
+            randomNumber < 69.95 -> {
+                // Common: Heals 10% of total health
+                val healAmount = (player.skills.getMaxLevel(Skills.CONSTITUTION) * 0.1).toInt()
+                Pair(healAmount, "It restores some health.")
+            }
+            randomNumber < 91.07 -> {
+                // Uncommon: Heals 100-200 health
+                val healAmount = Random.nextInt(100, 201)
+                Pair(healAmount, "That was a good kebab. You feel a lot better.")
+            }
+            randomNumber < 94.72 -> {
+                // Rare: Heals up to 300 health and raises Attack, Strength, and Defence by 2-3 levels
+                val boost = Random.nextInt(2, 4)
+                listOf(Skills.ATTACK, Skills.STRENGTH, Skills.DEFENCE).forEach { skill ->
+                    player.skills.setCurrentLevel(skill, player.skills.getCurrentLevel(skill) + boost)
+                }
+                Pair(300, "Wow, that was an amazing kebab! You feel really invigorated.")
+            }
+            else -> {
+                // Rare: Lowers a random skill (including non-combat skills) by a few levels
+                val randomSkill = (0..24).filter { it != Skills.CONSTITUTION }.random()
+                player.skills.setCurrentLevel(randomSkill, max(0, player.skills.getCurrentLevel(randomSkill) - Random.nextInt(1, 4)))
+                Pair(0, "That tasted a bit dodgy. You feel a bit ill.")
+            }
         }
     }
 


### PR DESCRIPTION
We eatin good tonight.

Source is the RS Wiki from October 2011: https://runescape.wiki/w/Kebab?oldid=4868155

This is basic, but I believe it's also fully authentic as well. This PR is actually pretty important too because kebab is an early-game food and many players' early-game strategy involves making use of kebabs, which is now possible with this PR.

## What has been done?

Added basic kebab eating.

## Has your code been documented?
Surprisingly, yes. 