### PR TITLE
Task priority correction

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
@@ -454,7 +454,7 @@ fun Player.openInterface(
         child,
         dest.interfaceId,
         if (dest.clickThrough) 1 else 0,
-        isModal = dest == InterfaceDestination.MAIN_SCREEN,
+        isModal = dest == InterfaceDestination.MAIN_SCREEN || dest == InterfaceDestination.MAIN_SCREEN_FULL,
     )
 }
 
@@ -466,6 +466,9 @@ fun Player.openInterface(
     isModal: Boolean = false,
 ) {
     if (isModal) {
+        if (interfaces.currentModal != -1) {
+            closeInterface(interfaces.currentModal)
+        }
         interfaces.openModal(parent, child, interfaceId)
     } else {
         interfaces.open(parent, child, interfaceId)

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/eating.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/items/food/eating.plugin.kts
@@ -5,12 +5,13 @@ Food.values.forEach { food ->
         if (!Foods.canEat(player, food)) {
             return@on_item_option
         }
-
-        val inventorySlot = player.getInteractingItemSlot()
-        if (player.inventory.remove(item = food.item, beginSlot = inventorySlot).hasSucceeded()) {
-            Foods.eat(player, food)
-            if (food.replacement != -1) {
-                player.inventory.add(item = food.replacement, beginSlot = inventorySlot)
+        player.queue(priority = TaskPriority.STRONG) {
+            val inventorySlot = player.getInteractingItemSlot()
+            if (player.inventory.remove(item = food.item, beginSlot = inventorySlot).hasSucceeded()) {
+                Foods.eat(player, food)
+                if (food.replacement != -1) {
+                    player.inventory.add(item = food.replacement, beginSlot = inventorySlot)
+                }
             }
         }
     }

--- a/game/src/main/kotlin/gg/rsmod/game/model/entity/Pawn.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/entity/Pawn.kt
@@ -683,9 +683,6 @@ abstract class Pawn(
         priority: TaskPriority = TaskPriority.STANDARD,
         logic: suspend QueueTask.(CoroutineScope) -> Unit,
     ) {
-        if (this is Player && priority == TaskPriority.STRONG) {
-            this.closeInterfaceModal()
-        }
         queues.queue(this, world.coroutineDispatcher, priority, logic)
     }
 
@@ -702,9 +699,6 @@ abstract class Pawn(
         // set the lockstate
         lock = lockState
 
-        if (this is Player && priority == TaskPriority.STRONG) {
-            this.closeInterfaceModal()
-        }
         queues.queue(this, world.coroutineDispatcher, priority, logic, lock = true)
     }
 

--- a/game/src/main/kotlin/gg/rsmod/game/model/queue/QueueTaskSet.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/queue/QueueTaskSet.kt
@@ -30,11 +30,7 @@ abstract class QueueTaskSet {
         task.lock = lock
         task.coroutine = suspendBlock.createCoroutine(completion = task)
 
-        if (priority == TaskPriority.STRONG) {
-            terminateTasks()
-        }
-
-        queue.addFirst(task)
+        queue.addLast(task)
     }
 
     /**
@@ -56,5 +52,20 @@ abstract class QueueTaskSet {
     fun terminateTasks() {
         queue.forEach { it.terminate() }
         queue.clear()
+    }
+
+    /**
+     * Remove all weak/normal [QueueTask] from our [queue], invoking each task's [QueueTask.terminate]
+     * before-hand.
+     */
+    fun removeWeakTasks() {
+        queue.forEach {
+            if (it.priority == TaskPriority.WEAK) {
+                it.terminate()
+            }
+        }
+        queue.removeAll {
+            it.priority == TaskPriority.WEAK
+        }
     }
 }

--- a/game/src/main/kotlin/gg/rsmod/game/model/queue/TaskPriority.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/queue/TaskPriority.kt
@@ -19,6 +19,14 @@ enum class TaskPriority {
 
     /**
      * A strong priority task will close menus to execute itself sooner.
+     * Terminates weak/standard, but not strong/soft priority queues
+     * Closes modal interface prior to executing
      */
     STRONG,
+
+    /**
+     * A soft task cannot be interrupted and will run until completion.
+     * Closes modal interface prior to executing
+     */
+    SOFT
 }

--- a/game/src/main/kotlin/gg/rsmod/game/model/queue/impl/PawnQueueTaskSet.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/queue/impl/PawnQueueTaskSet.kt
@@ -28,6 +28,7 @@ class PawnQueueTaskSet : QueueTaskSet() {
         val iterator = queue.iterator()
         while (iterator.hasNext()) {
             val task = iterator.next()
+
             if (task.priority == TaskPriority.STANDARD && task.ctx is Player && task.ctx.hasMenuOpen()) {
                 val nonStandardTask = queue.firstOrNull { q -> q.priority != TaskPriority.STANDARD }
                 if (nonStandardTask != null) {
@@ -60,7 +61,7 @@ class PawnQueueTaskSet : QueueTaskSet() {
                  * Task is no longer in a suspended state, which means its job is
                  * complete.
                  */
-                queue.remove(task)
+                iterator.remove()
 
                 /*
                  * If the task locked the player, then unlock them on complete

--- a/game/src/main/kotlin/gg/rsmod/game/model/queue/impl/PawnQueueTaskSet.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/queue/impl/PawnQueueTaskSet.kt
@@ -24,9 +24,10 @@ class PawnQueueTaskSet : QueueTaskSet() {
         if (strongOrSoft != null) {
             removeWeakTasks()
         }
-        while (true) {
-            val task = queue.peekFirst() ?: break
 
+        val iterator = queue.iterator()
+        while (iterator.hasNext()) {
+            val task = iterator.next()
             if (task.priority == TaskPriority.STANDARD && task.ctx is Player && task.ctx.hasMenuOpen()) {
                 val nonStandardTask = queue.firstOrNull { q -> q.priority != TaskPriority.STANDARD }
                 if (nonStandardTask != null) {
@@ -74,7 +75,6 @@ class PawnQueueTaskSet : QueueTaskSet() {
                  */
                 continue
             }
-            break
         }
     }
 

--- a/game/src/main/kotlin/gg/rsmod/game/model/queue/impl/PawnQueueTaskSet.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/queue/impl/PawnQueueTaskSet.kt
@@ -28,7 +28,13 @@ class PawnQueueTaskSet : QueueTaskSet() {
             val task = queue.peekFirst() ?: break
 
             if (task.priority == TaskPriority.STANDARD && task.ctx is Player && task.ctx.hasMenuOpen()) {
-                continue
+                val nonStandardTask = queue.firstOrNull { q -> q.priority != TaskPriority.STANDARD }
+                if (nonStandardTask != null) {
+                    continue
+                }
+                else {
+                    break
+                }
             }
 
             if (!task.invoked) {


### PR DESCRIPTION
## What has been done?

- Re-structured task execution to more closely match RuneScape's underlying queue mechanics
- Strong queues now only remove weak queues and not all of them
- Soft queue priority type has been added, which is similar to strong 
- if a modal interface is opened it will now close currently opened one first
- eating is now a strong action which will close interfaces

## Has your code been documented?
yes