### PR TITLE
Add setting exit tile to createTemporaryInstance

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/model/World.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/World.kt
@@ -719,6 +719,7 @@ class World(
     fun createTemporaryInstance(
         owner: Player,
         regionId: Int,
+        exitTile: Tile = gameContext.home,
     ): InstancedMap? {
         val baseX = (regionId shr 8 and 0xFF) shl 6
         val baseZ = (regionId and 0xFF) shl 6
@@ -737,7 +738,7 @@ class World(
         val instancedMapConfigurationBuilder = InstancedMapConfiguration.Builder()
         instancedMapConfigurationBuilder.addAttribute(InstancedMapAttribute.DEALLOCATE_ON_LOGOUT)
         instancedMapConfigurationBuilder.setOwner(owner.uid)
-        instancedMapConfigurationBuilder.setExitTile(gameContext.home)
+        instancedMapConfigurationBuilder.setExitTile(exitTile)
         val instancedMapConfiguration = instancedMapConfigurationBuilder.build()
         val instance = instanceAllocator.allocate(this, instancedChunkSet, instancedMapConfiguration)
 


### PR DESCRIPTION
## What has been done?
- Added the option to set the exit tile for instances created using `createTemporaryInstance`. Currently it just uses `gameContext.home` (Lumbridge). This will remain as the default.