### PR TITLE
Instances

### DIFF
--- a/data/packets.yml
+++ b/data/packets.yml
@@ -647,6 +647,26 @@ out-packets:
         - name: ignores
           type: BYTES
 
+  - message: gg.rsmod.game.message.impl.RebuildRegionMessage
+    type: VARIABLE_SHORT
+    opcode: 128
+    structure:
+        - name: zoneZ
+          type: SHORT
+        - name: build_area
+          type: BYTE
+        - name: force_load
+          type: BYTE
+          trans: SUBTRACT
+        - name: area_mode
+          type: BYTE
+          trans: SUBTRACT
+        - name: zoneX
+          type: SHORT
+          order: LITTLE
+        - name: data
+          type: BYTES
+
 in-packets:
 
   - message: gg.rsmod.game.message.impl.IgnoreMessage # No data

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -1578,15 +1578,15 @@ on_command("instanceregion", Privilege.ADMIN_POWER) {
     val baseX = (player.tile.regionId shr 8 and 0xFF) shl 6
     val baseZ = (player.tile.regionId and 0xFF) shl 6
 
-    val bottomLeftChunkCoords = Tile(baseX, baseZ).chunkCoords
-    val topRightChunkCoords = Tile(baseX + 63, baseZ + 63).chunkCoords
+    val bottomLeftTile = Tile(baseX, baseZ)
+    val topRightTile = Tile(baseX + 63, baseZ + 63)
 
     val areaToCopy =
         Area(
-            bottomLeftChunkCoords.toTile().x,
-            bottomLeftChunkCoords.toTile().z,
-            topRightChunkCoords.toTile().x + 8,
-            topRightChunkCoords.toTile().z + 8,
+            bottomLeftTile.x,
+            bottomLeftTile.z,
+            topRightTile.x + 8,
+            topRightTile.z + 8,
         )
     val instancedChunkSet = generateInstance(areaToCopy)
     val instancedMapConfigurationBuilder = InstancedMapConfiguration.Builder()

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -4,10 +4,15 @@ import de.mkammerer.argon2.Argon2Factory
 import gg.rsmod.game.fs.def.NpcDef
 import gg.rsmod.game.message.impl.LocAnimMessage
 import gg.rsmod.game.message.impl.LogoutFullMessage
+import gg.rsmod.game.model.Area
+import gg.rsmod.game.model.Tile
 import gg.rsmod.game.model.attr.*
 import gg.rsmod.game.model.bits.INFINITE_VARS_STORAGE
 import gg.rsmod.game.model.bits.InfiniteVarsType
 import gg.rsmod.game.model.collision.ObjectType
+import gg.rsmod.game.model.instance.InstancedChunkSet
+import gg.rsmod.game.model.instance.InstancedMapAttribute
+import gg.rsmod.game.model.instance.InstancedMapConfiguration
 import gg.rsmod.game.model.priv.Privilege
 import gg.rsmod.game.model.region.ChunkCoords
 import gg.rsmod.game.model.timer.ACTIVE_COMBAT_TIMER
@@ -1490,6 +1495,57 @@ on_command("unlockalltracks", Privilege.ADMIN_POWER) {
         if (it == -1) return@forEach
         player.setVarp(it, -1)
     }
+}
+
+on_command("instanceregion", Privilege.ADMIN_POWER) {
+    val bottomLeftChunkCoords = Tile(3200, 3200).chunkCoords
+    val topRightChunkCoords = Tile(3263, 3263).chunkCoords
+
+    val areaToCopy =
+        Area(
+            bottomLeftChunkCoords.toTile().x,
+            bottomLeftChunkCoords.toTile().z,
+            topRightChunkCoords.toTile().x + 8,
+            topRightChunkCoords.toTile().z + 8,
+        )
+    val instancedChunkSet = generateInstance(areaToCopy)
+    val instancedMapConfigurationBuilder = InstancedMapConfiguration.Builder()
+    instancedMapConfigurationBuilder.addAttribute(InstancedMapAttribute.DEALLOCATE_ON_LOGOUT)
+    instancedMapConfigurationBuilder.setOwner(player.uid)
+    instancedMapConfigurationBuilder.setExitTile(world.gameContext.home)
+    val instancedMapConfiguration = instancedMapConfigurationBuilder.build()
+    val instancedChunk = world.instanceAllocator.allocate(player.world, instancedChunkSet, instancedMapConfiguration)!!
+
+    player.queue {
+        player.teleportTo(instancedChunk.area.bottomLeftX + 21, instancedChunk.area.bottomLeftZ + 19)
+    }
+//    println(instancedChunk.area.bottomLeftX)
+//    println(instancedChunk.area.bottomLeftZ)
+}
+
+fun generateInstance(mainMapArea: Area): InstancedChunkSet {
+    val numChunksX = (mainMapArea.topRightX - mainMapArea.bottomLeftX) / 8
+    val numChunksZ = (mainMapArea.topRightZ - mainMapArea.bottomLeftZ) / 8
+    val instanceChunkSet = InstancedChunkSet.Builder()
+    for (x in (0 until numChunksX)) {
+        for (z in (0 until numChunksZ)) {
+            for (height in 0..3) {
+                instanceChunkSet.set(
+                    chunkX = (x),
+                    chunkZ = (z),
+                    height = (height),
+                    rot = 0,
+                    copy =
+                        Tile(
+                            x = (mainMapArea.bottomLeftX + (x * 8)),
+                            z = (mainMapArea.bottomLeftZ + (z * 8)),
+                            height = (height),
+                        ),
+                )
+            }
+        }
+    }
+    return instanceChunkSet.build()
 }
 
 fun displayKillCounts(

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -1588,6 +1588,7 @@ on_command("instanceregion", Privilege.ADMIN_POWER) {
     val instancedChunkSet = generateInstance(areaToCopy)
     val instancedMapConfigurationBuilder = InstancedMapConfiguration.Builder()
     instancedMapConfigurationBuilder.addAttribute(InstancedMapAttribute.DEALLOCATE_ON_LOGOUT)
+    instancedMapConfigurationBuilder.addNpc(Npcs.COOK, 10, 15, 0, world)
     instancedMapConfigurationBuilder.setOwner(player.uid)
     instancedMapConfigurationBuilder.setExitTile(world.gameContext.home)
     val instancedMapConfiguration = instancedMapConfigurationBuilder.build()

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -1575,8 +1575,11 @@ on_command("unlockalltracks", Privilege.ADMIN_POWER) {
 }
 
 on_command("instanceregion", Privilege.ADMIN_POWER) {
-    val bottomLeftChunkCoords = Tile(3200, 3200).chunkCoords
-    val topRightChunkCoords = Tile(3263, 3263).chunkCoords
+    val baseX = (player.tile.regionId shr 8 and 0xFF) * 64
+    val baseZ = (player.tile.regionId and 0xFF) * 64
+
+    val bottomLeftChunkCoords = Tile(baseX, baseZ).chunkCoords
+    val topRightChunkCoords = Tile(baseX + 63, baseZ + 63).chunkCoords
 
     val areaToCopy =
         Area(
@@ -1588,7 +1591,6 @@ on_command("instanceregion", Privilege.ADMIN_POWER) {
     val instancedChunkSet = generateInstance(areaToCopy)
     val instancedMapConfigurationBuilder = InstancedMapConfiguration.Builder()
     instancedMapConfigurationBuilder.addAttribute(InstancedMapAttribute.DEALLOCATE_ON_LOGOUT)
-    instancedMapConfigurationBuilder.addNpc(Npcs.COOK, 10, 15, 0, world)
     instancedMapConfigurationBuilder.setOwner(player.uid)
     instancedMapConfigurationBuilder.setExitTile(world.gameContext.home)
     val instancedMapConfiguration = instancedMapConfigurationBuilder.build()

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -1599,8 +1599,6 @@ on_command("instanceregion", Privilege.ADMIN_POWER) {
     player.queue {
         player.teleportTo(instancedChunk.area.bottomLeftX + 21, instancedChunk.area.bottomLeftZ + 19)
     }
-//    println(instancedChunk.area.bottomLeftX)
-//    println(instancedChunk.area.bottomLeftZ)
 }
 
 fun generateInstance(mainMapArea: Area): InstancedChunkSet {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/cmd/commands.plugin.kts
@@ -1575,8 +1575,8 @@ on_command("unlockalltracks", Privilege.ADMIN_POWER) {
 }
 
 on_command("instanceregion", Privilege.ADMIN_POWER) {
-    val baseX = (player.tile.regionId shr 8 and 0xFF) * 64
-    val baseZ = (player.tile.regionId and 0xFF) * 64
+    val baseX = (player.tile.regionId shr 8 and 0xFF) shl 6
+    val baseZ = (player.tile.regionId and 0xFF) shl 6
 
     val bottomLeftChunkCoords = Tile(baseX, baseZ).chunkCoords
     val topRightChunkCoords = Tile(baseX + 63, baseZ + 63).chunkCoords

--- a/game/src/main/kotlin/gg/rsmod/game/message/MessageEncoderSet.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/MessageEncoderSet.kt
@@ -74,6 +74,7 @@ class MessageEncoderSet {
         put(SetPrivateChatFilterEncoder(), SetPrivateChatFilterMessage::class.java)
         put(MessagePrivateSentEncoder(), MessagePrivateSentMessage::class.java)
         put(UpdateIgnoreListEncoder(), UpdateIgnoreListMessage::class.java)
+        put(RebuildRegionEncoder(), RebuildRegionMessage::class.java)
     }
 
     private fun <T : Message> put(

--- a/game/src/main/kotlin/gg/rsmod/game/message/impl/RebuildRegionMessage.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/impl/RebuildRegionMessage.kt
@@ -11,6 +11,8 @@ data class RebuildRegionMessage(
     val z: Int,
     val forceLoad: Int,
     val coordinates: IntArray,
+    val buildArea: Int,
+    val areaMode: Int,
     val xteaKeyService: XteaKeyService?,
 ) : Message {
     override fun equals(other: Any?): Boolean {
@@ -22,6 +24,8 @@ data class RebuildRegionMessage(
         if (x != other.x) return false
         if (z != other.z) return false
         if (forceLoad != other.forceLoad) return false
+        if (buildArea != other.buildArea) return false
+        if (areaMode != other.areaMode) return false
         if (!coordinates.contentEquals(other.coordinates)) return false
         if (xteaKeyService != other.xteaKeyService) return false
 
@@ -32,6 +36,8 @@ data class RebuildRegionMessage(
         var result = x
         result = 31 * result + z
         result = 31 * result + forceLoad
+        result = 31 * result + buildArea
+        result = 31 * result + areaMode
         result = 31 * result + coordinates.contentHashCode()
         result = 31 * result + (xteaKeyService?.hashCode() ?: 0)
         return result

--- a/game/src/main/kotlin/gg/rsmod/game/message/impl/RebuildRegionMessage.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/message/impl/RebuildRegionMessage.kt
@@ -4,8 +4,29 @@ import gg.rsmod.game.message.Message
 import gg.rsmod.game.service.xtea.XteaKeyService
 
 /**
- * @author Tom <rspsmods@gmail.com>
+ * Represents a message responsible for rebuilding a specific region in the game
+ * based on the provided coordinates and parameters.
+ *
+ * @property x The x-coordinate of the region.
+ * @property z The z-coordinate of the region.
+ * @property forceLoad A flag indicating whether the region should be forcefully loaded.
+ * @property coordinates An array consisting of coordinates related to the region.
+ * @property buildArea The identifier of the build area for the region.
+ * @property areaMode The mode applied to the area during the rebuild process. The value of
+ * `areaMode` determines specific behavior based on the client constants:
+ *   - `DEFAULT (-1)`: Default behavior, applies no special rules.
+ *   - `STATIC_AREA (0)`: Indicates the area is static and unchanging.
+ *   - `CLEAR_LOCAL_NPCS (1)`: Clears all local NPCs (Non-Player Characters) within the area.
+ *   - `ALLOW_OUT_OF_BOUNDS (3)`: Allows building operations outside the region’s defined boundaries.
+ *   - `RETAIN_OUT_OF_BOUNDS (4)`: Retains items or configurations beyond the region’s normal boundaries.
+ * @property xteaKeyService The service responsible for providing XTEA keys required
+ * for map decryption within the region. These keys ensure secure and correct decryption
+ * of game map data.
+ *
+ * This message is critical in managing game regions dynamically, enabling
+ * functionality like forced loading, boundary adjustments, and NPC management.
  */
+
 data class RebuildRegionMessage(
     val x: Int,
     val z: Int,

--- a/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/entity/Player.kt
@@ -231,6 +231,9 @@ abstract class Player(
     var publicFilterSetting = ChatFilterType.ON
     var tradeFilterSetting = ChatFilterType.ON
 
+    var movedToInstance = false
+    var movedFromInstance = false
+
     override val entityType: EntityType = EntityType.PLAYER
 
     /**

--- a/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapAllocator.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapAllocator.kt
@@ -8,6 +8,7 @@ import gg.rsmod.game.model.entity.DynamicObject
 import gg.rsmod.game.model.entity.Player
 import gg.rsmod.game.model.entity.StaticObject
 import gg.rsmod.game.model.region.Chunk
+import gg.rsmod.game.model.region.ChunkCoords
 
 /**
  * A system responsible for allocating and de-allocating [InstancedMap]s.
@@ -236,12 +237,15 @@ class InstancedMapAllocator {
         world: World,
         map: InstancedMap,
     ) {
-        val regionCount = map.chunks.regionSize
         val chunks = world.chunks
 
-        for (i in 0 until regionCount) {
-            val tile = map.area.bottomLeft.transform(i * Chunk.REGION_SIZE, i * Chunk.REGION_SIZE)
-            chunks.remove(tile.chunkCoords)
+        val bottomLeftChunk = map.area.bottomLeft.chunkCoords
+        val topRightChunk = map.area.topRight.chunkCoords
+
+        for (x in bottomLeftChunk.x until topRightChunk.x) {
+            for (z in bottomLeftChunk.z until topRightChunk.z) {
+                chunks.remove(ChunkCoords(x, z))
+            }
         }
     }
 

--- a/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapAllocator.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapAllocator.kt
@@ -4,6 +4,7 @@ import gg.rsmod.game.model.Area
 import gg.rsmod.game.model.EntityType
 import gg.rsmod.game.model.Tile
 import gg.rsmod.game.model.World
+import gg.rsmod.game.model.entity.Npc
 import gg.rsmod.game.model.entity.Player
 import gg.rsmod.game.model.entity.StaticObject
 import gg.rsmod.game.model.region.Chunk
@@ -61,6 +62,7 @@ class InstancedMapAllocator {
                 val map = allocate(x, z, chunks, configs)
                 applyCollision(world, map, configs.bypassObjectChunkBounds)
                 maps.add(map)
+                addNpcs(configs.npcs, map)
                 return map
             }
         }
@@ -229,6 +231,25 @@ class InstancedMapAllocator {
                     }
                 }
             }
+        }
+    }
+
+    private fun addNpcs(
+        npcs: List<Npc>,
+        map: InstancedMap,
+    ) {
+        npcs.forEach { npc ->
+            npc.world.spawn(
+                Npc(
+                    npc.id,
+                    Tile(
+                        map.area.bottomLeftX + npc.tile.x,
+                        map.area.bottomLeftZ + npc.tile.z,
+                        npc.tile.height,
+                    ),
+                    npc.world,
+                ),
+            )
         }
     }
 

--- a/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapAllocator.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapAllocator.kt
@@ -4,7 +4,6 @@ import gg.rsmod.game.model.Area
 import gg.rsmod.game.model.EntityType
 import gg.rsmod.game.model.Tile
 import gg.rsmod.game.model.World
-import gg.rsmod.game.model.entity.DynamicObject
 import gg.rsmod.game.model.entity.Player
 import gg.rsmod.game.model.entity.StaticObject
 import gg.rsmod.game.model.region.Chunk
@@ -194,7 +193,7 @@ class InstancedMapAllocator {
                                 val localZ = obj.tile.z % 8
 
                                 val newObj =
-                                    DynamicObject(
+                                    StaticObject(
                                         obj.id,
                                         obj.type,
                                         (obj.rot + chunk.rot) and 0x3,

--- a/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapConfiguration.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapConfiguration.kt
@@ -2,6 +2,8 @@ package gg.rsmod.game.model.instance
 
 import gg.rsmod.game.model.PlayerUID
 import gg.rsmod.game.model.Tile
+import gg.rsmod.game.model.World
+import gg.rsmod.game.model.entity.Npc
 import java.util.*
 
 /**
@@ -35,6 +37,7 @@ class InstancedMapConfiguration private constructor(
     val owner: PlayerUID?,
     val attributes: EnumSet<InstancedMapAttribute>,
     val bypassObjectChunkBounds: Boolean,
+    val npcs: List<Npc>,
 ) {
     class Builder {
         private var exitTile: Tile? = null
@@ -44,6 +47,8 @@ class InstancedMapConfiguration private constructor(
         private val attributes = EnumSet.noneOf(InstancedMapAttribute::class.java)
 
         private var bypassObjectChunkBounds: Boolean = false
+
+        private val npcs = mutableListOf<Npc>()
 
         fun build(): InstancedMapConfiguration {
             val ownerRequired =
@@ -57,7 +62,7 @@ class InstancedMapConfiguration private constructor(
                 owner != null || attributes.none { it in ownerRequired },
             ) { "One or more attributes require an owner to be set." }
 
-            return InstancedMapConfiguration(exitTile!!, owner, attributes, bypassObjectChunkBounds)
+            return InstancedMapConfiguration(exitTile!!, owner, attributes, bypassObjectChunkBounds, npcs)
         }
 
         fun setExitTile(tile: Tile): Builder {
@@ -77,6 +82,24 @@ class InstancedMapConfiguration private constructor(
             attributes.add(attribute)
             attributes.addAll(others)
             return this
+        }
+
+        /**
+         * Adds NPCs when the instance is allocated. Tile positions for the NPCs should be
+         * the offset based on the bottom left tile of the instance.
+         */
+        fun addNpc(npc: Npc) {
+            npcs.add(npc)
+        }
+
+        fun addNpc(
+            id: Int,
+            offsetX: Int,
+            offsetZ: Int,
+            height: Int,
+            world: World,
+        ) {
+            addNpc(Npc(id, Tile(offsetX, offsetZ, height), world))
         }
 
         /**

--- a/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapConfiguration.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapConfiguration.kt
@@ -86,7 +86,7 @@ class InstancedMapConfiguration private constructor(
 
         /**
          * Adds NPCs when the instance is allocated. Tile positions for the NPCs should be
-         * the offset based on the bottom left tile of the instance.
+         * the relative coordinates based on the bottom left tile of the instance.
          */
         fun addNpc(npc: Npc) {
             npcs.add(npc)
@@ -94,12 +94,12 @@ class InstancedMapConfiguration private constructor(
 
         fun addNpc(
             id: Int,
-            offsetX: Int,
-            offsetZ: Int,
+            relativeX: Int,
+            relativeZ: Int,
             height: Int,
             world: World,
         ) {
-            addNpc(Npc(id, Tile(offsetX, offsetZ, height), world))
+            addNpc(Npc(id, Tile(relativeX, relativeZ, height), world))
         }
 
         /**

--- a/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapConfiguration.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/instance/InstancedMapConfiguration.kt
@@ -85,8 +85,9 @@ class InstancedMapConfiguration private constructor(
         }
 
         /**
-         * Adds NPCs when the instance is allocated. Tile positions for the NPCs should be
-         * the relative coordinates based on the bottom left tile of the instance.
+         * Adds an NPC to a list that will be spawned when the instance is allocated.
+         * Tile positions for the NPCs should be the relative coordinates based on the
+         * bottom left tile of the instance.
          */
         fun addNpc(npc: Npc) {
             npcs.add(npc)

--- a/game/src/main/kotlin/gg/rsmod/game/sync/task/NpcSynchronizationTask.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/sync/task/NpcSynchronizationTask.kt
@@ -49,10 +49,20 @@ class NpcSynchronizationTask(
     private fun getSegments(player: Player): List<SynchronizationSegment> {
         val segments = mutableListOf<SynchronizationSegment>()
 
-        val localNpcs = player.localNpcs
+        if (player.movedToInstance) {
+            player.localNpcs.clear()
+            segments.add(NpcCountSegment(0))
+            return segments
+        }
+
+        var localNpcs = player.localNpcs
         val iterator = localNpcs.iterator()
 
-        segments.add(NpcCountSegment(localNpcs.size))
+        if (player.movedFromInstance) {
+            segments.add(NpcCountSegment(0))
+        } else {
+            segments.add(NpcCountSegment(localNpcs.size))
+        }
         while (iterator.hasNext()) {
             val npc = iterator.next()
             if (shouldRemove(player, npc)) {

--- a/game/src/main/kotlin/gg/rsmod/game/sync/task/NpcSynchronizationTask.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/sync/task/NpcSynchronizationTask.kt
@@ -49,20 +49,16 @@ class NpcSynchronizationTask(
     private fun getSegments(player: Player): List<SynchronizationSegment> {
         val segments = mutableListOf<SynchronizationSegment>()
 
-        if (player.movedToInstance) {
+        if (player.movedToInstance || player.movedFromInstance) {
             player.localNpcs.clear()
             segments.add(NpcCountSegment(0))
             return segments
         }
 
-        var localNpcs = player.localNpcs
+        val localNpcs = player.localNpcs
         val iterator = localNpcs.iterator()
 
-        if (player.movedFromInstance) {
-            segments.add(NpcCountSegment(0))
-        } else {
-            segments.add(NpcCountSegment(localNpcs.size))
-        }
+        segments.add(NpcCountSegment(localNpcs.size))
         while (iterator.hasNext()) {
             val npc = iterator.next()
             if (shouldRemove(player, npc)) {

--- a/game/src/main/kotlin/gg/rsmod/game/sync/task/PlayerPreSynchronizationTask.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/sync/task/PlayerPreSynchronizationTask.kt
@@ -19,6 +19,9 @@ object PlayerPreSynchronizationTask : SynchronizationTask<Player> {
         val last = pawn.lastKnownRegionBase
         val current = pawn.tile
 
+        pawn.movedToInstance = last != null && last.x < 6368 && current.x >= 6400
+        pawn.movedFromInstance = last != null && last.x >= 6368 && current.x < 6400
+
         if (last == null || shouldRebuildRegion(last, current)) {
             val regionX = ((current.x shr 3) - (Chunk.MAX_VIEWPORT shr 4)) shl 3
             val regionZ = ((current.z shr 3) - (Chunk.MAX_VIEWPORT shr 4)) shl 3

--- a/game/src/main/kotlin/gg/rsmod/game/sync/task/PlayerPreSynchronizationTask.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/sync/task/PlayerPreSynchronizationTask.kt
@@ -29,14 +29,17 @@ object PlayerPreSynchronizationTask : SynchronizationTask<Player> {
             val instance = pawn.world.instanceAllocator.getMap(current)
             val rebuildMessage =
                 when {
-                    instance != null ->
+                    instance != null -> {
                         RebuildRegionMessage(
                             current.x shr 3,
                             current.z shr 3,
-                            1,
+                            0,
                             instance.getCoordinates(pawn.tile),
+                            0,
+                            1,
                             xteaService,
                         )
+                    }
                     else ->
                         RebuildNormalMessage(
                             pawn.mapSize,


### PR DESCRIPTION
## What has been done?
- Added the RebuildRegion packet
- Adjusted the pre-existing `RebuildRegionEncoder` and `RebuildRegionMessage` to work for our client
- Added the `instanceregion` test command

## Todo
- [x] Figure out why `NpcSynchronizationTask` breaks instancing. Commenting out the `run` function fixes the issue but then you have no NPCs.
- [x] Resolve movement issues when in an instanced area (Does the PF update fix this?)
- [x] Remove `DynamicObject`s from the instance after the player leaves / logs out. Currently they're only removed from the bottom left 8x8 chunk
