### PR TITLE
fix: Sending keys for all regions

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/message/encoder/RebuildNormalEncoder.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/encoder/RebuildNormalEncoder.kt
@@ -30,22 +30,13 @@ class RebuildNormalEncoder : MessageEncoder<RebuildNormalMessage>() {
             val rz = (chunkZ + (Chunk.MAX_VIEWPORT shr 4)) shr 3
 
             val buf = Unpooled.buffer(Short.SIZE_BYTES + (Int.SIZE_BYTES * 10))
-            var forceSend = false
-            if ((chunkX / 8 == 48 || chunkX / 8 == 49) && chunkZ / 8 == 48) {
-                forceSend = true
-            }
-            if (chunkX / 8 == 48 && chunkZ / 8 == 148) {
-                forceSend = true
-            }
 
             for (x in lx..rx) {
                 for (z in lz..rz) {
-                    if (!forceSend || z != 49 && z != 149 && z != 147 && x != 50 && (x != 49 || z != 47)) {
-                        val region = z + (x shl 8)
-                        val keys = message.xteaKeyService?.get(region) ?: XteaKeyService.EMPTY_KEYS
-                        for (xteaKey in keys) {
-                            buf.writeInt(xteaKey) // Client always reads as int
-                        }
+                    val region = z + (x shl 8)
+                    val keys = message.xteaKeyService?.get(region) ?: XteaKeyService.EMPTY_KEYS
+                    for (xteaKey in keys) {
+                        buf.writeInt(xteaKey) // Client always reads as int
                     }
                 }
             }


### PR DESCRIPTION
## What has been done?

REBUILD_NORMAL should always be sending a specific amount of keys based on its build area, and the forceSend logic / skipping specific areas circumvents that logic and results in a client crash.

This fixes that!

## Has your code been documented?

No :)
