### PR TITLE
Quick Fix: Fix Lost City starting requirements check in dialogue

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/lumbridge/warrior.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/lumbridge/warrior.plugin.kts
@@ -143,7 +143,7 @@ suspend fun lookingforShamus(it: QueueTask) {
             when (it.options("Yes.", "No.", title = "     Start Lost City?     ")) {
                 1 -> {
                     if (it.player.skills.getMaxLevel(Skills.CRAFTING) >= 31 &&
-                        it.player.skills.getMaxLevel(Skills.WOODCUTTING) > 36
+                        it.player.skills.getMaxLevel(Skills.WOODCUTTING) >= 36
                     )
                         {
                             it.chatPlayer("Thanks for the help!")

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/lumbridge/warrior.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/lumbridge/warrior.plugin.kts
@@ -143,16 +143,15 @@ suspend fun lookingforShamus(it: QueueTask) {
             when (it.options("Yes.", "No.", title = "     Start Lost City?     ")) {
                 1 -> {
                     if (it.player.skills.getMaxLevel(Skills.CRAFTING) >= 31 &&
-                        it.player.skills.getMaxLevel(Skills.WOODCUTTING) >= 36
-                    )
-                        {
-                            it.chatPlayer("Thanks for the help!")
-                            it.chatNpc(
-                                "Help? What help? I didn't help! Please Don't say I",
-                                "did, I'll get in trouble!",
-                            )
-                            it.player.startQuest(LostCity)
-                        } else {
+                        it.player.skills.getMaxLevel(Skills.WOODCUTTING) >= 36) {
+                        it.chatPlayer("Thanks for the help!")
+                        it.chatNpc(
+                            "Help? What help? I didn't help! Please Don't say I",
+                            "did, I'll get in trouble!",
+                        )
+                        it.player.startQuest(LostCity)
+                    }
+                    else {
                         it.messageBox("You don't have the skill levels to start this quest...")
                         if (it.player.skills.getMaxLevel(Skills.CRAFTING) < 31) {
                             it.messageBox("You need 31 crafting.")


### PR DESCRIPTION
## What has been done?

- Changed a > to a >= check when checking woodcutting level requirements for starting the quest. Previously you were unable to start the quest with 36 woodcutting because of the erroneous check

## Has your code been documented?