### PR TITLE
fix: Fixed kebab heal amount

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Foods.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Foods.kt
@@ -103,8 +103,8 @@ object Foods {
                 Pair(0, "That kebab didn't seem to do a lot.")
             }
             randomNumber < 69.95 -> {
-                // Common: Heals 10% of total health
-                val healAmount = (player.skills.getMaxLevel(Skills.CONSTITUTION) * 0.1).toInt()
+                // Common: Heals 10% of total health (the current max consitution level is 10% of total)
+                val healAmount = player.skills.getMaxLevel(Skills.CONSTITUTION).toInt()
                 Pair(healAmount, "It restores some health.")
             }
             randomNumber < 91.07 -> {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Foods.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Foods.kt
@@ -103,7 +103,7 @@ object Foods {
                 Pair(0, "That kebab didn't seem to do a lot.")
             }
             randomNumber < 69.95 -> {
-                // Common: Heals 10% of total health (the current max constitution level is 10% of total)
+                // Common: Heals 10% of total health (the current max constitution level is 10% of total health)
                 val healAmount = player.skills.getMaxLevel(Skills.CONSTITUTION).toInt()
                 Pair(healAmount, "It restores some health.")
             }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Foods.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/Foods.kt
@@ -103,7 +103,7 @@ object Foods {
                 Pair(0, "That kebab didn't seem to do a lot.")
             }
             randomNumber < 69.95 -> {
-                // Common: Heals 10% of total health (the current max consitution level is 10% of total)
+                // Common: Heals 10% of total health (the current max constitution level is 10% of total)
                 val healAmount = player.skills.getMaxLevel(Skills.CONSTITUTION).toInt()
                 Pair(healAmount, "It restores some health.")
             }


### PR DESCRIPTION
Kebabs were only healing 10% of what they should be. At 190 constitution, they would only heal 1 instead of 10 - this is of course very obviously incorrect. This fixes that issue since the Player's max constitution level is already 10% of their total constitution. I have tested and double checked that it now heals the proper amount.

## What has been done?
I fixed a bug in some code I wrote. Kebabs now heal the proper amount.

## Has your code been documented?
The existing code and the bug fix are both fully commented yes.