### PR TITLE
Fix Compost disease rates to actually match wiki rate

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/constants/CompostState.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/farming/constants/CompostState.kt
@@ -13,8 +13,8 @@ enum class CompostState(
     val lives: Int,
 ) {
     None(itemId = -1, diseaseChanceFactor = 1.0, varbitValue = 0, xp = 0.0, lives = 0),
-    Compost(itemId = Items.COMPOST, diseaseChanceFactor = 0.5, varbitValue = 1, 18.0, lives = 1),
-    SuperCompost(itemId = Items.SUPERCOMPOST, diseaseChanceFactor = 0.8, varbitValue = 2, 26.0, lives = 2),
+    Compost(itemId = Items.COMPOST, diseaseChanceFactor = 0.28, varbitValue = 1, 18.0, lives = 1),
+    SuperCompost(itemId = Items.SUPERCOMPOST, diseaseChanceFactor = 0.14, varbitValue = 2, 26.0, lives = 2),
     ;
 
     val replacement = Items.BUCKET


### PR DESCRIPTION
Wiki states disease rate for supercompost is reduced to 14% chance of disease, while regular compost is half as effective, only reduced to a 28% chance of disease)

Rates were previously erroneously swapped, where regular compost was giving much better disease rates than super compost 

## What has been done?

- Fixed the disease ratios for compost to actually match wiki, making sure supercompost is actually better than normal compost (in this case lower ratio means less chance for disease)

## Has your code been documented?