### PR TITLE
fix: combination action checks proper skill and not just crafting

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/combine/CombinationAction.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/combine/CombinationAction.kt
@@ -23,7 +23,7 @@ object CombinationAction {
         }
 
         inventory.add(data.resultItem, assureFullInsertion = true)
-        player.addXp(Skills.CRAFTING, data.experience)
+        player.addXp(data.skill, data.experience)
 
         if (data.tool != CombinationTool.NONE) {
             player.filterableMessage("You use your ${player.world.definitions.get(ItemDef::class.java, data.tool.item).name.lowercase()} to make ${Misc.formatWithIndefiniteArticle(

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/combine/CombinationAction.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/combine/CombinationAction.kt
@@ -51,8 +51,8 @@ object CombinationAction {
         if (!inventory.hasItems(data.items))
             return false
 
-        if (player.skills.getCurrentLevel(Skills.CRAFTING) < data.levelRequired) {
-            task.itemMessageBox("You need a Crafting level of ${data.levelRequired} to<br>craft ${Misc.formatWithIndefiniteArticle(
+        if (player.skills.getCurrentLevel(data.skill) < data.levelRequired) {
+            task.itemMessageBox("You need a ${Skills.getSkillName(player.world, data.skill)} level of ${data.levelRequired} to<br>craft ${Misc.formatWithIndefiniteArticle(
                 resultName
             )}.", item = data.resultItem)
             return false


### PR DESCRIPTION
## What has been done?
 - Fixed the CombinationAction canCombine function to check the CombinationData's skill and not just crafting

Before
![image](https://github.com/2011Scape/game/assets/26328586/ddf4b27b-50b4-4b66-85d5-59ee3e31e5c6)

After
![image](https://github.com/2011Scape/game/assets/26328586/ba491f2e-da7b-41cc-8093-c34920881b35)


## Has your code been documented?
Yes