### PR TITLE
Fix NPC magic combat

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/formula/MagicCombatFormula.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/combat/formula/MagicCombatFormula.kt
@@ -96,9 +96,19 @@ object MagicCombatFormula : CombatFormula {
             hit *= multiplier
             hit = Math.floor(hit)
         } else if (pawn is Npc) {
-            val multiplier = 1.0 + (pawn.getMagicDamageBonus() / 100.0)
-            hit *= multiplier
-            hit = Math.floor(hit)
+            val spell = pawn.attr[Combat.CASTING_SPELL]
+            if (spell == null) {
+                val a = getEffectiveAttackLevel(pawn)
+                val b = 1.0 + (pawn.getMagicDamageBonus() / 100.0)
+
+                var base = 0.5 + a * (b + 64.0) / 640.0
+                hit = Math.floor(base)
+            }
+            else {
+                val multiplier = 1.0 + (pawn.getMagicDamageBonus() / 100.0)
+                hit *= multiplier
+                hit = Math.floor(hit)
+            }
         }
 
         hit *= getDamageDealMultiplier(pawn)


### PR DESCRIPTION
## What has been done?
- Magic combat for npc uses the default formula for damage if there is no spell being cast. 
This allows npcs with special combat mechanics (like revenants/aberrant spectres) to do damage that isn't a 1

## Has your code been documented?