### PR TITLE
feat: add swamp toad spawns and functionality

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_9525.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_9525.plugin.kts
@@ -1,5 +1,17 @@
 package gg.rsmod.plugins.content.areas.spawns
 
+/**
+ * South-west gnome stronghold (Lake)
+ */
+
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2406, z = 3405, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2408, z = 3408, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2381, z = 3414, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2382, z = 3412, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2388, z = 3410, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2399, z = 3406, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2401, z = 3404, respawnCycles = 90)
+
 spawn_npc(npc = Npcs.BUTTERFLY_154, x = 2378, z = 3418, height = 0, walkRadius = 5, direction = Direction.NORTH, static = false) //Butterfly
 spawn_npc(npc = Npcs.BUTTERFLY_154, x = 2380, z = 3422, height = 0, walkRadius = 5, direction = Direction.NORTH, static = false) //Butterfly
 spawn_npc(npc = Npcs.BUTTERFLY_154, x = 2392, z = 3442, height = 0, walkRadius = 5, direction = Direction.NORTH, static = false) //Butterfly

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_9526.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/spawns/spawns_9526.plugin.kts
@@ -1,5 +1,28 @@
 package gg.rsmod.plugins.content.areas.spawns
 
+/**
+ * North-west gnome stronghold (Swamp enclosure)
+ */
+
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2409, z = 3514, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2407, z = 3516, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2424, z = 3514, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2411, z = 3512, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2412, z = 3519, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2413, z = 3511, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2415, z = 3518, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2417, z = 3508, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2421, z = 3509, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2428, z = 3510, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2416, z = 3512, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2417, z = 3512, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2417, z = 3515, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2417, z = 3516, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2418, z = 3511, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2418, z = 3517, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2421, z = 3519, respawnCycles = 90)
+spawn_item(item = Items.SWAMP_TOAD, amount = 1, x = 2424, z = 3517, respawnCycles = 90)
+
 spawn_npc(npc = 2393, x = 2395, z = 3481, height = 0, walkRadius = 5, direction = Direction.NORTH, static = false) //Mysterious ghost
 spawn_npc(npc = 3828, x = 2370, z = 3483, height = 0, walkRadius = 5, direction = Direction.NORTH, static = false) //Devin Mendelberg
 spawn_npc(npc = Npcs.ANITA, x = 2390, z = 3514, height = 1, walkRadius = 5, direction = Direction.NORTH, static = false) //Anita

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Food.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Food.kt
@@ -60,6 +60,7 @@ enum class Food(
     FAT_SNAIL_MEAT(item = Items.FAT_SNAIL_MEAT, heal = 90),
     CHOMPY(item = Items.COOKED_CHOMPY, heal = 100),
     JUBBLY(item = Items.COOKED_JUBBLY, heal = 150),
+    TOADS_LEGS(item = Items.TOADS_LEGS, heal = 30),
 
 
     /** Sandwiches */

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/swamp_toad.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/swamp_toad.plugin.kts
@@ -1,0 +1,17 @@
+package gg.rsmod.plugins.content.items
+
+import gg.rsmod.plugins.api.cfg.Items
+
+/**
+ * Removing the legs from a swamp toad
+ * Should get rid of the swamp toad and leave the legs in its place
+ */
+
+on_item_option(item = Items.SWAMP_TOAD, option = "Remove-legs") {
+    val itemSlot = player.getInteractingItemSlot()
+    val itemHasBeenRemoved = player.inventory.remove(player.getInteractingItem(), beginSlot = player.getInteractingItemSlot()).hasSucceeded()
+    if(itemHasBeenRemoved) {
+        player.inventory[itemSlot] = Item(Items.TOADS_LEGS)
+        player.message("You pull the legs off the toad. Poor toad. At least they'll grow back.")
+    }
+}


### PR DESCRIPTION
## What has been done?
 - Added swamp toad spawns to the swamp in north-western gnome stronghold
 - Added swamp toad spawns to the lake in south-western gnome stronghold
 - Added the ability to remove swamp toad legs from the toads
 - Added the ability to eat toad legs

## Has your code been documented?
Yes

## Sources for info
https://runescape.wiki/w/Toad%27s_legs?oldid=4987128

https://runescape.wiki/w/Swamp_toad?oldid=3893849 
South west stronghold spawns are not mentioned here but are present in OSRS and mentioned in a later 2014 update leading me to believe they would be there in 2011. 2014 update referenced a spawn in the middle of the south western lake which has been retained

https://oldschool.runescape.wiki/w/Swamp_toad_(item) 
Used for spawn locations

Respawn cycle 90 is based off of previously existing spawns for region 11573 (Taverly)