### PR TITLE
Change npc magic combat formula

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/formula/MagicCombatFormula.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/formula/MagicCombatFormula.kt
@@ -96,9 +96,11 @@ object MagicCombatFormula : CombatFormula {
             hit *= multiplier
             hit = Math.floor(hit)
         } else if (pawn is Npc) {
-            val multiplier = 1.0 + (pawn.getMagicDamageBonus() / 100.0)
-            hit *= multiplier
-            hit = Math.floor(hit)
+            val a = getEffectiveAttackLevel(pawn)
+            val b = 1.0 + (pawn.getMagicDamageBonus() / 100.0)
+
+            var base = 0.5 + a * (b + 64.0) / 640.0
+            hit = Math.floor(base)
         }
 
         hit *= getDamageDealMultiplier(pawn)


### PR DESCRIPTION
NPC's which have special mechanics that utilize multiple attack styles cannot utilize the spell id setting in combat defs

## What has been done?

- Magic combat formula for NPC now uses same formula as ranged/melee. The previous formula was busted and only returned max of 1 (if there was no spell associated with the npc)

## Has your code been documented?