### PR TITLE
Fixed banshees not requiring 15 slayer

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/slayer/data/SlayerMaster.kt
@@ -66,7 +66,13 @@ enum class SlayerMaster(
 val slayerData = SlayerData(
     mapOf(
         SlayerMaster.TURAEL to listOf(
-            Assignment(assignment = SlayerAssignment.BANSHEE, weight = 8.45),
+            Assignment(
+                assignment = SlayerAssignment.BANSHEE,
+                requirement = listOf(
+                    SkillRequirement(skill = Skills.SLAYER, level = 15)
+                ), 
+                weight = 8.45
+            ),
             Assignment(assignment = SlayerAssignment.BAT, weight = 2.82),
             Assignment(assignment = SlayerAssignment.BIRD, weight = 2.82),
             Assignment(assignment = SlayerAssignment.BEAR, weight = 2.82),


### PR DESCRIPTION
## What has been done?

Fixed banshees being assigned as a slayer task before 15 slayer, they require 15 slayer because of earmuffs. 

## Has your code been documented?

No, it's not necessary because the surrounding code is not either.