### PR TITLE
fix: reduce agility overshoot needed for triple loot

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/thieving/pickpocketing/Pickpocketing.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/thieving/pickpocketing/Pickpocketing.kt
@@ -76,7 +76,7 @@ object Pickpocketing {
         return if (thievingLevelOvershoot >= 10 && agilityLevelOvershoot >= 0 && player.world.random(7) == 1) {
             when {
                 thievingLevelOvershoot >= 30 && agilityLevelOvershoot >= 20 -> 4
-                thievingLevelOvershoot >= 20 && agilityLevelOvershoot >= 20 -> 3
+                thievingLevelOvershoot >= 20 && agilityLevelOvershoot >= 10 -> 3
                 else -> 2
             }
         } else {


### PR DESCRIPTION
## What has been done?
 - Reduced the agility level overshoot needed for triple loot by 10
## Has your code been documented?
Yes

Fixes #466 