### PR TITLE
Restless ghost cleanup

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/lumbridge/father_urhney.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/lumbridge/father_urhney.plugin.kts
@@ -163,6 +163,7 @@ suspend fun duringRestlessGhost(it: QueueTask) {
                     it.chatNpc("I'll tell you what I can do, though - take this amulet.")
                     it.itemMessageBox("Father Urhney gives you an amulet.", item = Items.GHOSTSPEAK_AMULET)
                     it.player.inventory.add(Items.GHOSTSPEAK_AMULET)
+                    it.player.advanceToNextStage(theRestLessGhost)
                     it.chatNpc("It's a ghostspeak amulet.")
                     it.chatNpc(
                         "It's called that because, when you wear it, you can speak",
@@ -175,7 +176,6 @@ suspend fun duringRestlessGhost(it: QueueTask) {
                         "the best I can do right now.",
                     )
                     it.chatPlayer("Thank you. I'll give it a try.")
-                    it.player.advanceToNextStage(theRestLessGhost)
                 }
             }
         }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/lumbridge/rock_with_skull.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/lumbridge/rock_with_skull.plugin.kts
@@ -35,17 +35,32 @@ on_obj_option(Objs.ROCKS_47714, "search") {
                 if (player.inventory.capacity < 1) {
                     player.filterableMessage("You don't have enough inventory space.")
                 } else if (player.inventory.add(Items.MUDDY_SKULL).hasSucceeded()) {
-                    player.advanceToNextStage(theRestlessGhost)
+                    if (player.getCurrentStage(theRestlessGhost) == 3) {
+                        player.advanceToNextStage(theRestlessGhost)
+                    }
                     player.message("You take the skull from the pile of rocks.")
                     // varbit = 0 transforms obj to 47714, 1 = obj 47715, 2 = invisible
                     player.setVarbit(2130, 1)
-                    player.message("A skeleton warlock has appeared!")
-                    val skeletonWarlock = Npc(Npcs.SKELETON_WARLOCK, location, world)
-                    skeletonWarlock.animate(1993)
-                    world.spawn(skeletonWarlock)
-                    skeletonWarlock.facePawn(player)
+                    if (!world.npcs.any { npc -> npc.id == Npcs.SKELETON_WARLOCK && npc.owner == player }) {
+                        player.message("A skeleton warlock has appeared!")
+                        val skeletonWarlock = Npc(player, Npcs.SKELETON_WARLOCK, location, world)
+                        player.lock = LockState.FULL
+                        skeletonWarlock.facePawn(player)
+                        world.spawn(skeletonWarlock)
+                        skeletonWarlock.animate(1993)
+                        wait(3)
+                        player.lock = LockState.NONE
+                        skeletonWarlock.attack(player)
+                    }
                 }
             }
         }
+    }
+}
+
+on_obj_option(Objs.ROCKS_47715, "search") {
+    player.lockingQueue(lockState = LockState.FULL) {
+        player.message("There's nothing there of any interest.")
+        wait(1)
     }
 }


### PR DESCRIPTION
## What has been done?
- Fix a bug where player could complete the quest but not receive the rewards or quest points, by interacting with the rock multiple times after destroying the muddy skull
- Made it so the warlock does their spawn animation properly and then attacks the player
- Added a missing interaction with empty rock
- The player is now the "owner" of the spawned warlock, which will disappear upon logout instead of sticking around
- The player can no longer spawn more warlocks if there is already one spawned for the player 

## Has your code been documented?