### PR TITLE
Change combat level message for max combat from lvl 126 to 138

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/level_up.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/level_up.plugin.kts
@@ -99,9 +99,9 @@ set_level_up_logic {
                 if (lastCombat >= combatArray[i] || currentCombatLevel < combatArray[i]) {
                     continue
                 }
-                if (currentCombatLevel == 126) { // TODO CHANGE TO LVL 138 ONCE SUMMONING IS ADDED
+                if (currentCombatLevel == 138) {
                     player.message(
-                        "<col=800000>Congratulations! Your Combat level is now 126! You've achieved the highest Combat level possible!",
+                        "<col=800000>Congratulations! Your Combat level is now 138! You've achieved the highest Combat level possible!",
                         type = ChatMessageType.GAME_MESSAGE,
                     )
                 } else {


### PR DESCRIPTION
## What has been done?

Fixing bug where you get a message that says you reached max combat at level 126, but with Summoning it was raised to 138.

## Has your code been documented?