### PR TITLE
Fix Pathfinding for Interacting with objects

### DIFF
--- a/game/build.gradle
+++ b/game/build.gradle
@@ -1,40 +1,30 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id "com.github.johnrengelman.shadow" version "5.0.0"
     id 'org.jetbrains.dokka' version '0.9.18'
-    id 'org.jetbrains.kotlin.jvm' version '1.8.0'
-    id 'java'
 }
 
 apply plugin: 'application'
 
-description = 'RSMod Game'
+description = '2011Scape Game'
 mainClassName = 'gg.rsmod.game.Launcher'
 
 run {
     workingDir = rootProject.projectDir
 }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(19)
-    }
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "19"
-    }
-}
-
 dependencies {
     implementation project(':util')
     implementation project(':net')
-    implementation project(":game:pathfinder")
+
     runtimeClasspath project(":game:plugins")
 
     implementation "org.jetbrains.kotlin:kotlin-scripting-common:$kotlinVersion"
     implementation "org.jetbrains.kotlin:kotlin-script-runtime:$kotlinVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kcoroutineVersion"
+
+    implementation project(":game:pathfinder")
 
     implementation "org.reflections:reflections:$reflectionsVersion"
     implementation "commons-io:commons-io:$commonsIoVersion"
@@ -53,7 +43,7 @@ sourceSets {
 }
 
 tasks.register("install") {
-    description = 'Install RSMod'
+    description = 'Install 2011Scape'
 
     doLast {
 

--- a/game/build.gradle
+++ b/game/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id "com.github.johnrengelman.shadow" version "5.0.0"
     id 'org.jetbrains.dokka' version '0.9.18'
+    id 'org.jetbrains.kotlin.jvm' version '1.8.0'
+    id 'java'
 }
 
 apply plugin: 'application'
@@ -10,6 +12,18 @@ mainClassName = 'gg.rsmod.game.Launcher'
 
 run {
     workingDir = rootProject.projectDir
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(19)
+    }
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = "19"
+    }
 }
 
 dependencies {

--- a/game/plugins/build.gradle
+++ b/game/plugins/build.gradle
@@ -1,5 +1,9 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id 'org.jetbrains.dokka'
+    id 'org.jetbrains.kotlin.jvm' version '1.8.0'
+    id 'java'
 }
 
 dependencies {
@@ -11,6 +15,18 @@ dependencies {
     testImplementation 'io.mockk:mockk:1.13.4'
     implementation "org.jetbrains.kotlin:kotlin-script-runtime:1.8.0"
 
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(19)
+    }
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = "19"
+    }
 }
 
 dokka {

--- a/game/plugins/build.gradle
+++ b/game/plugins/build.gradle
@@ -1,9 +1,6 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id 'org.jetbrains.dokka'
-    id 'org.jetbrains.kotlin.jvm' version '1.8.0'
-    id 'java'
 }
 
 dependencies {
@@ -15,18 +12,6 @@ dependencies {
     testImplementation 'io.mockk:mockk:1.13.4'
     implementation "org.jetbrains.kotlin:kotlin-script-runtime:1.8.0"
 
-}
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(19)
-    }
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    kotlinOptions {
-        jvmTarget = "19"
-    }
 }
 
 dokka {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/cfg/Objs.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/cfg/Objs.kt
@@ -7193,6 +7193,7 @@ object Objs {
     const val A_SINKING_CANOE_12160 = 12160
     const val A_SINKING_CANOE_12161 = 12161
     const val A_SINKING_CANOE_12162 = 12162
+    const val CANOE_STATION_12163 = 12163
     const val CHAOS_DOOR = 12172
     const val FISHING_SPOT_12201 = 12201
     const val MOLE_HILL = 12202

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/asgarnia/crafting_guild.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/asgarnia/crafting_guild.plugin.kts
@@ -36,7 +36,7 @@ fun handleGuildDoor(player: Player, obj: GameObject) {
     val blockEntrance = DynamicObject(id = 0, type = 0, rot = 0, tile = Tile(x = 2933, z = 3288))
     val doorOpen = DynamicObject(id = obj.id, type = 0, rot = 2, tile = Tile(x = obj.tile.x, z = obj.tile.z))
     val isNorth = player.tile.z >= obj.tile.z
-        if (player.hasEquipped(slot = EquipmentType.CHEST, Items.BROWN_APRON)) {
+        if ((player.hasEquipped(slot = EquipmentType.CHEST, Items.BROWN_APRON) || !isNorth)) {
             player.lockingQueue(lockState = LockState.DELAY_ACTIONS) {
                 world.remove(doorObject)
                 player.playSound(Sfx.DOOR_OPEN)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -185,7 +185,7 @@ fun printGridAroundTile(centerTile: Tile) {
         for (x in (centerTile.x - areaSize)..(centerTile.x + areaSize)) {
             val tile = Tile(x, y)
             val displayChar = if (x == centerTile.x && y == centerTile.z) {
-                "x"
+                "X"
             } else {
                 val tileFlag = world.collision[tile.x, tile.z, tile.height]
                 getCollisionFlagLetter(tileFlag)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -168,7 +168,7 @@ fun getSurroundingRegions(regionId: Int): List<Int> {
 
 on_command("col_map") {
     val args = player.getCommandArgs()
-    tryWithUsage(player, args, "Invalid format! Example of proper command <col=42C66C>::show_grid username</col>") { values ->
+    tryWithUsage(player, args, "Invalid format! Example of proper command <col=42C66C>::col_map username</col>") { values ->
         val p = world.getPlayerForName(values[0].replace("_", " ")) ?: return@tryWithUsage
         printGridAroundTile(p.getCentreTile())
     }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/Combat.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/Combat.kt
@@ -146,7 +146,7 @@ object Combat {
         val withinRange = world.collision.raycast(start, end, projectile = projectile)
 
         // Return true if the pawn is within range or if it needs to move towards the target
-        return withinRange || PawnPathAction.walkTo(it, pawn, target, interactionRange = distance, lineOfSight = false)
+        return withinRange || PawnPathAction.walkTo(it, pawn, target, lineOfSightRange = distance, lineOfSight = false)
     }
 
     fun getProjectileLifespan(source: Pawn, target: Tile, type: ProjectileType): Int = when (type) {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/canoes/canoes.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/canoes/canoes.plugin.kts
@@ -4,6 +4,8 @@ import gg.rsmod.game.message.impl.LocAnimMessage
 import gg.rsmod.game.model.attr.CANOE_VARBIT
 import gg.rsmod.plugins.content.skills.woodcutting.AxeType
 
+
+private val CANOE_STATION = intArrayOf(Objs.CANOE_STATION, Objs.CANOE_STATION_12163)
 private val CANOE_STATIONS_SHAPE_CANOE = Objs.CANOE_STATION_12146
 private val CANOE_STATIONS_FLOAT = intArrayOf(
     Objs.CANOE_STATION_12147, Objs.CANOE_STATION_12148, Objs.CANOE_STATION_12149, Objs.CANOE_STATION_12150
@@ -16,7 +18,7 @@ private val CANOE_STATIONS_PADDLE_CANOE = intArrayOf(
     Objs.CANOE_STATION_12155,
     Objs.CANOE_STATION_12156,
     Objs.CANOE_STATION_12157,
-    Objs.CANOE_STATION_12158
+    Objs.CANOE_STATION_12158,
 )
 
 private val STAGE_TREE_NONINTERACTABLE = 9
@@ -28,7 +30,7 @@ private val FLOAT_ANIMATION = 3304
  * Handles the chopping-down of the Canoe Station tree.
  * @author Kevin Senez <ksenez94@gmail.com>
  */
-on_obj_option(obj = Objs.CANOE_STATION, option = "chop-down") {
+on_obj_options(objects = CANOE_STATION, options = arrayOf("chop-down", "make-canoe"), 2) {
     // The object being interacted with
     val obj = player.getInteractingGameObj()
 
@@ -51,13 +53,13 @@ on_obj_option(obj = Objs.CANOE_STATION, option = "chop-down") {
     // If no axe, don't allow player to progress the canoe construction.
     if (axe == null) {
         player.message("You do not have an axe which you have the woodcutting level to use.")
-        return@on_obj_option
+        return@on_obj_options
     }
 
     // Checks if the player has at least level 12 woodcutting.
     if (player.skills.getCurrentLevel(Skills.WOODCUTTING) < 12) {
         player.message("You need a Woodcutting level of at least 12 to chop down this tree.")
-        return@on_obj_option
+        return@on_obj_options
     }
 
     // Lock the player and queue the chopping down of the tree.
@@ -103,7 +105,7 @@ on_obj_option(obj = Objs.CANOE_STATION, option = "chop-down") {
  * Handles the shaping of the Canoe Station.
  * @author Kevin Senez <ksenez94@gmail.com>
  */
-on_obj_option(obj = CANOE_STATIONS_SHAPE_CANOE, option = "shape-canoe") {
+on_obj_option(obj = CANOE_STATIONS_SHAPE_CANOE, option = "shape-canoe", lineOfSightDistance = 6) {
     // The object being interacted with.
     val obj = player.getInteractingGameObj()
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/npcwalk/npc_random_walk.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/npcwalk/npc_random_walk.plugin.kts
@@ -2,6 +2,7 @@ package gg.rsmod.plugins.content.mechanics.npcwalk
 
 import gg.rsmod.game.model.attr.FACING_PAWN_ATTR
 import gg.rsmod.game.model.attr.NO_CLIP_ATTR
+import gg.rsmod.game.pathfinder.collision.CollisionStrategies
 
 val SEARCH_FOR_PATH_TIMER = TimerKey()
 val SEARCH_FOR_PATH_DELAY = 15..30
@@ -28,11 +29,15 @@ on_timer(SEARCH_FOR_PATH_TIMER) {
 
             val noClip = npc.attr[NO_CLIP_ATTR] ?: false
 
+            val canSwim = npc.canSwim
+
+            val customCollisionStrategy = if (canSwim) CollisionStrategies.Blocked else null
+
             /*
              * Only walk to destination if the chunk has previously been created.
              */
             if (world.collision.isZoneAllocated(dest.x, dest.z, dest.height)) {
-                npc.walkTo(dest)
+                npc.walkTo(dest, detectCollision = !noClip, customCollisionStrategy = customCollisionStrategy)
             }
         }
     }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/duck/duck.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/npcs/duck/duck.plugin.kts
@@ -4,8 +4,10 @@ val FORCE_CHAT_TIMER = TimerKey()
 val DELAY = 60..120
 
 on_global_npc_spawn {
-    if(npc.id == Npcs.DUCK || npc.id == Npcs.DUCK_2693 || npc.id == Npcs.DUCK_6113) {
+    if(npc.id == Npcs.DUCK || npc.id == Npcs.DUCK_2693 || npc.id == Npcs.DUCK_6113 || npc.id == Npcs.DUCKLING
+        || npc.id == Npcs.DUCKLINGS) {
         npc.timers[FORCE_CHAT_TIMER] = world.random(DELAY)
+        npc.canSwim = true
     }
 }
 

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/bank_locs/deposit_box.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/bank_locs/deposit_box.plugin.kts
@@ -6,7 +6,11 @@ import gg.rsmod.plugins.content.inter.bank.openDepositBox
  * @author Alycia <https://github.com/alycii>
  */
 
-private val depositBoxes = listOf(Objs.DEPOSIT_BOX, Objs.DEPOSIT_BOX_2132)
+private val depositBoxes = listOf(Objs.DEPOSIT_BOX, Objs.DEPOSIT_BOX_2132, Objs.DEPOSIT_BOX_15985,
+    Objs.DEPOSIT_BOX_24995, Objs.DEPOSIT_BOX_32924, Objs.BANK_DEPOSIT_BOX_6836, Objs.BANK_DEPOSIT_BOX_9398,
+    Objs.BANK_DEPOSIT_BOX, Objs.BANK_DEPOSIT_BOX_20228, Objs.BANK_DEPOSIT_BOX_25937, Objs.BANK_DEPOSIT_BOX_26969,
+    Objs.BANK_DEPOSIT_BOX_32930, Objs.BANK_DEPOSIT_BOX_32931, Objs.BANK_DEPOSIT_BOX_34755, Objs.BANK_DEPOSIT_BOX_36788,
+    Objs.BANK_DEPOSIT_BOX_39830)
 
 depositBoxes.forEach {
     on_obj_option(obj = it, option = "deposit") {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/pick/pick_cabbage.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/pick/pick_cabbage.plugin.kts
@@ -2,7 +2,7 @@ package gg.rsmod.plugins.content.objs.pick
 
 val RESPAWN_DELAY = 100
 
-on_obj_option(obj = Objs.CABBAGE_1161, option = "pick", lineOfSightDistance = 0) {
+on_obj_option(obj = Objs.CABBAGE_1161, option = "pick", lineOfSightDistance = 1) {
     val obj = player.getInteractingGameObj()
 
     if (obj.isSpawned(world)) {
@@ -13,6 +13,7 @@ on_obj_option(obj = Objs.CABBAGE_1161, option = "pick", lineOfSightDistance = 0)
                     player.message("You don't have room for this cabbage.")
                     return@queue
                 }
+                player.walkTo(obj.tile)
                 player.animate(827)
                 val item = if (world.percentChance(5.0)) Items.CABBAGE_SEED else Items.CABBAGE
                 wait(player.world.definitions.get(AnimDef::class.java, 827).cycleLength)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/pick/pick_flax.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/pick/pick_flax.plugin.kts
@@ -11,6 +11,7 @@ on_obj_option(obj = Objs.FLAX_2646, option = "pick", lineOfSightDistance = 1) {
             player.message("You don't have room for this flax.")
             return@on_obj_option
         }
+        player.walkTo(obj.tile)
         player.animate(827)
         val item = Items.FLAX
         player.inventory.add(item = item)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/pick/pick_onion.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/pick/pick_onion.plugin.kts
@@ -5,7 +5,7 @@ val RESPAWN_DELAY = 100
 val ids = arrayOf(Objs.ONION_3366)
 
 ids.forEach {
-    on_obj_option(obj = it, option = "pick", lineOfSightDistance = 0) {
+    on_obj_option(obj = it, option = "pick", lineOfSightDistance = 1) {
         val obj = player.getInteractingGameObj()
 
         if (obj.isSpawned(world)) {
@@ -16,6 +16,7 @@ ids.forEach {
                         player.message("You don't have room for this onion.")
                         return@queue
                     }
+                    player.walkTo(obj.tile)
                     player.animate(827)
                     val item = if (world.percentChance(5.0)) Items.ONION_SEED else Items.ONION
                     wait(player.world.definitions.get(AnimDef::class.java, 827).cycleLength)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/pick/pick_potato.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/pick/pick_potato.plugin.kts
@@ -2,7 +2,7 @@ package gg.rsmod.plugins.content.objs.pick
 
 val RESPAWN_DELAY = 100
 
-on_obj_option(obj = Objs.POTATO_312, option = "pick", lineOfSightDistance = 0) {
+on_obj_option(obj = Objs.POTATO_312, option = "pick", lineOfSightDistance = 1) {
     val obj = player.getInteractingGameObj()
 
     if (obj.isSpawned(world)) {
@@ -13,6 +13,7 @@ on_obj_option(obj = Objs.POTATO_312, option = "pick", lineOfSightDistance = 0) {
                     player.message("You don't have room for this potato.")
                     return@queue
                 }
+                player.walkTo(obj.tile)
                 player.animate(827)
                 val item = if (world.percentChance(5.0)) Items.POTATO_SEED else Items.POTATO
                 wait(player.world.definitions.get(AnimDef::class.java, 827).cycleLength)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/pick/pick_wheat.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/objs/pick/pick_wheat.plugin.kts
@@ -5,7 +5,7 @@ val RESPAWN_DELAY = 20
 val wheatObjects = arrayOf(Objs.WHEAT, Objs.WHEAT_15506, Objs.WHEAT_15507, Objs.WHEAT_15508, Objs.WHEAT_22300)
 
 wheatObjects.forEach { wheat ->
-    on_obj_option(obj = wheat, option = "pick") {
+    on_obj_option(obj = wheat, option = "pick", lineOfSightDistance = 1) {
         val obj = player.getInteractingGameObj()
 
         if (obj.isSpawned(world)) {
@@ -14,6 +14,7 @@ wheatObjects.forEach { wheat ->
                     player.message("You don't have room for this grain.")
                     return@queue
                 }
+                player.walkTo(obj.tile)
                 player.animate(827)
                 val item = Items.GRAIN
                 wait(player.world.definitions.get(AnimDef::class.java, 827).cycleLength)

--- a/game/src/main/kotlin/gg/rsmod/game/action/GroundItemPathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/GroundItemPathAction.kt
@@ -99,7 +99,7 @@ object GroundItemPathAction {
     }
 
     private fun handleLeanAction(p: Player, groundItem: GroundItem, opt: Int) : Boolean {
-        if(groundItem.tile.isWithinRadius(p.tile, 1)) {
+        if(groundItem.tile.isWithinRadius(p.tile, 1) && !p.isPathBlocked(groundItem)) {
             p.queue {
                 wait(2)
                 p.faceTile(groundItem.tile)

--- a/game/src/main/kotlin/gg/rsmod/game/action/GroundItemPathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/GroundItemPathAction.kt
@@ -86,6 +86,10 @@ object GroundItemPathAction {
                 handleAction(p, item, opt)
                 break
             }
+            if (p.isPathBlocked(item)) {
+                p.writeMessage(Entity.YOU_CANT_REACH_THAT)
+                break
+            }
             if(handleLeanAction(p, item, opt)) {
                 break
             }

--- a/game/src/main/kotlin/gg/rsmod/game/action/GroundItemPathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/GroundItemPathAction.kt
@@ -97,6 +97,7 @@ object GroundItemPathAction {
     private fun handleLeanAction(p: Player, groundItem: GroundItem, opt: Int) : Boolean {
         if(groundItem.tile.isWithinRadius(p.tile, 1)) {
             p.queue {
+                wait(2)
                 p.faceTile(groundItem.tile)
                 p.animate(535)
                 wait(2)

--- a/game/src/main/kotlin/gg/rsmod/game/action/ObjectPathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/ObjectPathAction.kt
@@ -19,6 +19,7 @@ import gg.rsmod.game.model.timer.FROZEN_TIMER
 import gg.rsmod.game.model.timer.STUN_TIMER
 import gg.rsmod.game.pathfinder.Route
 import gg.rsmod.game.pathfinder.collision.CollisionStrategies
+import gg.rsmod.game.pathfinder.flag.CollisionFlag
 import gg.rsmod.game.plugin.Plugin
 import gg.rsmod.util.AabbUtil
 import gg.rsmod.util.DataConstants
@@ -32,16 +33,16 @@ import java.util.*
  */
 object ObjectPathAction {
 
-    fun walk(player: Player, obj: GameObject, lineOfSightRange: Int?, logic: Plugin.() -> Unit) {
+    fun walk(player: Player, obj: GameObject, interactionRange: Int?, logic: Plugin.() -> Unit) {
         player.queue(TaskPriority.STANDARD) {
             terminateAction = {
                 player.stopMovement()
                 player.write(SetMapFlagMessage(255, 255))
             }
 
-            val route = walkTo(obj, lineOfSightRange)
+            val route = walkTo(obj, interactionRange)
             if (route.success) {
-                if (lineOfSightRange == null || lineOfSightRange > 0) {
+                if (interactionRange == null || interactionRange > 0) {
                     faceObj(player, obj)
                 }
                 player.executePlugin(logic)
@@ -62,9 +63,9 @@ object ObjectPathAction {
 
         val item = player.attr[INTERACTING_ITEM]!!.get()!!
         val obj = player.attr[INTERACTING_OBJ_ATTR]!!.get()!!
-        val lineOfSightRange = player.world.plugins.getObjInteractionDistance(obj.id)
+        val interactionRange = player.world.plugins.getObjInteractionDistance(obj.id)
 
-        walk(player, obj, lineOfSightRange) {
+        walk(player, obj, interactionRange) {
             player.faceTile(obj.tile)
             if (!player.world.plugins.executeItemOnObject(player, obj.getTransform(player), item.id)) {
                 player.writeMessage(Entity.NOTHING_INTERESTING_HAPPENS)
@@ -80,25 +81,24 @@ object ObjectPathAction {
 
         val obj = player.attr[INTERACTING_OBJ_ATTR]!!.get()!!
         val opt = player.attr[INTERACTING_OPT_ATTR]
-        val lineOfSightRange = player.world.plugins.getObjInteractionDistance(obj.id)
-        walk(player, obj, lineOfSightRange) {
+        val interactionRange = player.world.plugins.getObjInteractionDistance(obj.id)
+        walk(player, obj, interactionRange) {
             if (!player.world.plugins.executeObject(player, obj.getTransform(player), opt!!)) {
                 player.writeMessage(Entity.NOTHING_INTERESTING_HAPPENS)
             }
         }
     }
 
-    private suspend fun QueueTask.walkTo(obj: GameObject, lineOfSightRange: Int?): Route {
+    private suspend fun QueueTask.walkTo(obj: GameObject, interactionRange: Int?): Route {
         val pawn = ctx as Pawn
 
         val def = obj.getDef(pawn.world.definitions)
-        var tile = obj.tile
+        val tile = obj.tile
         val type = obj.type
         val rot = obj.rot
         var width = def.width
         var length = def.length
-        val clipMask = def.clipMask
-
+        val blockApproach = def.blockApproach
         val wall = type == ObjectType.LENGTHWISE_WALL.value || type == ObjectType.DIAGONAL_WALL.value
         val diagonal = type == ObjectType.DIAGONAL_WALL.value || type == ObjectType.DIAGONAL_INTERACTABLE.value
         val wallDeco = type == ObjectType.INTERACTABLE_WALL_DECORATION.value || type == ObjectType.INTERACTABLE_WALL.value
@@ -118,21 +118,21 @@ object ObjectPathAction {
          * from.
          */
         val blockBits = 4
-        val clipFlag = (DataConstants.BIT_MASK[blockBits] and (clipMask shl rot)) or (clipMask shr (blockBits - rot))
+        val blockFlag = (DataConstants.BIT_MASK[blockBits] and (blockApproach shl rot)) or (blockApproach shr (blockBits - rot))
 
-        if ((0x1 and clipFlag) != 0) {
+        if ((0x1 and blockFlag) != 0) {
             blockDirections.add(Direction.NORTH)
         }
 
-        if ((0x2 and clipFlag) != 0) {
+        if ((0x2 and blockFlag) != 0) {
             blockDirections.add(Direction.EAST)
         }
 
-        if ((0x4 and clipFlag) != 0) {
+        if ((0x4 and blockFlag) != 0) {
             blockDirections.add(Direction.SOUTH)
         }
 
-        if ((clipFlag and 0x8) != 0) {
+        if ((blockFlag and 0x8) != 0) {
             blockDirections.add(Direction.WEST)
         }
 
@@ -162,8 +162,6 @@ object ObjectPathAction {
                 3 -> blockedWallDirections.add(Direction.WEST)
             }
         }
-
-
         if (wall) {
             /*
              * Check if the pawn is within interaction distance of the wall.
@@ -178,58 +176,20 @@ object ObjectPathAction {
             blockDirections.addAll(blockedWallDirections)
         }
 
-        // TODO: this will be fixed with new PF update
-        if(def.name.contains("Furnace")) {
-            tile = when(rot) {
-                0 -> tile.transform(0, width shr 1)
-                1 -> tile.transform(width shr 1, 0)
-                else -> tile
-            }
-        }
-
-        val destination: Tile = pawn.world.findRandomTileAround(obj.tile, radius = 1, centreWidth = def.width, centreLength = def.length) ?: obj.tile
-
         val route = pawn.world.pathFinder.findPath(
             level = pawn.tile.height,
             srcX = pawn.tile.x,
             srcZ = pawn.tile.z,
-            destX = destination.x,
-            destZ = destination.z,
+            destX = tile.x,
+            destZ = tile.z,
+            destWidth = def.width,
+            destHeight = def.length,
             srcSize = pawn.getSize(),
             collision = CollisionStrategies.Normal,
-            objRot = rot,
-            objShape = type,
-            blockAccessFlags = clipFlag
+            objRot = obj.rot,
+            objShape = obj.type,
+            blockAccessFlags = def.blockApproach
         )
-
-        /*
-         * If the object is not a 'diagonal' object, you shouldn't be able to
-         * interact with them from diagonal tiles.
-         */
-/*        if (!diagonal) {
-            builder.clipDiagonalTiles()
-        }
-
-        if(diagonal && width < 2 && length < 2) {
-            builder.clipDiagonalTiles()
-        }*/
-
-        /*
-         * If the object is not a wall object, or if we have a line of sight range
-         * set for the object, then we shouldn't clip the tiles that overlap the
-         * object; otherwise we do clip them.
-         */
-//        if (!wall && (lineOfSightRange == null || lineOfSightRange > 0)) {
-//            builder.clipOverlapTiles()
-//        }
-
-        /*val route = pawn.createPathFindingStrategy().calculateRoute(builder.build())
-
-        if (pawn.timers.has(FROZEN_TIMER) && !pawn.tile.sameAs(route.tail)) {
-            return Route(ArrayDeque(), success = false, tail = pawn.tile)
-        }
-
-        pawn.walkPath(route.path, MovementQueue.StepType.NORMAL, detectCollision = true)*/
 
         val tileQueue: Queue<Tile> = ArrayDeque(route.waypoints.map { Tile(it.x, it.z, it.level) })
         pawn.walkPath(tileQueue, MovementQueue.StepType.NORMAL, detectCollision = true)
@@ -254,13 +214,29 @@ object ObjectPathAction {
             // Here we assume that route.waypoints is already of type List<RouteCoordinates>
             return Route(route.waypoints, alternative = false, success = true)
         }
+        // Find the nearest tile within the object's dimensions to the player
+        val nearestTile = findNearestTile(pawn.tile, tile, width, length, rot)
 
-        // Ensure the route is successful only if the player reaches the object within the interaction distance
-        if (route.success && pawn.tile.isWithinRadius(tile, lineOfSightRange ?: 1)) {
+        val dir = Direction.between(pawn.tile, nearestTile)
+        val collisionFlag = pawn.world.collision.get(nearestTile.x, nearestTile.z, nearestTile.height)
+        val isBlocked = (collisionFlag and getDirectionFlag(dir)) != 0
+
+        // Ensure the route is successful only if the player is within interaction range to the nearest object tile
+        if (route.success && pawn.tile.isWithinRadius(nearestTile, interactionRange ?: 1) && (!isBlocked || wall || wallDeco)) {
             return route
         }
-
+        println("isBlocked: $isBlocked, nearestTile: $nearestTile, collisionFlag: $collisionFlag")
         return Route.FAILED
+    }
+
+    private fun findNearestTile(playerTile: Tile, objectTile: Tile, width: Int, length: Int, rotation: Int): Tile {
+        val adjustedWidth = if (rotation == 1 || rotation == 3) length else width
+        val adjustedLength = if (rotation == 1 || rotation == 3) width else length
+
+        val nearestX = playerTile.x.coerceIn(objectTile.x .. objectTile.x + adjustedWidth)
+        val nearestZ = playerTile.z.coerceIn(objectTile.z .. objectTile.z + adjustedLength)
+
+        return Tile(nearestX, nearestZ, objectTile.height)
     }
 
     private fun faceObj(pawn: Pawn, obj: GameObject) {
@@ -297,6 +273,20 @@ object ObjectPathAction {
                 }
                 pawn.faceTile(tile, width, length)
             }
+        }
+    }
+
+    private fun getDirectionFlag(direction: Direction): Int {
+        return when (direction) {
+            Direction.NORTH -> CollisionFlag.WALL_SOUTH
+            Direction.EAST -> CollisionFlag.WALL_WEST
+            Direction.SOUTH -> CollisionFlag.WALL_NORTH
+            Direction.WEST -> CollisionFlag.WALL_EAST
+            Direction.NORTH_EAST -> CollisionFlag.WALL_SOUTH_EAST
+            Direction.NORTH_WEST -> CollisionFlag.WALL_SOUTH_WEST
+            Direction.SOUTH_EAST -> CollisionFlag.WALL_NORTH_EAST
+            Direction.SOUTH_WEST -> CollisionFlag.WALL_NORTH_WEST
+            else -> 0
         }
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/action/ObjectPathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/ObjectPathAction.kt
@@ -65,7 +65,6 @@ object ObjectPathAction {
         val lineOfSightRange = player.world.plugins.getObjInteractionDistance(obj.id)
 
         walk(player, obj, lineOfSightRange) {
-            player.faceTile(obj.tile)
             if (!player.world.plugins.executeItemOnObject(player, obj.getTransform(player), item.id)) {
                 player.writeMessage(Entity.NOTHING_INTERESTING_HAPPENS)
                 if (player.world.devContext.debugObjects) {
@@ -92,7 +91,7 @@ object ObjectPathAction {
     private suspend fun QueueTask.walkTo(obj: GameObject, lineOfSightRange: Int?): Route {
         val pawn = ctx as Pawn
         val def = obj.getDef(pawn.world.definitions)
-        val tile = obj.tile
+        var tile = obj.tile
         val type = obj.type
         val rot = obj.rot
         var width = def.width
@@ -216,14 +215,11 @@ object ObjectPathAction {
         // Find the nearest tile within the object's dimensions to the player
         val nearestTile = findNearestTile(pawn.tile, tile, width, length, rot)
 
-        val dir = Direction.between(pawn.tile, nearestTile)
+        val dir = Direction.between(pawn.tile, obj.tile)
         val collisionFlag = pawn.world.collision.get(nearestTile.x, nearestTile.z, nearestTile.height)
         val isBlocked = (collisionFlag and getDirectionFlag(dir)) != 0
         val radius = lineOfSightRange ?: 1
 
-        if (def.name.contains("canoe", true)) {
-            val radius = 2
-        }
         val isWithinRadius = pawn.tile.isWithinRadius(nearestTile, radius)
         // Ensure the route is successful only if the player is within interaction range to the nearest object tile
         if (route.success && (isWithinRadius) && (!isBlocked || wall || wallDeco)) {
@@ -239,8 +235,8 @@ object ObjectPathAction {
         val adjustedWidth = if (rotation == 1 || rotation == 3) length else width
         val adjustedLength = if (rotation == 1 || rotation == 3) width else length
 
-        val nearestX = playerTile.x.coerceIn(objectTile.x .. objectTile.x + adjustedWidth)
-        val nearestZ = playerTile.z.coerceIn(objectTile.z .. objectTile.z + adjustedLength)
+        val nearestX = playerTile.x.coerceIn(objectTile.x..objectTile.x + adjustedWidth)
+        val nearestZ = playerTile.z.coerceIn(objectTile.z..objectTile.z + adjustedLength)
 
         return Tile(nearestX, nearestZ, objectTile.height)
     }

--- a/game/src/main/kotlin/gg/rsmod/game/action/ObjectPathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/ObjectPathAction.kt
@@ -81,7 +81,6 @@ object ObjectPathAction {
         val obj = player.attr[INTERACTING_OBJ_ATTR]!!.get()!!
         val opt = player.attr[INTERACTING_OPT_ATTR]
         val lineOfSightRange = player.world.plugins.getObjInteractionDistance(obj.id)
-
         walk(player, obj, lineOfSightRange) {
             if (!player.world.plugins.executeObject(player, obj.getTransform(player), opt!!)) {
                 player.writeMessage(Entity.NOTHING_INTERESTING_HAPPENS)
@@ -196,6 +195,9 @@ object ObjectPathAction {
             destZ = obj.tile.z,
             srcSize = pawn.getSize(),
             collision = CollisionStrategies.Normal,
+            objRot = rot,
+            objShape = type,
+            blockAccessFlags = clipFlag
         )
 
         /*
@@ -251,7 +253,12 @@ object ObjectPathAction {
             return Route(route.waypoints, alternative = false, success = true)
         }
 
-        return route
+        // Ensure the route is successful only if the player reaches the object within the interaction distance
+        if (route.success && pawn.tile.isWithinRadius(tile, lineOfSightRange ?: 1)) {
+            return route
+        }
+
+        return Route.FAILED
     }
 
     private fun faceObj(pawn: Pawn, obj: GameObject) {

--- a/game/src/main/kotlin/gg/rsmod/game/action/ObjectPathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/ObjectPathAction.kt
@@ -187,12 +187,14 @@ object ObjectPathAction {
             }
         }
 
+        val destination: Tile = pawn.world.findRandomTileAround(obj.tile, radius = 1, centreWidth = def.width, centreLength = def.length) ?: obj.tile
+
         val route = pawn.world.pathFinder.findPath(
             level = pawn.tile.height,
             srcX = pawn.tile.x,
             srcZ = pawn.tile.z,
-            destX = obj.tile.x,
-            destZ = obj.tile.z,
+            destX = destination.x,
+            destZ = destination.z,
             srcSize = pawn.getSize(),
             collision = CollisionStrategies.Normal,
             objRot = rot,

--- a/game/src/main/kotlin/gg/rsmod/game/action/ObjectPathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/ObjectPathAction.kt
@@ -19,7 +19,6 @@ import gg.rsmod.game.model.timer.FROZEN_TIMER
 import gg.rsmod.game.model.timer.STUN_TIMER
 import gg.rsmod.game.pathfinder.Route
 import gg.rsmod.game.pathfinder.collision.CollisionStrategies
-import gg.rsmod.game.pathfinder.flag.CollisionFlag
 import gg.rsmod.game.plugin.Plugin
 import gg.rsmod.util.AabbUtil
 import gg.rsmod.util.DataConstants
@@ -215,19 +214,17 @@ object ObjectPathAction {
         // Find the nearest tile within the object's dimensions to the player
         val nearestTile = findNearestTile(pawn.tile, tile, width, length, rot)
 
-        val dir = Direction.between(pawn.tile, obj.tile)
-        val collisionFlag = pawn.world.collision.get(nearestTile.x, nearestTile.z, nearestTile.height)
-        val isBlocked = (collisionFlag and getDirectionFlag(dir)) != 0
+        val isPathBlocked = pawn.isPathBlocked(nearestTile)
         val radius = lineOfSightRange ?: 1
 
         val isWithinRadius = pawn.tile.isWithinRadius(nearestTile, radius)
         // Ensure the route is successful only if the player is within interaction range to the nearest object tile
-        if (route.success && (isWithinRadius) && (!isBlocked || wall || wallDeco)) {
-            println("isBlocked: $isBlocked, nearestTile: $nearestTile, isWithinRadius: $isWithinRadius, radius: $radius")
+        if (route.success && (isWithinRadius) && (!isPathBlocked || wall || wallDeco)) {
+            //println("isBlocked: $isPathBlocked, nearestTile: $nearestTile, isWithinRadius: $isWithinRadius, radius: $radius")
 
             return route
         }
-        println("isBlocked: $isBlocked, nearestTile: $nearestTile, isWithinRadius: $isWithinRadius, radius: $radius")
+        //println("isBlocked: $isPathBlocked, nearestTile: $nearestTile, isWithinRadius: $isWithinRadius, radius: $radius")
         return Route.FAILED
     }
 
@@ -275,20 +272,6 @@ object ObjectPathAction {
                 }
                 pawn.faceTile(tile, width, length)
             }
-        }
-    }
-
-    private fun getDirectionFlag(direction: Direction): Int {
-        return when (direction) {
-            Direction.NORTH -> CollisionFlag.WALL_SOUTH
-            Direction.EAST -> CollisionFlag.WALL_WEST
-            Direction.SOUTH -> CollisionFlag.WALL_NORTH
-            Direction.WEST -> CollisionFlag.WALL_EAST
-            Direction.NORTH_EAST -> CollisionFlag.WALL_SOUTH_EAST
-            Direction.NORTH_WEST -> CollisionFlag.WALL_SOUTH_WEST
-            Direction.SOUTH_EAST -> CollisionFlag.WALL_NORTH_EAST
-            Direction.SOUTH_WEST -> CollisionFlag.WALL_NORTH_WEST
-            else -> 0
         }
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/action/PawnPathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/PawnPathAction.kt
@@ -16,7 +16,6 @@ import gg.rsmod.game.model.timer.RESET_PAWN_FACING_TIMER
 import gg.rsmod.game.model.timer.STUN_TIMER
 import gg.rsmod.game.plugin.Plugin
 import gg.rsmod.util.AabbUtil
-import gg.rsmod.game.pathfinder.PathFinder
 import gg.rsmod.game.pathfinder.collision.CollisionStrategies
 import java.lang.ref.WeakReference
 import java.util.*
@@ -98,7 +97,7 @@ object PawnPathAction {
             }
         }
 
-        val pathFound = walkTo(it, pawn, other, interactionRange = lineOfSightRange ?: 1, lineOfSight = lineOfSightRange != null)
+        val pathFound = walkTo(it, pawn, other, lineOfSightRange = lineOfSightRange ?: 1, lineOfSight = lineOfSightRange != null)
         if (!pathFound) {
             pawn.movementQueue.clear()
             if (pawn is Player) {
@@ -186,12 +185,12 @@ object PawnPathAction {
         }
     }
 
-    suspend fun walkTo(it: QueueTask, pawn: Pawn, target: Pawn, interactionRange: Int, lineOfSight: Boolean): Boolean {
+    suspend fun walkTo(it: QueueTask, pawn: Pawn, target: Pawn, lineOfSightRange: Int, lineOfSight: Boolean): Boolean {
         val sourceSize = pawn.getSize()
         val targetSize = target.getSize()
         val sourceTile = pawn.tile
         val targetTile = target.tile
-        val projectile = interactionRange > 2
+        val projectile = lineOfSightRange > 2
 
         val frozen = pawn.timers.has(FROZEN_TIMER)
         val stunned = pawn.timers.has(STUN_TIMER)
@@ -211,9 +210,9 @@ object PawnPathAction {
 
             if (!projectile) {
                 return if (!lineOfSight) {
-                    bordering(sourceTile, sourceSize, targetTile, interactionRange)
+                    bordering(sourceTile, sourceSize, targetTile, lineOfSightRange)
                 } else {
-                    overlap(sourceTile, sourceSize, targetTile, interactionRange) && (interactionRange == 0 || !sourceTile.sameAs(targetTile))
+                    overlap(sourceTile, sourceSize, targetTile, lineOfSightRange) && (lineOfSightRange == 0 || !sourceTile.sameAs(targetTile))
                             && pawn.world.collision.raycast(sourceTile, targetTile, lineOfSight)
                 }
             }
@@ -252,7 +251,7 @@ object PawnPathAction {
 //
 //        pawn.walkPath(route.path, MovementQueue.StepType.NORMAL, detectCollision = true)
 //
-        if (pawn.hasLineOfSightTo(target, true, interactionRange) && projectile) {
+        if (pawn.hasLineOfSightTo(target, true, lineOfSightRange) && projectile) {
             return newRoute.success
         }
 //

--- a/game/src/main/kotlin/gg/rsmod/game/fs/def/ObjectDef.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/fs/def/ObjectDef.kt
@@ -14,15 +14,17 @@ class ObjectDef(override val id: Int) : Definition(id) {
     var name = ""
     var width = 1
     var length = 1
-    var solid = true
-    var impenetrable = true
-    var interactive = false
+    var blockPath = true
+    var blockProjectile = true
+    var interactType = false
     var obstructive = false
-    var clipMask = 0
+    var blockApproach = 0
+    var contouredGround: Int = -1
     var varbit = -1
     var varp = -1
     var animation = -1
     var rotated = false
+    var hallow = false
     val options: Array<String?> = Array(5) { "" }
     var transforms: Array<Int>? = null
 
@@ -30,8 +32,11 @@ class ObjectDef(override val id: Int) : Definition(id) {
 
     var depleted: Int = -1
 
-    var interactType = 2
+    var solid = 2
+    var supportsItems: Int = -1
 
+    var ambientSoundId: Int = -1
+    var ambientSoundRadius: Int = -1
 
     fun getRotatedWidth(obj: GameObject): Int = when {
         (obj.rot and 0x1) == 1 -> length
@@ -62,12 +67,12 @@ class ObjectDef(override val id: Int) : Definition(id) {
             14 -> width = buf.readUnsignedByte().toInt()
             15 -> length = buf.readUnsignedByte().toInt()
             17 -> {
-                interactType = 0
-                solid = false
+                solid = 0
+                blockPath = false
             }
-            18 -> impenetrable = false
-            19 -> interactive = buf.readUnsignedByte().toInt() == 1
-            21 -> {}
+            18 -> blockProjectile = false
+            19 -> interactType = buf.readUnsignedByte().toInt() == 1
+            21 -> contouredGround = 0
             22 -> {}
             23 -> {}
             24 -> {
@@ -76,7 +81,7 @@ class ObjectDef(override val id: Int) : Definition(id) {
                     animation = -1
                 }
             }
-            27 -> interactType = 1
+            27 -> solid = 1
             28 -> buf.readUnsignedByte()
             29 -> buf.readByte()
             in 30 until 35 -> {
@@ -111,13 +116,13 @@ class ObjectDef(override val id: Int) : Definition(id) {
             65 -> buf.readUnsignedShort()
             66 -> buf.readUnsignedShort()
             67 -> buf.readUnsignedShort()
-            69 -> clipMask = buf.readUnsignedByte().toInt()
+            69 -> blockApproach = buf.readUnsignedByte().toInt()
             70 -> buf.readShort()
             71 -> buf.readShort()
             72 -> buf.readShort()
-            74 -> {}
             73 -> obstructive = true
-            75 -> buf.readUnsignedByte()
+            74 -> hallow = true
+            75 -> supportsItems = buf.readUnsignedByte().toInt()
             77, 92 -> {
                 varbit = buf.readUnsignedShort()
                 varp = buf.readUnsignedShort()
@@ -142,8 +147,8 @@ class ObjectDef(override val id: Int) : Definition(id) {
                 }
             }
             78 -> {
-                buf.readUnsignedShort()
-                buf.readUnsignedByte()
+                ambientSoundId = buf.readUnsignedShort()
+                ambientSoundRadius = buf.readUnsignedByte().toInt()
             }
             79 -> {
                 buf.readUnsignedShort()
@@ -154,7 +159,7 @@ class ObjectDef(override val id: Int) : Definition(id) {
                     buf.readUnsignedShort()
                 }
             }
-            81 -> buf.readUnsignedByte()
+            81 -> contouredGround = buf.readUnsignedByte() * 256
             82 -> {}
             88 -> {}
             89 -> {}

--- a/game/src/main/kotlin/gg/rsmod/game/message/handler/OpLoc1Handler.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/handler/OpLoc1Handler.kt
@@ -40,6 +40,7 @@ class OpLoc1Handler : MessageHandler<OpLoc1Message> {
          */
         val chunk = world.chunks.getOrCreate(tile)
         val obj = chunk.getEntities<GameObject>(tile, EntityType.STATIC_OBJECT, EntityType.DYNAMIC_OBJECT).firstOrNull { it.id == message.id } ?: return
+        val def = obj.getDef(world.definitions)
 
         log(client, "Object action 1: id=%d, x=%d, z=%d, movement=%d", message.id, message.x, message.z, message.movementType)
         if(world.devContext.debugObjects) {
@@ -49,13 +50,15 @@ class OpLoc1Handler : MessageHandler<OpLoc1Message> {
         client.closeInterfaceModal()
         client.fullInterruption(movement = true, animations = true, interactions = true, queue = true)
 
+
         if (message.movementType == 1 && world.privileges.isEligible(client.privilege, Privilege.ADMIN_POWER)) {
-            val def = obj.getDef(world.definitions)
             client.moveTo(world.findRandomTileAround(obj.tile, radius = 1, centreWidth = def.width, centreLength = def.length) ?: obj.tile)
         }
 
         client.attr[INTERACTING_OPT_ATTR] = 1
         client.attr[INTERACTING_OBJ_ATTR] = WeakReference(obj)
         client.executePlugin(ObjectPathAction.objectInteractPlugin)
+        client.writeConsoleMessage("Object Definition: id:${def.id}, width: ${def.width}, length: ${def.length}, blockApproach: ${def.blockApproach}, rotation: ${def.rotated}, solid: ${def.solid}")
+
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/model/Direction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/Direction.kt
@@ -117,14 +117,14 @@ enum class Direction(val orientationValue: Int, val walkValue: Int, val faceNpc:
 
         fun getDirectionFlag(direction: Direction): Int {
             return when (direction) {
-                NORTH -> CollisionFlag.WALL_SOUTH
-                EAST -> CollisionFlag.WALL_WEST
-                SOUTH -> CollisionFlag.WALL_NORTH
-                WEST -> CollisionFlag.WALL_EAST
-                NORTH_EAST -> CollisionFlag.WALL_SOUTH_EAST
-                NORTH_WEST -> CollisionFlag.WALL_SOUTH_WEST
-                SOUTH_EAST -> CollisionFlag.WALL_NORTH_EAST
-                SOUTH_WEST -> CollisionFlag.WALL_NORTH_WEST
+                NORTH -> CollisionFlag.BLOCK_NORTH
+                EAST -> CollisionFlag.BLOCK_EAST
+                SOUTH -> CollisionFlag.BLOCK_SOUTH
+                WEST -> CollisionFlag.BLOCK_WEST
+                NORTH_EAST -> CollisionFlag.BLOCK_NORTH_EAST
+                NORTH_WEST -> CollisionFlag.BLOCK_NORTH_WEST
+                SOUTH_EAST -> CollisionFlag.BLOCK_SOUTH_EAST
+                SOUTH_WEST -> CollisionFlag.BLOCK_SOUTH_WEST
                 else -> 0
             }
         }

--- a/game/src/main/kotlin/gg/rsmod/game/model/Direction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/Direction.kt
@@ -117,14 +117,14 @@ enum class Direction(val orientationValue: Int, val walkValue: Int, val faceNpc:
 
         fun getDirectionFlag(direction: Direction): Int {
             return when (direction) {
-                NORTH -> CollisionFlag.BLOCK_NORTH
-                EAST -> CollisionFlag.BLOCK_EAST
-                SOUTH -> CollisionFlag.BLOCK_SOUTH
-                WEST -> CollisionFlag.BLOCK_WEST
-                NORTH_EAST -> CollisionFlag.BLOCK_NORTH_EAST
-                NORTH_WEST -> CollisionFlag.BLOCK_NORTH_WEST
-                SOUTH_EAST -> CollisionFlag.BLOCK_SOUTH_EAST
-                SOUTH_WEST -> CollisionFlag.BLOCK_SOUTH_WEST
+                NORTH -> CollisionFlag.WALL_SOUTH
+                EAST -> CollisionFlag.WALL_WEST
+                SOUTH -> CollisionFlag.WALL_NORTH
+                WEST -> CollisionFlag.WALL_EAST
+                NORTH_EAST -> CollisionFlag.WALL_SOUTH_WEST
+                NORTH_WEST -> CollisionFlag.WALL_SOUTH_EAST
+                SOUTH_EAST -> CollisionFlag.WALL_NORTH_WEST
+                SOUTH_WEST -> CollisionFlag.WALL_NORTH_EAST
                 else -> 0
             }
         }

--- a/game/src/main/kotlin/gg/rsmod/game/model/Direction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/Direction.kt
@@ -1,5 +1,7 @@
 package gg.rsmod.game.model
 
+import gg.rsmod.game.pathfinder.flag.CollisionFlag
+
 /**
  * Represents cardinal and ordinal directions in the game.
  *
@@ -111,6 +113,20 @@ enum class Direction(val orientationValue: Int, val walkValue: Int, val faceNpc:
                 return EAST
             }
             return if (deltaZ < 0) SOUTH else NORTH
+        }
+
+        fun getDirectionFlag(direction: Direction): Int {
+            return when (direction) {
+                NORTH -> CollisionFlag.WALL_SOUTH
+                EAST -> CollisionFlag.WALL_WEST
+                SOUTH -> CollisionFlag.WALL_NORTH
+                WEST -> CollisionFlag.WALL_EAST
+                NORTH_EAST -> CollisionFlag.WALL_SOUTH_EAST
+                NORTH_WEST -> CollisionFlag.WALL_SOUTH_WEST
+                SOUTH_EAST -> CollisionFlag.WALL_NORTH_EAST
+                SOUTH_WEST -> CollisionFlag.WALL_NORTH_WEST
+                else -> 0
+            }
         }
 
         fun calculateAttackDirection(npc: Tile, player: Tile): Direction {

--- a/game/src/main/kotlin/gg/rsmod/game/model/MovementQueue.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/MovementQueue.kt
@@ -52,7 +52,7 @@ class MovementQueue(val pawn: Pawn) {
 
             walkDirection = Direction.between(tile, next.tile)
 
-            if (walkDirection != Direction.NONE && (!next.detectCollision || pawn.world.canTraverse(tile, walkDirection))) {
+            if (walkDirection != Direction.NONE && (!next.detectCollision || pawn.world.canTraverse(tile, walkDirection, pawn))) {
                 if(pawn is Npc) {
                     val entitiesClipped = mutableListOf<Pawn>()
 
@@ -85,7 +85,7 @@ class MovementQueue(val pawn: Pawn) {
                     if (next != null) {
                         runDirection = Direction.between(tile, next.tile)
 
-                        if (!next.detectCollision || pawn.world.canTraverse(tile, runDirection)) {
+                        if (!next.detectCollision || pawn.world.canTraverse(tile, runDirection, pawn)) {
                             tile = Tile(next.tile)
                             pawn.lastFacingDirection = runDirection
                         } else {

--- a/game/src/main/kotlin/gg/rsmod/game/model/World.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/World.kt
@@ -13,7 +13,6 @@ import gg.rsmod.game.fs.def.ObjectDef
 import gg.rsmod.game.message.impl.LogoutFullMessage
 import gg.rsmod.game.message.impl.UpdateRebootTimerMessage
 import gg.rsmod.game.model.attr.AttributeMap
-import gg.rsmod.game.model.collision.CollisionManager
 import gg.rsmod.game.model.collision.ObjectType
 import gg.rsmod.game.model.collision.isClipped
 import gg.rsmod.game.model.combat.NpcCombatDef
@@ -592,11 +591,11 @@ class World(val gameContext: GameContext, val devContext: DevContext) {
             }
 
             val interactive  = when (type) {
-                ExamineEntityType.OBJECT -> definitions.get(ObjectDef::class.java, id).interactive
+                ExamineEntityType.OBJECT -> definitions.get(ObjectDef::class.java, id).interactType
                 else -> null
             }
             val solid  = when (type) {
-                ExamineEntityType.OBJECT -> definitions.get(ObjectDef::class.java, id).solid
+                ExamineEntityType.OBJECT -> definitions.get(ObjectDef::class.java, id).blockPath
                 else -> null
             }
             if (examine != null) {

--- a/game/src/main/kotlin/gg/rsmod/game/model/World.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/World.kt
@@ -44,6 +44,7 @@ import net.runelite.cache.fs.Store
 import gg.rsmod.game.pathfinder.PathFinder
 import gg.rsmod.game.pathfinder.StepValidator
 import gg.rsmod.game.pathfinder.collision.CollisionFlagMap
+import gg.rsmod.game.pathfinder.flag.CollisionFlag
 import java.io.File
 import java.security.SecureRandom
 import java.util.*
@@ -97,23 +98,33 @@ class World(val gameContext: GameContext, val devContext: DevContext) {
 
     val chunks = ChunkSet(this)
 
-    val collision = CollisionFlagMap()
+    val collision: CollisionFlagMap = CollisionFlagMap()
+
     val stepValidator = StepValidator(collision)
     val pathFinder = PathFinder(collision)
 
     fun canTraverse(
         source: Tile,
         direction: Direction,
-        srcSize: Int = 1,
+        pawn: Pawn,
+        srcSize: Int = 1
     ): Boolean {
-        return stepValidator.canTravel(
-            level = source.height,
-            x = source.x,
-            z = source.z,
-            offsetX = direction.getDeltaX(),
-            offsetZ = direction.getDeltaZ(),
-            size = srcSize,
-        )
+        val nextTile = source.step(direction)
+        val collisionFlags = collision[nextTile.x, nextTile.z, nextTile.height]
+
+        return if (pawn is Npc && pawn.canSwim) {
+            // Allow movement if the FLOOR flag is set, regardless of other flags
+            (collisionFlags and CollisionFlag.FLOOR) != 0
+        } else {
+            stepValidator.canTravel(
+                level = source.height,
+                x = source.x,
+                z = source.z,
+                offsetX = direction.getDeltaX(),
+                offsetZ = direction.getDeltaZ(),
+                size = srcSize
+            )
+        }
     }
 
     val instanceAllocator = InstancedMapAllocator()

--- a/game/src/main/kotlin/gg/rsmod/game/model/collision/CollisionFlagMapExt.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/collision/CollisionFlagMapExt.kt
@@ -128,12 +128,12 @@ private fun CollisionFlagMap.changeNormalCollision(definitions: DefinitionSet, o
     val shape = obj.type
     val location = obj.tile
     val rotation = obj.rot
-    val interactType = def.interactType
-    val blockProjectile = def.impenetrable
+    val solid = def.solid
+    val blockProjectile = def.blockProjectile
     val breakRouteFinding = def.obstructive
 
     when {
-        shape in GameObjectShape.WALL_SHAPES && interactType != 0 -> {
+        shape in GameObjectShape.WALL_SHAPES && solid != 0 -> {
             changeWallCollision(
                 location,
                 rotation,
@@ -143,7 +143,7 @@ private fun CollisionFlagMap.changeNormalCollision(definitions: DefinitionSet, o
                 add
             )
         }
-        shape in GameObjectShape.NORMAL_SHAPES && interactType != 0 -> {
+        shape in GameObjectShape.NORMAL_SHAPES && solid != 0 -> {
             var width = def.width
             var length = def.length
             if (rotation == 1 || rotation == 3) {
@@ -159,7 +159,7 @@ private fun CollisionFlagMap.changeNormalCollision(definitions: DefinitionSet, o
                 add
             )
         }
-        shape in GameObjectShape.GROUND_DECOR_SHAPES && interactType == 1 -> changeFloorDecor(location, add)
+        shape in GameObjectShape.GROUND_DECOR_SHAPES && solid == 1 -> changeFloorDecor(location, add)
     }
 }
 

--- a/game/src/main/kotlin/gg/rsmod/game/model/entity/Npc.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/entity/Npc.kt
@@ -56,9 +56,9 @@ class Npc private constructor(val id: Int, world: World, val spawnTile: Tile) : 
     var walkRadius = 0
 
     /**
-     * The radius from [spawnTile], in tiles, which the npc can randomly walk.
+     * This flag indicates whether this npc can traverse water tiles.
      */
-    var followRadius = 0
+    var canSwim = false
 
     /**
      * The current hitpoints the npc has.

--- a/game/src/main/kotlin/gg/rsmod/game/model/entity/Pawn.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/entity/Pawn.kt
@@ -695,6 +695,30 @@ abstract class Pawn(val world: World) : Entity() {
         world.getService(LoggerService::class.java, searchSubclasses = true)?.logEvent(this, event)
     }
 
+    /**
+     * Checks if the path between the player and the ground item is blocked by a collision flag.
+     *
+     * @param item The item that is being checked for being blocked by a collision flag to the pawn.
+     * @return True if the path is blocked, false otherwise.
+     */
+    fun isPathBlocked(item: GroundItem): Boolean {
+        val dir = Direction.between(this.tile, item.tile)
+        val collisionFlag = this.world.collision.get(item.tile.x, item.tile.z, item.tile.height)
+        return (collisionFlag and Direction.getDirectionFlag(dir)) != 0
+    }
+
+    /**
+     * Checks if the path between the player and the ground item is blocked by a collision flag.
+     *
+     * @param tile The tile that is being checked for being blocked by a collision flag to the pawn.
+     * @return True if the path is blocked, false otherwise.
+     */
+    fun isPathBlocked(tile: Tile): Boolean {
+        val dir = Direction.between(this.tile, tile)
+        val collisionFlag = this.world.collision.get(tile.x, tile.z, tile.height)
+        return (collisionFlag and Direction.getDirectionFlag(dir)) != 0
+    }
+
     fun hasLineOfSightTo(other: Pawn, projectile: Boolean, maximumDistance: Int = 12): Boolean {
         if (this.tile.height != other.tile.height) {
             return false

--- a/game/src/main/kotlin/gg/rsmod/game/model/entity/Pawn.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/entity/Pawn.kt
@@ -704,11 +704,12 @@ abstract class Pawn(val world: World) : Entity() {
     fun isPathBlocked(item: GroundItem): Boolean {
         val dir = Direction.between(this.tile, item.tile)
         val collisionFlag = this.world.collision.get(item.tile.x, item.tile.z, item.tile.height)
+        println("dir: $dir, collisionFlag: $collisionFlag, DirectionFlag: ${Direction.getDirectionFlag(dir)}")
         return (collisionFlag and Direction.getDirectionFlag(dir)) != 0
     }
 
     /**
-     * Checks if the path between the player and the ground item is blocked by a collision flag.
+     * Checks if the path between the player and the tile is blocked by a collision flag.
      *
      * @param tile The tile that is being checked for being blocked by a collision flag to the pawn.
      * @return True if the path is blocked, false otherwise.

--- a/game/src/main/kotlin/gg/rsmod/game/service/game/ObjectMetadataService.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/service/game/ObjectMetadataService.kt
@@ -55,7 +55,7 @@ class ObjectMetadataService : Service {
                 val def = definitions.getNullable(ObjectDef::class.java, metadata.id) ?: return@forEach
                 def.examine = metadata.examine
                 def.depleted = metadata.depleted
-                metadata.solid?.let { def.solid = it }
+                metadata.solid?.let { def.blockPath = it }
             }
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 org.gradle.daemon=true
 org.gradle.parallel=true
-org.gradle.jvmargs=-Xms512m -Xmx4g
+org.gradle.jvmargs=-Xmx8g -Dkotlin.daemon.jvm.options=-Xmx6g


### PR DESCRIPTION
## What has been done?
- Implemented objects and ground item interactions with the new RSMod Pathfinding (version 5.0).
- Improved naming in the ObjectDef class.
- Fixed bug with random event timer throwing ConcurrentModificationException error.
- Added pawn canSwim flag for ducks so they can "swim" on water tiles.
- Added col_map command to print out collision flags around a player. Useful for debugging pathfinding.

## Todo
- Add object interaction exception for pathing to the Target objects in the Ranging Guild.

## Object Interaction Edge Case Testing

https://github.com/2011Scape/game/assets/75695035/8aafbf99-f67c-42ff-a4c7-953ac7d6f2bf

https://github.com/2011Scape/game/assets/75695035/168e108a-4780-43f8-988f-71992fa72245



## Has your code been documented?
Yes.